### PR TITLE
Reference Metal compute backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,14 @@ env:
   # to surface upstream incompatibility early. Mirrors the krypt / tikr baseline.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-# Linux-only: infr is a Vulkan-first engine. `glslc` (shaderc) compiles the
+# Mostly Linux: infr is a Vulkan-first engine. `glslc` (shaderc) compiles the
 # compute shaders at build time, and the dp4a shaders need a recent glslc
 # (GL_EXT_integer_dot_product) — Ubuntu 24.04 ships shaderc 2023.8 which is too
 # old, so we pin ubuntu-26.04 (shaderc 2025+). The GPU integration tests are
 # #[ignore]'d (they need a real Vulkan device); CI builds + runs the CPU suite.
 # ash loads Vulkan at runtime via dlopen, so no libvulkan is needed to build.
+# The `test-macos` job additionally builds on Apple Silicon and runs the
+# reference Metal backend's parity suite against a real Metal device.
 
 jobs:
   fmt:
@@ -87,3 +89,24 @@ jobs:
       - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --workspace --locked
+
+  # macOS / Metal: the Linux jobs above never build `infr-metal` (it is
+  # `#![cfg(target_os = "macos")]`). This job builds the workspace on an
+  # Apple-Silicon runner — which has a real Metal device — and runs the
+  # infr-metal parity suite. Those tests are `#[ignore]`d like the Vulkan GPU
+  # tests, so they need an explicit `--include-ignored`.
+  test-macos:
+    name: cargo test (macOS / Metal)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install glslc (shaderc)
+        run: brew install shaderc
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: false
+      - run: rustup update --no-self-update stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace --locked
+      - run: cargo test -p infr-metal --locked -- --include-ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +348,33 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "libc",
 ]
 
 [[package]]
@@ -602,6 +635,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1102,6 +1162,7 @@ dependencies = [
  "infr-core",
  "infr-cpu",
  "infr-gguf",
+ "infr-metal",
  "infr-vulkan",
  "llguidance",
  "rayon",
@@ -1109,6 +1170,19 @@ dependencies = [
  "tokenizers 0.20.4",
  "toktrie_hf_tokenizers",
  "tracing",
+]
+
+[[package]]
+name = "infr-metal"
+version = "0.0.0"
+dependencies = [
+ "bytemuck",
+ "half",
+ "infr-core",
+ "infr-cpu",
+ "infr-gguf",
+ "metal",
+ "objc",
 ]
 
 [[package]]
@@ -1307,6 +1381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1424,21 @@ name = "memo-map"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
+name = "metal"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
 
 [[package]]
 name = "mime"
@@ -1431,6 +1529,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/infr-core",
     "crates/infr-vulkan",
+    "crates/infr-metal",
     "crates/infr-hub",
     "crates/infr-gguf",
     "crates/infr-cpu",
@@ -25,6 +26,7 @@ repository = "https://github.com/kryptic-sh/infr"
 # internal
 infr-core = { path = "crates/infr-core" }
 infr-vulkan = { path = "crates/infr-vulkan" }
+infr-metal = { path = "crates/infr-metal" }
 infr-hub = { path = "crates/infr-hub" }
 infr-gguf = { path = "crates/infr-gguf" }
 infr-cpu = { path = "crates/infr-cpu" }
@@ -53,6 +55,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ash = "0.38"
 gpu-allocator = { version = "0.27", features = ["vulkan"] }
+metal = "0.33"
+objc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
     "blocking",
     "rustls-tls",

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ greedy), `INFR_MAX_NEW`, `INFR_MAX_CTX`, `INFR_NCMOE` (MoE expert CPU offload),
 - **Format:** GGUF
 - **Models:** Llama / Qwen3 / Gemma 3 / Gemma 4 (dense + E2B) (GPU); Qwen3.5/3.6
   (CPU ref); DiffusionGemma (planned)
-- **GPU:** AMD / NVIDIA / Intel via Vulkan (cooperative-matrix matmul)
+- **GPU:** AMD / NVIDIA / Intel via Vulkan (cooperative-matrix matmul); Apple via a
+  correctness-first **reference Metal backend** (`INFR_METAL=1`) covering every op the CPU
+  reference does — dense, MoE (`qwen3moe`) and Qwen3-Next (`qwen35`)
 - **Store:** own cache at `$XDG_CACHE_HOME/infr/models` (standalone HF + Ollama
   HTTP pulls)
 - **API:** OpenAI-compatible HTTP (streaming) — works with opencode / Claude
@@ -136,7 +138,7 @@ decode   DecodeStrategy   (AutoRegressive; DiffusionDenoise later)
 model    Model            (Llama/Qwen3; Qwen3-Next CPU ref; DiffusionGemma later)
 runtime  tensors, KV cache, command/descriptor management
 loader   WeightSource     (Gguf; safetensors later)
-compute  Compute          (Vulkan via ash + SPIR-V; Metal/CUDA later)
+compute  Compute          (Vulkan via ash + SPIR-V; reference Metal via MSL; CUDA later)
 ```
 
 ## License

--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -330,7 +330,21 @@ fn cmd_run(model: &str, message: Option<&str>) -> anyhow::Result<()> {
     // the borrow-based dense `ChatSession` needs no ownership change).
     let is_q35 = infr_llama::qwen35::is_qwen35(&gguf);
     let llama; // declared here so a borrowing ChatSession / MoeChat outlives `chat`
-    let model: Box<dyn infr_llama::model::ChatModel + '_> = if std::env::var("INFR_CPU").is_ok() {
+    let model: Box<dyn infr_llama::model::ChatModel + '_> = if std::env::var("INFR_METAL").is_ok() {
+        if is_q35 {
+            eprintln!(
+                "[metal backend — qwen35/Qwen3-Next on the agnostic seam, Apple GPU (reference)]"
+            );
+            Box::new(infr_llama::model::CpuQwen35Chat::new_metal(gguf.clone()))
+        } else {
+            eprintln!(
+                "[metal backend — dense/MoE forward on Apple GPU via the agnostic compute graph (reference)]"
+            );
+            Box::new(infr_llama::model::CpuDenseChat::new_metal(
+                infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
+            ))
+        }
+    } else if std::env::var("INFR_CPU").is_ok() {
         if is_q35 {
             eprintln!("[cpu backend — qwen35/Qwen3-Next on the agnostic seam, no GPU]");
             Box::new(infr_llama::model::CpuQwen35Chat::new(gguf.clone()))

--- a/crates/infr-llama/Cargo.toml
+++ b/crates/infr-llama/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 infr-core.workspace = true
 infr-chat.workspace = true
 infr-vulkan.workspace = true
+infr-metal.workspace = true
 infr-gguf.workspace = true
 infr-cpu.workspace = true
 serde_json.workspace = true

--- a/crates/infr-llama/src/cpu_backend.rs
+++ b/crates/infr-llama/src/cpu_backend.rs
@@ -155,6 +155,40 @@ pub(crate) fn generate_dense_gpu(
     )
 }
 
+/// Metal seam runner: the SAME dense forward as [`generate_dense_cpu`], on the reference Metal
+/// backend through the agnostic [`Graph`]. Weights are uploaded to Metal buffers in their NATIVE
+/// GGUF dtype (the backend dequantizes lazily in its own `bytes_to_f32`, exactly like the CPU
+/// interpreter — so a quant weight occupies ~quant size, not 8× f32).
+#[cfg(target_os = "macos")]
+pub(crate) fn generate_dense_metal(
+    mtl: &infr_metal::MetalBackend,
+    g: &Gguf,
+    cfg: &Config,
+    token_embd: &[f32],
+    ple: Option<&PerLayerEmbd>,
+    prompt: &[u32],
+    max_new: usize,
+    on_token: impl FnMut(u32),
+) -> AResult<(Vec<u32>, GenStats)> {
+    generate_dense_backend(
+        mtl,
+        &|tb, dt, _n| {
+            let buf = mtl
+                .alloc(tb.len().max(1), BufferUsage::Weights)
+                .map_err(|e| anyhow!("{e}"))?;
+            mtl.upload(buf.as_ref(), &tb).map_err(|e| anyhow!("{e}"))?;
+            Ok((buf, dt))
+        },
+        g,
+        cfg,
+        token_embd,
+        ple,
+        prompt,
+        max_new,
+        on_token,
+    )
+}
+
 /// Backend-generic dense decode runner. Builds the agnostic decode [`Graph`] per token and runs it
 /// on `be` (CPU reference or Vulkan). `bind_weight` turns each native-dtype GGUF tensor into a
 /// backend buffer: the CPU maps it zero-copy from the mmap; the GPU pads + uploads it to VRAM. This

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -112,6 +112,38 @@ impl CpuModel {
         Ok(stats)
     }
 
+    /// Greedy generation on the reference **Metal** backend through the agnostic seam (the
+    /// Apple-GPU twin of [`generate_cpu`](Self::generate_cpu)): weights are uploaded to Metal
+    /// buffers, the per-token [`infr_core::graph::Graph`] is compiled + executed by `MetalBackend`,
+    /// and generated tokens stream through `on_piece`.
+    #[cfg(target_os = "macos")]
+    pub fn generate_metal(
+        &self,
+        prompt: &str,
+        max_new: usize,
+        mut on_piece: impl FnMut(&str),
+    ) -> Result<crate::GenStats> {
+        let enc = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| anyhow!("encode: {e}"))?;
+        let prompt_tokens: Vec<u32> = enc.get_ids().to_vec();
+        let mtl = infr_metal::MetalBackend::new().map_err(|e| anyhow!("metal init: {e}"))?;
+        let mut acc: Vec<u32> = Vec::new();
+        let mut printed = 0usize;
+        let (_generated, stats) = crate::cpu_backend::generate_dense_metal(
+            &mtl,
+            &self.gguf,
+            &self.cfg,
+            &self.token_embd,
+            self.per_layer_embd.as_ref(),
+            &prompt_tokens,
+            max_new,
+            |id| stream_token(&self.tokenizer, &mut acc, &mut printed, id, &mut on_piece),
+        )?;
+        Ok(stats)
+    }
+
     /// Render a user turn with the model's OWN embedded chat template (so an instruct model — Gemma,
     /// Qwen, … — answers coherently). Errors if the GGUF has no `tokenizer.chat_template` or it fails
     /// to render — infr only supports models that ship one (no fabricated-ChatML fallback).

--- a/crates/infr-llama/src/model.rs
+++ b/crates/infr-llama/src/model.rs
@@ -246,11 +246,21 @@ impl ChatModel for Qwen35Chat {
 /// rendered history in every turn, so multi-turn context works.
 pub struct CpuDenseChat {
     model: CpuModel,
+    /// Run the dense forward on the reference Metal backend instead of the CPU interpreter.
+    metal: bool,
 }
 
 impl CpuDenseChat {
     pub fn new(model: CpuModel) -> Self {
-        Self { model }
+        Self {
+            model,
+            metal: false,
+        }
+    }
+
+    /// Same dense model, but driven through the reference Metal backend (`INFR_METAL`).
+    pub fn new_metal(model: CpuModel) -> Self {
+        Self { model, metal: true }
     }
 }
 
@@ -265,6 +275,14 @@ impl ChatModel for CpuDenseChat {
         max_new: usize,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
+        if self.metal {
+            #[cfg(target_os = "macos")]
+            return self.model.generate_metal(prompt, max_new, |p| on_piece(p));
+            #[cfg(not(target_os = "macos"))]
+            return Err(anyhow::anyhow!(
+                "the Metal backend is only available on macOS"
+            ));
+        }
         self.model.generate_cpu(prompt, max_new, |p| on_piece(p))
     }
 }
@@ -273,11 +291,18 @@ impl ChatModel for CpuDenseChat {
 /// Same follow-up as [`Qwen35Chat`]: `qwen35::generate_cpu` reloads the GGUF per turn.
 pub struct CpuQwen35Chat {
     path: std::path::PathBuf,
+    /// Run the qwen35 decode on the reference Metal backend instead of the CPU interpreter.
+    metal: bool,
 }
 
 impl CpuQwen35Chat {
     pub fn new(path: std::path::PathBuf) -> Self {
-        Self { path }
+        Self { path, metal: false }
+    }
+
+    /// Same qwen35 decode, driven through the reference Metal backend (`INFR_METAL`).
+    pub fn new_metal(path: std::path::PathBuf) -> Self {
+        Self { path, metal: true }
     }
 }
 
@@ -292,6 +317,14 @@ impl ChatModel for CpuQwen35Chat {
         max_new: usize,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
+        if self.metal {
+            #[cfg(target_os = "macos")]
+            return crate::qwen35::generate_metal(&self.path, prompt, max_new, |p| on_piece(p));
+            #[cfg(not(target_os = "macos"))]
+            return Err(anyhow::anyhow!(
+                "the Metal backend is only available on macOS"
+            ));
+        }
         crate::qwen35::generate_cpu(&self.path, prompt, max_new, |p| on_piece(p))
     }
 }

--- a/crates/infr-llama/src/qwen35.rs
+++ b/crates/infr-llama/src/qwen35.rs
@@ -16,7 +16,7 @@ use infr_core::graph::{Activation, AttnMask, Graph, Op};
 use infr_core::tensor::TensorDesc;
 use infr_core::{DType, TensorId, WeightSource};
 use infr_cpu::CpuBackend;
-use infr_gguf::Gguf;
+use infr_gguf::{Gguf, TensorBytes};
 use infr_vulkan::VulkanBackend;
 
 /// A linear-projection weight on whichever device has a kernel for it: GPU (the shared
@@ -1175,7 +1175,13 @@ pub fn render_chat_messages(path: &std::path::Path, messages: &[(&str, &str)]) -
 
 /// Greedy pure-CPU generation for qwen35 / Qwen3-Next on the agnostic seam (no Vulkan). `prompt` is
 /// the already-formatted text (see [`render_chat`]); returns timing/counts, text streams via `on_piece`.
-pub fn generate_cpu(
+/// Backend-generic Qwen3-Next (qwen35) decode runner: builds the per-token composite [`Graph`]
+/// (gated-DeltaNet + conv1d + attention) and runs it on `be`. `bind_weight` turns each native-dtype
+/// GGUF tensor into a backend buffer (CPU maps it zero-copy from the mmap; Metal uploads it). The
+/// thin [`generate_cpu`] / [`generate_metal`] wrappers pick the backend.
+fn generate_seam(
+    be: &dyn Backend,
+    bind_weight: &dyn Fn(TensorBytes) -> Result<Box<dyn Buffer>>,
     path: &std::path::Path,
     prompt: &str,
     n: usize,
@@ -1202,7 +1208,6 @@ pub fn generate_cpu(
     let prompt_ids: Vec<u32> = enc.get_ids().to_vec();
     let max_ctx = prompt_ids.len() + n + 1;
 
-    let be = CpuBackend::new();
     let attn = |i: usize| c.is_attn_layer(i);
     let n_ff_of = |i: usize| -> Result<usize> {
         Ok(g.tensors()
@@ -1225,7 +1230,7 @@ pub fn generate_cpu(
             .clone();
         let numel: usize = info.shape.iter().product();
         let tb = g.tensor_bytes_arc(name).map_err(|e| anyhow!("{e}"))?;
-        wbufs.push(be.map_weight(tb));
+        wbufs.push(bind_weight(tb)?);
         wspecs.push((info.dtype, numel));
         Ok(())
     };
@@ -1769,6 +1774,43 @@ pub fn generate_cpu(
         n_gen: decode_n,
         decode_secs: decode_t.as_secs_f64(),
     })
+}
+
+/// Qwen3-Next decode on the CPU reference backend (weights mapped zero-copy from the GGUF mmap).
+pub fn generate_cpu(
+    path: &std::path::Path,
+    prompt: &str,
+    n: usize,
+    on_piece: impl FnMut(&str),
+) -> Result<crate::GenStats> {
+    let be = CpuBackend::new();
+    generate_seam(&be, &|tb| Ok(be.map_weight(tb)), path, prompt, n, on_piece)
+}
+
+/// Qwen3-Next decode on the reference Metal backend (weights uploaded to Metal buffers in their
+/// native GGUF dtype; the backend dequantizes lazily). The Apple-GPU twin of [`generate_cpu`].
+#[cfg(target_os = "macos")]
+pub fn generate_metal(
+    path: &std::path::Path,
+    prompt: &str,
+    n: usize,
+    on_piece: impl FnMut(&str),
+) -> Result<crate::GenStats> {
+    let be = infr_metal::MetalBackend::new().map_err(|e| anyhow!("metal init: {e}"))?;
+    generate_seam(
+        &be,
+        &|tb| {
+            let buf = be
+                .alloc(tb.len().max(1), BufferUsage::Weights)
+                .map_err(|e| anyhow!("{e}"))?;
+            be.upload(buf.as_ref(), &tb).map_err(|e| anyhow!("{e}"))?;
+            Ok(buf)
+        },
+        path,
+        prompt,
+        n,
+        on_piece,
+    )
 }
 
 /// Open the GGUF at `path` and build the bespoke qwen35 [`Model`] (GPU-resident forward, or the

--- a/crates/infr-metal/Cargo.toml
+++ b/crates/infr-metal/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "infr-metal"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+infr-core.workspace = true
+infr-gguf.workspace = true
+half.workspace = true
+bytemuck.workspace = true
+
+# Apple-only: `metal`/`objc` link the Objective-C runtime and don't build off macOS. The crate is
+# `#![cfg(target_os = "macos")]`, so on other targets it compiles to an empty lib with no deps.
+[target.'cfg(target_os = "macos")'.dependencies]
+metal.workspace = true
+objc.workspace = true
+
+[dev-dependencies]
+infr-cpu.workspace = true

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1,0 +1,726 @@
+//! Graph execution: host-side staging (identical to the CPU interpreter) with each op's arithmetic
+//! dispatched to a Metal compute kernel. See the crate docs for why this is host-orchestrated.
+
+use crate::{metal_buf, MetalBackend};
+use infr_core::backend::{Bindings, Plan};
+use infr_core::error::Error;
+use infr_core::graph::{Op, TensorKind};
+use infr_core::tensor::{DType, TensorId};
+use infr_core::Result;
+use infr_gguf::dequant::dequant_block;
+use metal::{Buffer as MtlBuffer, ComputePipelineState, MTLResourceOptions, MTLSize};
+use std::ffi::c_void;
+use std::sync::Arc;
+
+/// Reinterpret raw buffer bytes as `f32` per `dtype` (dequantizing quant/f16/bf16, widening integer
+/// tensors). The host-side "read a tensor's value", matching `infr-cpu`'s `bytes_to_f32`.
+fn bytes_to_f32(bytes: &[u8], dtype: DType) -> Vec<f32> {
+    match dtype {
+        DType::F32 => bytemuck::cast_slice::<u8, f32>(bytes).to_vec(),
+        DType::I32 => bytemuck::cast_slice::<u8, i32>(bytes)
+            .iter()
+            .map(|&v| v as f32)
+            .collect(),
+        DType::U32 => bytemuck::cast_slice::<u8, u32>(bytes)
+            .iter()
+            .map(|&v| v as f32)
+            .collect(),
+        other => dequant_block(other, bytes).expect("metal backend: host dequant"),
+    }
+}
+
+/// Gated-FFN activation applied to the gate value (matches `infr-cpu`'s `act_fn`).
+fn act_fn(act: infr_core::graph::Activation, g: f32) -> f32 {
+    use infr_core::graph::Activation;
+    match act {
+        Activation::Silu => g / (1.0 + (-g).exp()),
+        Activation::Gelu => 0.5 * g * (1.0 + (0.797_884_6 * (g + 0.044715 * g * g * g)).tanh()),
+        Activation::Sigmoid => 1.0 / (1.0 + (-g).exp()),
+    }
+}
+
+impl MetalBackend {
+    // ---- small device-buffer helpers (StorageModeShared = CPU-visible on Apple Silicon) ----
+
+    /// A device buffer initialized from an f32 host slice.
+    fn f32_buf(&self, data: &[f32]) -> MtlBuffer {
+        let len = (data.len().max(1) * 4) as u64;
+        let buf = self
+            .device
+            .new_buffer(len, MTLResourceOptions::StorageModeShared);
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), buf.contents() as *mut f32, data.len());
+        }
+        buf
+    }
+
+    /// A zeroed device buffer of `n` f32s.
+    fn zeros_buf(&self, n: usize) -> MtlBuffer {
+        self.device
+            .new_buffer((n.max(1) * 4) as u64, MTLResourceOptions::StorageModeShared)
+    }
+
+    /// Read `n` f32s out of a device buffer.
+    fn read_f32(buf: &MtlBuffer, n: usize) -> Vec<f32> {
+        let mut out = vec![0f32; n];
+        unsafe {
+            std::ptr::copy_nonoverlapping(buf.contents() as *const f32, out.as_mut_ptr(), n);
+        }
+        out
+    }
+
+    /// Read the first `n` f16 elements of a buffer, widening to f32.
+    fn read_f16_prefix(buf: &crate::MetalBuffer, n: usize) -> Vec<f32> {
+        let ptr = buf.raw.contents() as *const u16;
+        (0..n)
+            .map(|i| half::f16::from_bits(unsafe { *ptr.add(i) }).to_f32())
+            .collect()
+    }
+
+    /// Encode one kernel dispatch and block until it completes (correctness-first: every op is its
+    /// own command buffer, so ops run strictly in graph order with no manual barriers). `data_bufs`
+    /// bind to buffer indices `0..k`; `params` (packed scalars) binds at index `k`.
+    fn dispatch(
+        &self,
+        pso: &ComputePipelineState,
+        data_bufs: &[&MtlBuffer],
+        params: &[u8],
+        threads: usize,
+    ) {
+        if threads == 0 {
+            return;
+        }
+        objc::rc::autoreleasepool(|| {
+            let cb = self.queue.new_command_buffer();
+            let enc = cb.new_compute_command_encoder();
+            enc.set_compute_pipeline_state(pso);
+            for (i, b) in data_bufs.iter().enumerate() {
+                enc.set_buffer(i as u64, Some(b), 0);
+            }
+            if !params.is_empty() {
+                enc.set_bytes(
+                    data_bufs.len() as u64,
+                    params.len() as u64,
+                    params.as_ptr() as *const c_void,
+                );
+            }
+            let tg = (pso.max_total_threads_per_threadgroup() as usize).min(threads.max(1)) as u64;
+            enc.dispatch_threads(MTLSize::new(threads as u64, 1, 1), MTLSize::new(tg, 1, 1));
+            enc.end_encoding();
+            cb.commit();
+            cb.wait_until_completed();
+        });
+    }
+
+    pub(crate) fn execute_graph(&self, plan: &dyn Plan, bindings: &Bindings) -> Result<()> {
+        let g = &plan
+            .as_any()
+            .downcast_ref::<infr_core::backend::GraphPlan>()
+            .expect("metal backend: plan is not a GraphPlan")
+            .graph;
+
+        // f32 working store for every Input/Internal/Output handle (mirrors the CPU interpreter).
+        // KV caches are written/read in place from their bound buffers (see `direct`).
+        let direct = g.in_place_inputs();
+        let mut vals: Vec<Vec<f32>> = vec![Vec::new(); g.tensors.len()];
+        for (i, decl) in g.tensors.iter().enumerate() {
+            match decl.kind {
+                TensorKind::Internal | TensorKind::Output => {
+                    vals[i] = vec![0f32; decl.desc.numel()]
+                }
+                TensorKind::Input if direct.contains(&TensorId(i as u32)) => {}
+                TensorKind::Input => {
+                    let buf = metal_buf(
+                        bindings
+                            .get(TensorId(i as u32))
+                            .expect("metal backend: unbound Input"),
+                    );
+                    let bytes = Self::read_bytes(buf);
+                    vals[i] = bytes_to_f32(&bytes, decl.desc.dtype);
+                }
+                TensorKind::Weight => {}
+            }
+        }
+
+        for op in &g.ops {
+            self.run_op(op, g, bindings, &mut vals)?;
+        }
+
+        // Write back Outputs (and mutated f32 Inputs, e.g. recurrent state) to their bound buffers.
+        for (i, decl) in g.tensors.iter().enumerate() {
+            let write_back = matches!(decl.kind, TensorKind::Output)
+                || (decl.kind == TensorKind::Input
+                    && decl.desc.dtype == DType::F32
+                    && !direct.contains(&TensorId(i as u32)));
+            if !write_back {
+                continue;
+            }
+            if let Some(buf) = bindings.get(TensorId(i as u32)) {
+                let b = metal_buf(buf);
+                let src: &[u8] = bytemuck::cast_slice(&vals[i]);
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        src.as_ptr(),
+                        b.raw.contents() as *mut u8,
+                        src.len().min(b.len),
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Fetch a dequantized weight as a device f32 buffer, cached by bound-buffer address.
+    fn weight_buf(
+        &self,
+        id: TensorId,
+        g: &infr_core::graph::Graph,
+        bindings: &Bindings,
+    ) -> Arc<MtlBuffer> {
+        let buf = metal_buf(bindings.get(id).expect("metal backend: unbound Weight"));
+        let key = buf as *const _ as usize;
+        if let Some(w) = self.weight_cache.lock().unwrap().get(&key) {
+            return w.clone();
+        }
+        let bytes = Self::read_bytes(buf);
+        let f = bytes_to_f32(&bytes, g.desc(id).dtype);
+        let w = Arc::new(self.f32_buf(&f));
+        self.weight_cache.lock().unwrap().insert(key, w.clone());
+        w
+    }
+
+    fn read_bytes(buf: &crate::MetalBuffer) -> Vec<u8> {
+        let mut v = vec![0u8; buf.len];
+        unsafe {
+            std::ptr::copy_nonoverlapping(buf.raw.contents() as *const u8, v.as_mut_ptr(), v.len());
+        }
+        v
+    }
+
+    /// Read `len` bytes at `off` from a buffer's (unified-memory) contents.
+    fn read_bytes_range(buf: &crate::MetalBuffer, off: usize, len: usize) -> Vec<u8> {
+        let mut v = vec![0u8; len];
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                (buf.raw.contents() as *const u8).add(off),
+                v.as_mut_ptr(),
+                len,
+            );
+        }
+        v
+    }
+
+    /// Dequantize a bound weight to host f32 (small weights: norm/conv/router-adjacent gains).
+    fn weight_host(
+        &self,
+        id: TensorId,
+        g: &infr_core::graph::Graph,
+        bindings: &Bindings,
+    ) -> Vec<f32> {
+        let buf = metal_buf(bindings.get(id).expect("metal backend: unbound Weight"));
+        bytes_to_f32(&Self::read_bytes(buf), g.desc(id).dtype)
+    }
+
+    /// Single-row matmul on the GPU: `out[out_f] = x[in_f] · Wᵀ`, W row-major [out_f, in_f] f32.
+    fn gpu_matvec(&self, x: &[f32], w: &[f32], in_f: usize, out_f: usize) -> Result<Vec<f32>> {
+        let bx = self.f32_buf(x);
+        let bw = self.f32_buf(w);
+        let bd = self.zeros_buf(out_f);
+        let pso = self.pipelines.get("linear_f32")?;
+        let mut p = 1u32.to_ne_bytes().to_vec(); // m = 1
+        p.extend_from_slice(&(in_f as u32).to_ne_bytes());
+        p.extend_from_slice(&(out_f as u32).to_ne_bytes());
+        self.dispatch(&pso, &[&bx, &bw, &bd], &p, out_f);
+        Ok(Self::read_f32(&bd, out_f))
+    }
+
+    fn run_op(
+        &self,
+        op: &Op,
+        g: &infr_core::graph::Graph,
+        bindings: &Bindings,
+        vals: &mut [Vec<f32>],
+    ) -> Result<()> {
+        match *op {
+            Op::RmsNorm {
+                x,
+                weight,
+                dst,
+                rows,
+                dim,
+                eps,
+            } => {
+                let (rows, dim) = (rows as usize, dim as usize);
+                let bx = self.f32_buf(&vals[x.0 as usize]);
+                let bw = self.weight_buf(weight, g, bindings);
+                let bd = self.zeros_buf(rows * dim);
+                let pso = self.pipelines.get("rmsnorm_f32")?;
+                let mut p = (rows as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(dim as u32).to_ne_bytes());
+                p.extend_from_slice(&eps.to_ne_bytes());
+                self.dispatch(&pso, &[&bx, bw.as_ref(), &bd], &p, rows);
+                vals[dst.0 as usize] = Self::read_f32(&bd, rows * dim);
+            }
+            Op::QkNorm {
+                x,
+                weight,
+                dst,
+                rows,
+                n_head,
+                head_dim,
+                eps,
+            } => {
+                let (rows, nh, hd) = (rows as usize, n_head as usize, head_dim as usize);
+                let bx = self.f32_buf(&vals[x.0 as usize]);
+                let bw = self.weight_buf(weight, g, bindings);
+                let bd = self.zeros_buf(rows * nh * hd);
+                let pso = self.pipelines.get("qknorm_f32")?;
+                let mut p = (rows as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(nh as u32).to_ne_bytes());
+                p.extend_from_slice(&(hd as u32).to_ne_bytes());
+                p.extend_from_slice(&eps.to_ne_bytes());
+                self.dispatch(&pso, &[&bx, bw.as_ref(), &bd], &p, rows * nh);
+                vals[dst.0 as usize] = Self::read_f32(&bd, rows * nh * hd);
+            }
+            Op::Linear {
+                x,
+                weight,
+                dst,
+                m,
+                in_f,
+                out_f,
+            } => {
+                let (m, in_f, out_f) = (m as usize, in_f as usize, out_f as usize);
+                let bx = self.f32_buf(&vals[x.0 as usize]);
+                let bw = self.weight_buf(weight, g, bindings); // dequantized f32, cached
+                let bd = self.zeros_buf(m * out_f);
+                let pso = self.pipelines.get("linear_f32")?;
+                let mut p = (m as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(in_f as u32).to_ne_bytes());
+                p.extend_from_slice(&(out_f as u32).to_ne_bytes());
+                self.dispatch(&pso, &[&bx, bw.as_ref(), &bd], &p, m * out_f);
+                vals[dst.0 as usize] = Self::read_f32(&bd, m * out_f);
+            }
+            Op::Rope {
+                x,
+                positions,
+                dst,
+                rows,
+                n_head,
+                head_dim,
+                rope_dim,
+                theta,
+                freq_factors,
+            } => {
+                let (rows, nh, hd) = (rows as usize, n_head as usize, head_dim as usize);
+                let bx = self.f32_buf(&vals[x.0 as usize]);
+                let bpos = self.f32_buf(&vals[positions.0 as usize]);
+                let bff = match freq_factors {
+                    Some(f) => self.f32_buf(&vals[f.0 as usize]),
+                    None => self.zeros_buf(1),
+                };
+                let bd = self.zeros_buf(rows * nh * hd);
+                let pso = self.pipelines.get("rope_f32")?;
+                let mut p = (rows as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(nh as u32).to_ne_bytes());
+                p.extend_from_slice(&(hd as u32).to_ne_bytes());
+                p.extend_from_slice(&(rope_dim).to_ne_bytes());
+                p.extend_from_slice(&theta.to_ne_bytes());
+                p.extend_from_slice(&(freq_factors.is_some() as u32).to_ne_bytes());
+                self.dispatch(&pso, &[&bx, &bpos, &bff, &bd], &p, rows * nh);
+                vals[dst.0 as usize] = Self::read_f32(&bd, rows * nh * hd);
+            }
+            Op::QkNormRope {
+                x,
+                weight,
+                positions,
+                dst,
+                rows,
+                n_head,
+                head_dim,
+                rope_dim,
+                theta,
+                eps,
+                freq_factors,
+            } => {
+                let (rows, nh, hd) = (rows as usize, n_head as usize, head_dim as usize);
+                let bx = self.f32_buf(&vals[x.0 as usize]);
+                let bw = self.weight_buf(weight, g, bindings);
+                let bpos = self.f32_buf(&vals[positions.0 as usize]);
+                let bff = match freq_factors {
+                    Some(f) => self.f32_buf(&vals[f.0 as usize]),
+                    None => self.zeros_buf(1),
+                };
+                let bd = self.zeros_buf(rows * nh * hd);
+                let pso = self.pipelines.get("qknormrope_f32")?;
+                let mut p = (rows as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(nh as u32).to_ne_bytes());
+                p.extend_from_slice(&(hd as u32).to_ne_bytes());
+                p.extend_from_slice(&(rope_dim).to_ne_bytes());
+                p.extend_from_slice(&theta.to_ne_bytes());
+                p.extend_from_slice(&eps.to_ne_bytes());
+                p.extend_from_slice(&(freq_factors.is_some() as u32).to_ne_bytes());
+                self.dispatch(&pso, &[&bx, bw.as_ref(), &bpos, &bff, &bd], &p, rows * nh);
+                vals[dst.0 as usize] = Self::read_f32(&bd, rows * nh * hd);
+            }
+            Op::Add { a, b, dst, n } => {
+                let n = n as usize;
+                let ba = self.f32_buf(&vals[a.0 as usize]);
+                let bb = self.f32_buf(&vals[b.0 as usize]);
+                let bd = self.zeros_buf(n);
+                let pso = self.pipelines.get("add_f32")?;
+                self.dispatch(&pso, &[&ba, &bb, &bd], &(n as u32).to_ne_bytes(), n);
+                vals[dst.0 as usize] = Self::read_f32(&bd, n);
+            }
+            Op::Scale { x, dst, s, n } => {
+                let n = n as usize;
+                let bx = self.f32_buf(&vals[x.0 as usize]);
+                let bd = self.zeros_buf(n);
+                let pso = self.pipelines.get("scale_f32")?;
+                let mut p = s.to_ne_bytes().to_vec();
+                p.extend_from_slice(&(n as u32).to_ne_bytes());
+                self.dispatch(&pso, &[&bx, &bd], &p, n);
+                vals[dst.0 as usize] = Self::read_f32(&bd, n);
+            }
+            Op::Softcap { x, dst, cap, n } => {
+                let n = n as usize;
+                let bx = self.f32_buf(&vals[x.0 as usize]);
+                let bd = self.zeros_buf(n);
+                let pso = self.pipelines.get("softcap_f32")?;
+                let mut p = cap.to_ne_bytes().to_vec();
+                p.extend_from_slice(&(n as u32).to_ne_bytes());
+                self.dispatch(&pso, &[&bx, &bd], &p, n);
+                vals[dst.0 as usize] = Self::read_f32(&bd, n);
+            }
+            Op::GatedAct {
+                gate,
+                up,
+                dst,
+                rows,
+                nff,
+                act,
+                up_off,
+            } => {
+                let (rows, nff) = (rows as usize, nff as usize);
+                let bg = self.f32_buf(&vals[gate.0 as usize]);
+                let bu = self.f32_buf(&vals[up.0 as usize]);
+                let bd = self.zeros_buf(rows * nff);
+                let pso = self.pipelines.get("gatedact_f32")?;
+                let act_code: u32 = match act {
+                    infr_core::graph::Activation::Silu => 0,
+                    infr_core::graph::Activation::Sigmoid => 2,
+                    infr_core::graph::Activation::Gelu => 1,
+                };
+                let mut p = (rows as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(nff as u32).to_ne_bytes());
+                p.extend_from_slice(&act_code.to_ne_bytes());
+                p.extend_from_slice(&up_off.to_ne_bytes());
+                self.dispatch(&pso, &[&bg, &bu, &bd], &p, rows * nff);
+                vals[dst.0 as usize] = Self::read_f32(&bd, rows * nff);
+            }
+            Op::WriteKv {
+                src,
+                cache,
+                rows,
+                row_stride,
+                pos,
+            } => {
+                // Stateful write into the persistent (unified-memory) KV buffer — cast to the cache
+                // dtype on write, touching only `rows` rows. Host-side, matching the CPU reference.
+                let (rows, rs, pos) = (rows as usize, row_stride as usize, pos as usize);
+                let s = &vals[src.0 as usize];
+                let cbuf = metal_buf(
+                    bindings
+                        .get(cache)
+                        .expect("metal backend: unbound KV cache"),
+                );
+                let base = pos * rs;
+                let n = rows * rs;
+                match g.desc(cache).dtype {
+                    DType::F16 => {
+                        let ptr = cbuf.raw.contents() as *mut u16;
+                        for (i, &v) in s[..n].iter().enumerate() {
+                            unsafe {
+                                *ptr.add(base + i) = half::f16::from_f32(v).to_bits();
+                            }
+                        }
+                    }
+                    _ => {
+                        let ptr = cbuf.raw.contents() as *mut f32;
+                        unsafe {
+                            std::ptr::copy_nonoverlapping(s.as_ptr(), ptr.add(base), n);
+                        }
+                    }
+                }
+            }
+            Op::Attention {
+                q,
+                k_cache,
+                v_cache,
+                dst,
+                rows,
+                kv_len,
+                n_head,
+                n_kv,
+                head_dim,
+                scale,
+                mask,
+                pos,
+            } => {
+                let (rows, kv_len, nh, nkv, hd) = (
+                    rows as usize,
+                    kv_len as usize,
+                    n_head as usize,
+                    n_kv as usize,
+                    head_dim as usize,
+                );
+                if hd > 256 {
+                    return Err(Error::Unsupported(format!(
+                        "metal attention: head_dim {hd} exceeds MAX_HD 256 (shader acc[] cap)"
+                    )));
+                }
+                // Materialize the valid KV prefix (kv_len rows) as f32, dequantizing an f16 cache —
+                // the inner dot runs in f32 either way. Read straight from the bound cache buffers.
+                let need = kv_len * nkv * hd;
+                let kbuf = metal_buf(bindings.get(k_cache).expect("metal: unbound k_cache"));
+                let vbuf = metal_buf(bindings.get(v_cache).expect("metal: unbound v_cache"));
+                let (ks, vs) = match g.desc(k_cache).dtype {
+                    DType::F16 => (
+                        Self::read_f16_prefix(kbuf, need),
+                        Self::read_f16_prefix(vbuf, need),
+                    ),
+                    _ => (
+                        Self::read_f32(&kbuf.raw, need),
+                        Self::read_f32(&vbuf.raw, need),
+                    ),
+                };
+                let bq = self.f32_buf(&vals[q.0 as usize]);
+                let bk = self.f32_buf(&ks);
+                let bv = self.f32_buf(&vs);
+                let bd = self.zeros_buf(rows * nh * hd);
+                let window: u32 = match mask {
+                    infr_core::graph::AttnMask::Causal => 0,
+                    infr_core::graph::AttnMask::SlidingWindow(w) => w as u32,
+                };
+                let pso = self.pipelines.get("attention_f32")?;
+                let mut p = (rows as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(kv_len as u32).to_ne_bytes());
+                p.extend_from_slice(&(nh as u32).to_ne_bytes());
+                p.extend_from_slice(&(nkv as u32).to_ne_bytes());
+                p.extend_from_slice(&(hd as u32).to_ne_bytes());
+                p.extend_from_slice(&scale.to_ne_bytes());
+                p.extend_from_slice(&window.to_ne_bytes());
+                p.extend_from_slice(&pos.to_ne_bytes());
+                self.dispatch(&pso, &[&bq, &bk, &bv, &bd], &p, rows * nh);
+                vals[dst.0 as usize] = Self::read_f32(&bd, rows * nh * hd);
+            }
+            Op::MoeFfn {
+                x,
+                router,
+                gate_exps,
+                up_exps,
+                down_exps,
+                dst,
+                ne,
+                n_expert,
+                n_used,
+                n_ff_exp,
+                scale,
+                act,
+            } => {
+                let (ne, n_expert, n_used, nffx) = (
+                    ne as usize,
+                    n_expert as usize,
+                    n_used as usize,
+                    n_ff_exp as usize,
+                );
+                let xs = vals[x.0 as usize].clone();
+                // Router (host, mirroring the CPU reference). Structurally the same top-k selection,
+                // but the logits use a naive f32 sum here vs the CPU's 8-accumulator dot, so the
+                // summation order differs — top-k can pick differently on a near-tie logit.
+                let rw = self.weight_host(router, g, bindings);
+                let logits: Vec<f32> = (0..n_expert)
+                    .map(|e| (0..ne).map(|i| rw[e * ne + i] * xs[i]).sum::<f32>())
+                    .collect();
+                let maxl = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                let mut probs: Vec<f32> = logits.iter().map(|&v| (v - maxl).exp()).collect();
+                let psum: f32 = probs.iter().sum();
+                for p in probs.iter_mut() {
+                    *p /= psum;
+                }
+                let mut idx: Vec<usize> = (0..n_expert).collect();
+                idx.sort_by(|&a, &b| {
+                    probs[b]
+                        .partial_cmp(&probs[a])
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                idx.truncate(n_used);
+                let wsum: f32 = idx.iter().map(|&e| probs[e]).sum::<f32>().max(1e-20);
+                // Per-expert stacked-weight byte-slice sizes (each expert = an equal slice).
+                let gbuf = metal_buf(bindings.get(gate_exps).expect("metal: unbound gate_exps"));
+                let ubuf = metal_buf(bindings.get(up_exps).expect("metal: unbound up_exps"));
+                let dbuf = metal_buf(bindings.get(down_exps).expect("metal: unbound down_exps"));
+                let (gst, ust, dsz) = (
+                    gbuf.len / n_expert,
+                    ubuf.len / n_expert,
+                    dbuf.len / n_expert,
+                );
+                let (gdt, udt, ddt) = (
+                    g.desc(gate_exps).dtype,
+                    g.desc(up_exps).dtype,
+                    g.desc(down_exps).dtype,
+                );
+                let mut out = vec![0f32; ne];
+                for &e in &idx {
+                    // Dequant only this expert's slices, then matvec on the GPU.
+                    let gw = bytes_to_f32(&Self::read_bytes_range(gbuf, e * gst, gst), gdt);
+                    let uw = bytes_to_f32(&Self::read_bytes_range(ubuf, e * ust, ust), udt);
+                    let dw = bytes_to_f32(&Self::read_bytes_range(dbuf, e * dsz, dsz), ddt);
+                    let gate = self.gpu_matvec(&xs, &gw, ne, nffx)?;
+                    let up = self.gpu_matvec(&xs, &uw, ne, nffx)?;
+                    let actv: Vec<f32> = (0..nffx).map(|i| act_fn(act, gate[i]) * up[i]).collect();
+                    let y = self.gpu_matvec(&actv, &dw, nffx, ne)?;
+                    let w_e = probs[e] / wsum * scale;
+                    for i in 0..ne {
+                        out[i] += w_e * y[i];
+                    }
+                }
+                vals[dst.0 as usize] = out;
+            }
+            // Sequential per-token recurrences (control-flow heavy, tiny) — host-side, exactly
+            // mirroring the CPU reference. The recurrent `state` is a bound f32 Input read/written
+            // through `vals` (loaded in the preamble, written back after the op loop).
+            Op::Conv1dSilu {
+                x,
+                weight,
+                state,
+                dst,
+                channels,
+                kernel,
+            } => {
+                let (cc, kk) = (channels as usize, kernel as usize);
+                let xs = vals[x.0 as usize].clone();
+                let ws = self.weight_host(weight, g, bindings); // [channels, kernel]
+                let st = &mut vals[state.0 as usize]; // [(kernel-1), channels], oldest first
+                let mut out = vec![0f32; cc];
+                for ch in 0..cc {
+                    let mut acc = 0f32;
+                    for j in 0..kk - 1 {
+                        acc += st[j * cc + ch] * ws[ch * kk + j];
+                    }
+                    acc += xs[ch] * ws[ch * kk + (kk - 1)];
+                    out[ch] = acc / (1.0 + (-acc).exp()); // silu
+                }
+                for j in 0..kk.saturating_sub(2) {
+                    for ch in 0..cc {
+                        st[j * cc + ch] = st[(j + 1) * cc + ch];
+                    }
+                }
+                if kk >= 2 {
+                    for ch in 0..cc {
+                        st[(kk - 2) * cc + ch] = xs[ch];
+                    }
+                }
+                vals[dst.0 as usize] = out;
+            }
+            Op::DeltaNet {
+                q,
+                k,
+                v,
+                b,
+                a,
+                a_coef,
+                dt_bias,
+                state,
+                dst,
+                n_vhead,
+                n_khead,
+                head_k,
+                head_v,
+                eps,
+            } => {
+                let (nv, nk, kd, vd) = (
+                    n_vhead as usize,
+                    n_khead as usize,
+                    head_k as usize,
+                    head_v as usize,
+                );
+                let qf = vals[q.0 as usize].clone();
+                let kf = vals[k.0 as usize].clone();
+                let vf = vals[v.0 as usize].clone();
+                let bf = vals[b.0 as usize].clone();
+                let af = vals[a.0 as usize].clone();
+                let acoef = self.weight_host(a_coef, g, bindings);
+                let dtb = self.weight_host(dt_bias, g, bindings);
+                let st = &mut vals[state.0 as usize]; // [nv, kd, vd]
+                let mut out = vec![0f32; nv * vd];
+                let qscale = 1.0 / (kd as f32).sqrt();
+                let l2 = |slice: &[f32]| -> f32 {
+                    (slice.iter().map(|x| x * x).sum::<f32>() + eps).sqrt()
+                };
+                for h in 0..nv {
+                    let kh_idx = h % nk; // GQA: q/k heads tiled to nv value heads
+                    let mut qh = qf[kh_idx * kd..kh_idx * kd + kd].to_vec();
+                    let mut kh = kf[kh_idx * kd..kh_idx * kd + kd].to_vec();
+                    let vh = &vf[h * vd..h * vd + vd];
+                    let qn = l2(&qh);
+                    let kn = l2(&kh);
+                    for x in qh.iter_mut() {
+                        *x = *x / qn * qscale;
+                    }
+                    for x in kh.iter_mut() {
+                        *x /= kn;
+                    }
+                    let beta = 1.0 / (1.0 + (-bf[h]).exp());
+                    let sp = {
+                        let z = af[h] + dtb[h];
+                        z.max(0.0) + (-z.abs()).exp().ln_1p()
+                    };
+                    let decay = (acoef[h] * sp).exp();
+                    let sh = &mut st[h * kd * vd..(h + 1) * kd * vd]; // [kd, vd]
+                    for x in sh.iter_mut() {
+                        *x *= decay;
+                    }
+                    let mut kv = vec![0f32; vd];
+                    for kk in 0..kd {
+                        let kkv = kh[kk];
+                        let row = &sh[kk * vd..kk * vd + vd];
+                        for d in 0..vd {
+                            kv[d] += kkv * row[d];
+                        }
+                    }
+                    let delta: Vec<f32> = (0..vd).map(|d| (vh[d] - kv[d]) * beta).collect();
+                    for kk in 0..kd {
+                        let kkv = kh[kk];
+                        let row = &mut sh[kk * vd..kk * vd + vd];
+                        for d in 0..vd {
+                            row[d] += kkv * delta[d];
+                        }
+                    }
+                    let oh = &mut out[h * vd..h * vd + vd];
+                    for kk in 0..kd {
+                        let qv = qh[kk];
+                        let row = &sh[kk * vd..kk * vd + vd];
+                        for d in 0..vd {
+                            oh[d] += qv * row[d];
+                        }
+                    }
+                }
+                vals[dst.0 as usize] = out;
+            }
+            // Pure data movement (no arithmetic): done host-side, identical to the CPU reference.
+            Op::Copy {
+                src,
+                src_off,
+                dst,
+                dst_off,
+                n,
+            } => {
+                let (so, dof, n) = (src_off as usize, dst_off as usize, n as usize);
+                let s = vals[src.0 as usize].clone();
+                vals[dst.0 as usize][dof..dof + n].copy_from_slice(&s[so..so + n]);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -1,0 +1,163 @@
+// Apple-only: the `metal`/`objc` crates link the Objective-C runtime and don't build off macOS.
+// The whole crate compiles to nothing elsewhere (its consumers gate their use to macOS too), so the
+// Linux-only CI still builds the workspace.
+#![cfg(target_os = "macos")]
+//! Reference Metal compute backend — a correctness-first implementation of the [`Backend`] seam
+//! (the same one `infr-cpu` and `infr-vulkan` implement) on Apple's Metal API.
+//!
+//! Priorities are *correctness and clarity*, not speed: the backend keeps each graph tensor's
+//! working values in host f32 vectors (exactly like the CPU interpreter), and delegates each op's
+//! arithmetic to a small Metal compute kernel operating on f32 `MTLBuffer`s. Quantized `Op::Linear`
+//! weights are dequantized to f32 on the host (reusing `infr_gguf::dequant`) and cached as device
+//! buffers, so the MSL kernels never need to understand a single GGUF quant format.
+//!
+//! This follows `infr-cpu`'s execution model closely, which is what makes it easy to keep in
+//! numeric parity (see `tests/parity.rs`). It is not bit-for-bit identical everywhere: quantized
+//! `Op::Linear` runs a full-f32 dequant dot here, whereas the CPU path quantizes the *activation*
+//! to Q8 and uses integer dots — so this backend is actually the slightly more accurate of the two.
+//! A resident-on-device, kernel-fused fast path is future work.
+
+use infr_core::backend::{Backend, Bindings, BufferUsage, Capabilities, GraphPlan, Plan};
+use infr_core::error::{Error, Result};
+use infr_core::graph::Graph;
+use metal::{Buffer as MtlBuffer, CommandQueue, Device};
+
+mod exec;
+mod shaders;
+
+fn be(msg: impl std::fmt::Display) -> Error {
+    Error::backend(msg)
+}
+
+/// A device buffer. On Apple Silicon `StorageModeShared` memory is CPU-visible, so `upload`/
+/// `download` are plain `memcpy`s against [`MtlBuffer::contents`].
+pub struct MetalBuffer {
+    raw: MtlBuffer,
+    len: usize,
+}
+
+// MTLBuffer is documented thread-safe for the create/read/write use here; the raw pointer in the
+// metal-rs wrapper makes it neither Send nor Sync by default.
+unsafe impl Send for MetalBuffer {}
+unsafe impl Sync for MetalBuffer {}
+
+impl infr_core::backend::Buffer for MetalBuffer {
+    fn len_bytes(&self) -> usize {
+        self.len
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+pub struct MetalBackend {
+    device: Device,
+    queue: CommandQueue,
+    pipelines: shaders::Pipelines,
+    /// Dequantized-weight cache: bound-buffer address → device f32 buffer. Weights are bound the
+    /// same every step, so a quantized weight is dequantized once and reused.
+    ///
+    /// Keyed by address only, and never invalidated — safe because this has a *single-generation
+    /// lifetime*: each `generate_*` builds a fresh `MetalBackend`, so the cache lives for exactly one
+    /// generation and distinct weights have distinct addresses. Reusing an instance across models
+    /// (with buffer free/realloc) could return a stale f32 for a recycled address; don't.
+    weight_cache: std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<MtlBuffer>>>,
+}
+
+// MTLDevice / MTLCommandQueue are documented thread-safe; the pipeline states are immutable after
+// creation. The metal-rs wrappers are !Send/!Sync only because they hold raw obj-c pointers.
+unsafe impl Send for MetalBackend {}
+unsafe impl Sync for MetalBackend {}
+
+impl MetalBackend {
+    pub fn new() -> Result<Self> {
+        let device = Device::system_default().ok_or_else(|| be("no Metal device found"))?;
+        let queue = device.new_command_queue();
+        let pipelines = shaders::Pipelines::build(&device)?;
+        Ok(Self {
+            device,
+            queue,
+            pipelines,
+            weight_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
+        })
+    }
+}
+
+impl Backend for MetalBackend {
+    fn name(&self) -> &str {
+        "metal"
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            name: self.device.name().to_string(),
+            f16: true,
+            cooperative_matrix: false,
+            max_buffer_bytes: self.device.max_buffer_length(),
+            unified_memory: self.device.has_unified_memory(),
+            // Like the CPU interpreter, this backend reads the baked `pos`/`kv_len` from the graph
+            // ops each execute, so the decode graph is rebuilt per token (no record-once replay).
+            decode_replay: false,
+        }
+    }
+
+    fn alloc(
+        &self,
+        bytes: usize,
+        _usage: BufferUsage,
+    ) -> Result<Box<dyn infr_core::backend::Buffer>> {
+        let len = bytes.max(4);
+        let raw = self
+            .device
+            .new_buffer(len as u64, metal::MTLResourceOptions::StorageModeShared);
+        Ok(Box::new(MetalBuffer { raw, len }))
+    }
+
+    fn upload(&self, dst: &dyn infr_core::backend::Buffer, src: &[u8]) -> Result<()> {
+        let b = metal_buf(dst);
+        if src.len() > b.len {
+            return Err(be(format!("upload: src {} > buffer {}", src.len(), b.len)));
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(src.as_ptr(), b.raw.contents() as *mut u8, src.len());
+        }
+        Ok(())
+    }
+
+    fn download(&self, src: &dyn infr_core::backend::Buffer, dst: &mut [u8]) -> Result<()> {
+        let b = metal_buf(src);
+        if dst.len() > b.len {
+            return Err(be(format!(
+                "download: dst {} > buffer {}",
+                dst.len(),
+                b.len
+            )));
+        }
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                b.raw.contents() as *const u8,
+                dst.as_mut_ptr(),
+                dst.len(),
+            );
+        }
+        Ok(())
+    }
+
+    fn compile(&self, graph: &Graph) -> Result<Box<dyn Plan>> {
+        Ok(GraphPlan::boxed(graph))
+    }
+
+    fn execute(&self, plan: &dyn Plan, bindings: &Bindings) -> Result<()> {
+        self.execute_graph(plan, bindings)
+    }
+
+    fn sync(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn metal_buf(b: &dyn infr_core::backend::Buffer) -> &MetalBuffer {
+    b.as_any()
+        .downcast_ref::<MetalBuffer>()
+        .expect("metal backend: buffer is not a MetalBuffer (mixed backends?)")
+}

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1,0 +1,252 @@
+//! MSL compute kernels and lazy pipeline-state cache.
+//!
+//! All kernels operate on `float` (f32) buffers — quantized weights are dequantized to f32 on the
+//! host before they reach a kernel, so the shaders stay format-agnostic and simple. The full MSL
+//! source is compiled once at backend init; individual `MTLComputePipelineState`s are created on
+//! first use and cached by function name.
+
+use crate::be;
+use infr_core::error::Result;
+use metal::{ComputePipelineState, Device, Library};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+pub struct Pipelines {
+    device: Device,
+    library: Library,
+    cache: Mutex<HashMap<&'static str, ComputePipelineState>>,
+}
+
+unsafe impl Send for Pipelines {}
+unsafe impl Sync for Pipelines {}
+
+impl Pipelines {
+    pub fn build(device: &Device) -> Result<Self> {
+        let opts = metal::CompileOptions::new();
+        // Reference backend: prefer accurate transcendentals (sin/cos/tanh) over fast intrinsics so
+        // results stay in tight numeric parity with the CPU interpreter.
+        opts.set_fast_math_enabled(false);
+        let library = device
+            .new_library_with_source(MSL_SRC, &opts)
+            .map_err(|e| be(format!("compile MSL library: {e}")))?;
+        Ok(Self {
+            device: device.clone(),
+            library,
+            cache: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Get (creating + caching on first use) the compute pipeline for an MSL kernel function.
+    pub fn get(&self, name: &'static str) -> Result<ComputePipelineState> {
+        if let Some(p) = self.cache.lock().unwrap().get(name) {
+            return Ok(p.clone());
+        }
+        let func = self
+            .library
+            .get_function(name, None)
+            .map_err(|e| be(format!("get MSL function {name}: {e}")))?;
+        let pso = self
+            .device
+            .new_compute_pipeline_state_with_function(&func)
+            .map_err(|e| be(format!("pipeline for {name}: {e}")))?;
+        self.cache.lock().unwrap().insert(name, pso.clone());
+        Ok(pso)
+    }
+}
+
+/// Metal Shading Language source for every kernel. Kept in one string so it compiles as a single
+/// library. Grows as ops are added.
+const MSL_SRC: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+// ---- elementwise ----
+kernel void add_f32(device const float* a   [[buffer(0)]],
+                    device const float* b   [[buffer(1)]],
+                    device float*       dst [[buffer(2)]],
+                    constant uint&      n   [[buffer(3)]],
+                    uint gid [[thread_position_in_grid]]) {
+    if (gid < n) dst[gid] = a[gid] + b[gid];
+}
+
+struct ScaleParams { float s; uint n; };
+kernel void scale_f32(device const float* x   [[buffer(0)]],
+                      device float*       dst [[buffer(1)]],
+                      constant ScaleParams& p [[buffer(2)]],
+                      uint gid [[thread_position_in_grid]]) {
+    if (gid < p.n) dst[gid] = x[gid] * p.s;
+}
+
+struct SoftcapParams { float cap; uint n; };
+kernel void softcap_f32(device const float* x   [[buffer(0)]],
+                        device float*       dst [[buffer(1)]],
+                        constant SoftcapParams& p [[buffer(2)]],
+                        uint gid [[thread_position_in_grid]]) {
+    if (gid < p.n) dst[gid] = p.cap * tanh(x[gid] / p.cap);
+}
+
+// ---- norms (one thread per normalized group; sequential reduce to match the CPU sum order) ----
+struct RmsParams { uint rows; uint dim; float eps; };
+kernel void rmsnorm_f32(device const float* x   [[buffer(0)]],
+                        device const float* w   [[buffer(1)]],
+                        device float*       dst [[buffer(2)]],
+                        constant RmsParams& p   [[buffer(3)]],
+                        uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows) return;
+    uint base = gid * p.dim;
+    float ss = 0.0f;
+    for (uint i = 0; i < p.dim; i++) { float v = x[base + i]; ss += v * v; }
+    ss /= (float)p.dim;
+    float s = 1.0f / sqrt(ss + p.eps);
+    for (uint i = 0; i < p.dim; i++) dst[base + i] = x[base + i] * s * w[i];
+}
+
+// per-head RMSNorm: one thread per (row, head), weight indexed within head_dim
+struct QkNormParams { uint rows; uint n_head; uint head_dim; float eps; };
+kernel void qknorm_f32(device const float* x   [[buffer(0)]],
+                       device const float* w   [[buffer(1)]],
+                       device float*       dst [[buffer(2)]],
+                       constant QkNormParams& p [[buffer(3)]],
+                       uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.n_head) return;
+    uint base = gid * p.head_dim;
+    float ss = 0.0f;
+    for (uint i = 0; i < p.head_dim; i++) { float v = x[base + i]; ss += v * v; }
+    ss /= (float)p.head_dim;
+    float s = 1.0f / sqrt(ss + p.eps);
+    for (uint i = 0; i < p.head_dim; i++) dst[base + i] = x[base + i] * s * w[i];
+}
+
+// ---- Linear: dst[m, out_f] = x[m, in_f] · Wᵀ, W row-major [out_f, in_f], pre-dequantized to f32.
+// Reference kernel: one thread per output element, sequential dot (matches the CPU sum order).
+struct LinearParams { uint m; uint in_f; uint out_f; };
+kernel void linear_f32(device const float* x   [[buffer(0)]],
+                       device const float* w   [[buffer(1)]],
+                       device float*       dst [[buffer(2)]],
+                       constant LinearParams& p [[buffer(3)]],
+                       uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.m * p.out_f) return;
+    uint r = gid / p.out_f;
+    uint o = gid % p.out_f;
+    device const float* xr = x + (ulong)r * p.in_f;
+    device const float* wo = w + (ulong)o * p.in_f;
+    float acc = 0.0f;
+    for (uint i = 0; i < p.in_f; i++) acc += xr[i] * wo[i];
+    dst[gid] = acc;
+}
+
+// ---- RoPE (NEOX): rotate the first rope_dim of each head; dims beyond pass through. One thread
+// per (row, head). `pos`/`ff` buffers are f32. `has_ff` selects the per-pair freq divisor.
+struct RopeParams { uint rows; uint n_head; uint head_dim; uint rope_dim; float theta; uint has_ff; };
+kernel void rope_f32(device const float* x   [[buffer(0)]],
+                     device const float* pos [[buffer(1)]],
+                     device const float* ff  [[buffer(2)]],
+                     device float*       dst [[buffer(3)]],
+                     constant RopeParams& p  [[buffer(4)]],
+                     uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.n_head) return;
+    uint r = gid / p.n_head;
+    uint base = gid * p.head_dim;
+    for (uint i = 0; i < p.head_dim; i++) dst[base + i] = x[base + i]; // pass-through
+    uint hf = p.rope_dim / 2;
+    float p0 = pos[r];
+    for (uint pp = 0; pp < hf; pp++) {
+        uint i0 = pp, i1 = pp + hf;
+        float ang = p0 * pow(p.theta, -2.0f * (float)pp / (float)p.rope_dim);
+        if (p.has_ff != 0) ang /= ff[pp];
+        float c = cos(ang), s = sin(ang);
+        float a = x[base + i0], b = x[base + i1];
+        dst[base + i0] = a * c - b * s;
+        dst[base + i1] = a * s + b * c;
+    }
+}
+
+// ---- Fused per-head RMSNorm + RoPE (QkNormRope): rmsnorm (× weight) then rotate the normed head.
+struct QkRopeParams { uint rows; uint n_head; uint head_dim; uint rope_dim; float theta; float eps; uint has_ff; };
+kernel void qknormrope_f32(device const float* x   [[buffer(0)]],
+                           device const float* w   [[buffer(1)]],
+                           device const float* pos [[buffer(2)]],
+                           device const float* ff  [[buffer(3)]],
+                           device float*       dst [[buffer(4)]],
+                           constant QkRopeParams& p [[buffer(5)]],
+                           uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.n_head) return;
+    uint r = gid / p.n_head;
+    uint base = gid * p.head_dim;
+    float ss = 0.0f;
+    for (uint i = 0; i < p.head_dim; i++) { float v = x[base + i]; ss += v * v; }
+    ss /= (float)p.head_dim;
+    float s = 1.0f / sqrt(ss + p.eps);
+    for (uint i = 0; i < p.head_dim; i++) dst[base + i] = x[base + i] * s * w[i];
+    uint hf = p.rope_dim / 2;
+    float p0 = pos[r];
+    for (uint pp = 0; pp < hf; pp++) {
+        uint i0 = pp, i1 = pp + hf;
+        float ang = p0 * pow(p.theta, -2.0f * (float)pp / (float)p.rope_dim);
+        if (p.has_ff != 0) ang /= ff[pp];
+        float c = cos(ang), sn = sin(ang);
+        float a = dst[base + i0], b = dst[base + i1];
+        dst[base + i0] = a * c - b * sn;
+        dst[base + i1] = a * sn + b * c;
+    }
+}
+
+// ---- Gated FFN activation: dst[r,i] = act(gate[r,i]) * up[r, i + up_off]. act: 0=SiLU,1=GELU,2=Sigmoid
+inline float gated_act(uint act, float g) {
+    if (act == 0u) return g / (1.0f + exp(-g));                       // SiLU
+    if (act == 2u) return 1.0f / (1.0f + exp(-g));                    // Sigmoid
+    // GELU (gelu_pytorch_tanh)
+    return 0.5f * g * (1.0f + tanh(0.7978845608f * (g + 0.044715f * g * g * g)));
+}
+struct GatedParams { uint rows; uint nff; uint act; uint up_off; };
+kernel void gatedact_f32(device const float* gate [[buffer(0)]],
+                         device const float* up   [[buffer(1)]],
+                         device float*       dst  [[buffer(2)]],
+                         constant GatedParams& p  [[buffer(3)]],
+                         uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.nff) return;
+    uint r = gid / p.nff;
+    uint i = gid % p.nff;
+    uint gb = r * p.nff + i;
+    uint ub = r * p.nff + p.up_off + i;
+    dst[gb] = gated_act(p.act, gate[gb]) * up[ub];
+}
+
+// ---- Scaled-dot-product attention (GQA + causal/sliding-window), one thread per (query, head).
+// K/V are pre-materialized to f32 (kv_len × n_kv × head_dim). Online (flash) softmax, single pass.
+constant constexpr uint MAX_HD = 256;
+struct AttnParams { uint rows; uint kv_len; uint n_head; uint n_kv; uint head_dim; float scale; uint window; uint pos; };
+kernel void attention_f32(device const float* q   [[buffer(0)]],
+                          device const float* k   [[buffer(1)]],
+                          device const float* v   [[buffer(2)]],
+                          device float*       dst [[buffer(3)]],
+                          constant AttnParams& p  [[buffer(4)]],
+                          uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.n_head) return;
+    uint ti = gid / p.n_head;
+    uint h = gid % p.n_head;
+    uint group = p.n_head / p.n_kv;
+    uint kvh = h / group;
+    uint qb = gid * p.head_dim;                 // (ti*n_head + h) * head_dim
+    uint abs = p.pos + ti;                       // absolute position of this query
+    uint lo = (p.window > 0u && abs + 1u > p.window) ? (abs + 1u - p.window) : 0u;
+
+    float acc[MAX_HD];
+    for (uint d = 0; d < p.head_dim; d++) acc[d] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint j = lo; j <= abs; j++) {
+        uint kb = (j * p.n_kv + kvh) * p.head_dim;
+        float sc = 0.0f;
+        for (uint d = 0; d < p.head_dim; d++) sc += q[qb + d] * k[kb + d];
+        sc *= p.scale;
+        float mnew = max(m, sc);
+        float corr = exp(m - mnew);
+        float pw = exp(sc - mnew);
+        l = l * corr + pw;
+        uint vb = (j * p.n_kv + kvh) * p.head_dim;
+        for (uint d = 0; d < p.head_dim; d++) acc[d] = acc[d] * corr + pw * v[vb + d];
+        m = mnew;
+    }
+    for (uint d = 0; d < p.head_dim; d++) dst[qb + d] = acc[d] / l;
+}
+"#;

--- a/crates/infr-metal/tests/backend.rs
+++ b/crates/infr-metal/tests/backend.rs
@@ -1,0 +1,28 @@
+//! Backend-plumbing tests: device init + buffer memory roundtrip.
+//!
+//! macOS-only, `#[ignore]`d (needs a real Metal device) — run with
+//! `cargo test -p infr-metal -- --include-ignored`.
+#![cfg(target_os = "macos")]
+
+use infr_core::backend::{Backend, BufferUsage};
+use infr_metal::MetalBackend;
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn buffer_upload_download_roundtrip() {
+    let be = MetalBackend::new().expect("open metal backend");
+    let data: Vec<u8> = (0..1024u32).map(|i| (i.wrapping_mul(7)) as u8).collect();
+    let buf = be.alloc(data.len(), BufferUsage::Weights).expect("alloc");
+    be.upload(buf.as_ref(), &data).expect("upload");
+    let mut back = vec![0u8; data.len()];
+    be.download(buf.as_ref(), &mut back).expect("download");
+    assert_eq!(data, back, "downloaded bytes must equal uploaded bytes");
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn backend_reports_metal_name() {
+    let be = MetalBackend::new().expect("open metal backend");
+    assert_eq!(be.name(), "metal");
+    assert!(!be.capabilities().name.is_empty(), "device name populated");
+}

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1,0 +1,844 @@
+//! Numeric-parity tests: run the SAME graph op on `infr-cpu` (the trusted reference interpreter)
+//! and on `infr-metal`, assert the outputs match. This is the contract a backend must satisfy.
+//!
+//! macOS-only (the backend is), and each test is `#[ignore]`d — it needs a real Metal device, like
+//! the Vulkan GPU tests. Run them with `cargo test -p infr-metal -- --include-ignored`.
+#![cfg(target_os = "macos")]
+
+use infr_core::backend::{Backend, Bindings, Buffer, BufferUsage};
+use infr_core::graph::{Graph, Op};
+use infr_core::tensor::{DType, TensorDesc, TensorId};
+use infr_cpu::CpuBackend;
+use infr_metal::MetalBackend;
+
+// ---- deterministic test data (LCG, no rng dependency) ----
+fn lcg(s: &mut u64) -> u64 {
+    *s = s
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    *s
+}
+fn rand_f32(n: usize, mut seed: u64) -> Vec<f32> {
+    (0..n)
+        .map(|_| ((lcg(&mut seed) >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0)
+        .collect()
+}
+fn f32_bytes(v: &[f32]) -> Vec<u8> {
+    bytemuck::cast_slice(v).to_vec()
+}
+fn i32_bytes(v: &[i32]) -> Vec<u8> {
+    bytemuck::cast_slice(v).to_vec()
+}
+
+/// Bind raw byte buffers to graph handles, run one graph on `be`, and read back `out` as f32.
+fn run(
+    be: &dyn Backend,
+    g: &Graph,
+    bound: &[(TensorId, Vec<u8>)],
+    out: TensorId,
+    out_n: usize,
+) -> Vec<f32> {
+    let mut bufs: Vec<(TensorId, Box<dyn Buffer>)> = Vec::new();
+    for (id, bytes) in bound {
+        let b = be
+            .alloc(bytes.len().max(4), BufferUsage::Activations)
+            .unwrap();
+        be.upload(b.as_ref(), bytes).unwrap();
+        bufs.push((*id, b));
+    }
+    let ob = be.alloc(out_n * 4, BufferUsage::Activations).unwrap();
+    bufs.push((out, ob));
+
+    let mut binds = Bindings::new();
+    for (id, b) in &bufs {
+        binds.bind(*id, b.as_ref());
+    }
+    let plan = be.compile(g).unwrap();
+    be.execute(plan.as_ref(), &binds).unwrap();
+    be.sync().unwrap();
+
+    let ob = &bufs.iter().find(|(i, _)| *i == out).unwrap().1;
+    let mut bytes = vec![0u8; out_n * 4];
+    be.download(ob.as_ref(), &mut bytes).unwrap();
+    bytemuck::cast_slice::<u8, f32>(&bytes).to_vec()
+}
+
+/// Run one graph on `be`, then download raw bytes of the bound tensor `readback` (used for
+/// stateful ops like WriteKv that mutate a bound buffer instead of producing an Output).
+fn run_readback(
+    be: &dyn Backend,
+    g: &Graph,
+    bound: &[(TensorId, Vec<u8>)],
+    readback: TensorId,
+    byte_len: usize,
+) -> Vec<u8> {
+    let mut bufs: Vec<(TensorId, Box<dyn Buffer>)> = Vec::new();
+    for (id, bytes) in bound {
+        let b = be
+            .alloc(bytes.len().max(4), BufferUsage::Activations)
+            .unwrap();
+        be.upload(b.as_ref(), bytes).unwrap();
+        bufs.push((*id, b));
+    }
+    let mut binds = Bindings::new();
+    for (id, b) in &bufs {
+        binds.bind(*id, b.as_ref());
+    }
+    let plan = be.compile(g).unwrap();
+    be.execute(plan.as_ref(), &binds).unwrap();
+    be.sync().unwrap();
+    let rb = &bufs.iter().find(|(i, _)| *i == readback).unwrap().1;
+    let mut bytes = vec![0u8; byte_len];
+    be.download(rb.as_ref(), &mut bytes).unwrap();
+    bytes
+}
+
+/// Run one graph on `be` and read back several tensors as f32 (Outputs, or mutated f32 Inputs like
+/// recurrent state). Any `read` id not present in `bound` is allocated zeroed and bound.
+fn run_multi(
+    be: &dyn Backend,
+    g: &Graph,
+    bound: &[(TensorId, Vec<u8>)],
+    reads: &[(TensorId, usize)],
+) -> Vec<Vec<f32>> {
+    let mut bufs: Vec<(TensorId, Box<dyn Buffer>)> = Vec::new();
+    for (id, bytes) in bound {
+        let b = be
+            .alloc(bytes.len().max(4), BufferUsage::Activations)
+            .unwrap();
+        be.upload(b.as_ref(), bytes).unwrap();
+        bufs.push((*id, b));
+    }
+    for (id, n) in reads {
+        if !bound.iter().any(|(bid, _)| bid == id) {
+            let b = be.alloc(n * 4, BufferUsage::Activations).unwrap();
+            bufs.push((*id, b));
+        }
+    }
+    let mut binds = Bindings::new();
+    for (id, b) in &bufs {
+        binds.bind(*id, b.as_ref());
+    }
+    let plan = be.compile(g).unwrap();
+    be.execute(plan.as_ref(), &binds).unwrap();
+    be.sync().unwrap();
+    reads
+        .iter()
+        .map(|(id, n)| {
+            let b = &bufs.iter().find(|(i, _)| i == id).unwrap().1;
+            let mut bytes = vec![0u8; n * 4];
+            be.download(b.as_ref(), &mut bytes).unwrap();
+            bytemuck::cast_slice::<u8, f32>(&bytes).to_vec()
+        })
+        .collect()
+}
+
+fn assert_close(cpu: &[f32], mtl: &[f32], tol: f32, what: &str) {
+    assert_eq!(cpu.len(), mtl.len(), "{what}: length");
+    for (i, (c, m)) in cpu.iter().zip(mtl.iter()).enumerate() {
+        let err = (c - m).abs() / c.abs().max(1.0);
+        assert!(
+            err <= tol,
+            "{what} elem {i}: cpu={c} metal={m} err={err} > {tol}"
+        );
+    }
+}
+
+/// Run on both backends and assert close.
+fn assert_parity(g: &Graph, bound: &[(TensorId, Vec<u8>)], out: TensorId, out_n: usize, tol: f32) {
+    let cpu = run(&CpuBackend::new(), g, bound, out, out_n);
+    let mtl = run(
+        &MetalBackend::new().expect("metal backend"),
+        g,
+        bound,
+        out,
+        out_n,
+    );
+    assert_eq!(cpu.len(), mtl.len());
+    for (i, (c, m)) in cpu.iter().zip(mtl.iter()).enumerate() {
+        let err = (c - m).abs() / c.abs().max(1.0);
+        assert!(
+            err <= tol,
+            "elem {i}: cpu={c} metal={m} rel_err={err} > tol={tol}"
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn add_parity() {
+    let n = 4096usize;
+    let mut g = Graph::new();
+    let a = g.input(TensorDesc::new(vec![n], DType::F32));
+    let b = g.input(TensorDesc::new(vec![n], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![n], DType::F32));
+    g.push(Op::Add {
+        a,
+        b,
+        dst,
+        n: n as u32,
+    });
+    let bound = vec![
+        (a, f32_bytes(&rand_f32(n, 1))),
+        (b, f32_bytes(&rand_f32(n, 2))),
+    ];
+    assert_parity(&g, &bound, dst, n, 0.0);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn scale_parity() {
+    let n = 4096usize;
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![n], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![n], DType::F32));
+    g.push(Op::Scale {
+        x,
+        dst,
+        s: 0.125,
+        n: n as u32,
+    });
+    let bound = vec![(x, f32_bytes(&rand_f32(n, 3)))];
+    assert_parity(&g, &bound, dst, n, 0.0);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn softcap_parity() {
+    let n = 4096usize;
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![n], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![n], DType::F32));
+    g.push(Op::Softcap {
+        x,
+        dst,
+        cap: 30.0,
+        n: n as u32,
+    });
+    // scale inputs up so tanh saturation is exercised
+    let xs: Vec<f32> = rand_f32(n, 4).iter().map(|v| v * 60.0).collect();
+    let bound = vec![(x, f32_bytes(&xs))];
+    assert_parity(&g, &bound, dst, n, 1e-5);
+}
+
+// naive reference matmul: dst[r,o] = sum_i x[r,i] * w[o,i]   (w row-major [out_f, in_f])
+fn ref_linear(x: &[f32], w: &[f32], m: usize, in_f: usize, out_f: usize) -> Vec<f32> {
+    let mut out = vec![0f32; m * out_f];
+    for r in 0..m {
+        for o in 0..out_f {
+            let mut acc = 0f32;
+            for i in 0..in_f {
+                acc += x[r * in_f + i] * w[o * in_f + i];
+            }
+            out[r * out_f + o] = acc;
+        }
+    }
+    out
+}
+
+fn f16_bytes(v: &[f32]) -> Vec<u8> {
+    v.iter()
+        .flat_map(|&x| half::f16::from_f32(x).to_le_bytes())
+        .collect()
+}
+
+// Quantize a whole row-major weight to GGUF Q8_0 (32-elem blocks: f16 scale + 32×i8).
+fn quantize_q8_0(w: &[f32]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for blk in w.chunks(32) {
+        let amax = blk.iter().fold(0f32, |m, &v| m.max(v.abs()));
+        let d = if amax > 0.0 { amax / 127.0 } else { 0.0 };
+        out.extend_from_slice(&half::f16::from_f32(d).to_le_bytes());
+        for &v in blk {
+            let q = if d > 0.0 {
+                (v / d).round().clamp(-127.0, 127.0) as i8
+            } else {
+                0
+            };
+            out.push(q as u8);
+        }
+    }
+    out
+}
+
+// A deterministic LCG byte stream — arbitrary but reproducible payload for the k-quant nibble
+// fields (which decode to finite values for *any* byte pattern).
+fn lcg_bytes(mut seed: u32, n: usize) -> Vec<u8> {
+    (0..n)
+        .map(|_| {
+            seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+            (seed >> 16) as u8
+        })
+        .collect()
+}
+
+// Synthesize a well-formed GGUF Q4_K weight: 144-byte / 256-elem blocks laid out as
+// [f16 d][f16 dmin][12B scales][128B qs]. We only need *valid* bytes with finite f16 scales — not a
+// faithful quantization of any target — because the parity test compares Metal's dequant against a
+// reference dequant of these SAME bytes. Scale/nibble fields take an arbitrary reproducible pattern.
+fn synth_q4k(n_elem: usize, seed: u32) -> Vec<u8> {
+    assert_eq!(n_elem % 256, 0, "Q4_K blocks are 256 elems");
+    let mut out = Vec::new();
+    for blk_i in 0..(n_elem / 256) {
+        let mut blk = vec![0u8; 144];
+        blk[0..2].copy_from_slice(&half::f16::from_f32(0.05).to_le_bytes()); // d
+        blk[2..4].copy_from_slice(&half::f16::from_f32(0.10).to_le_bytes()); // dmin
+        blk[4..144].copy_from_slice(&lcg_bytes(seed ^ blk_i as u32, 140)); // scales + qs
+        out.extend_from_slice(&blk);
+    }
+    out
+}
+
+// Synthesize a well-formed GGUF Q6_K weight: 210-byte / 256-elem blocks laid out as
+// [128B ql][64B qh][16×i8 scales][f16 d]. Same rationale as `synth_q4k`.
+fn synth_q6k(n_elem: usize, seed: u32) -> Vec<u8> {
+    assert_eq!(n_elem % 256, 0, "Q6_K blocks are 256 elems");
+    let mut out = Vec::new();
+    for blk_i in 0..(n_elem / 256) {
+        let mut blk = vec![0u8; 210];
+        blk[0..208].copy_from_slice(&lcg_bytes(seed ^ blk_i as u32, 208)); // ql + qh + scales
+        blk[208..210].copy_from_slice(&half::f16::from_f32(0.03).to_le_bytes()); // d
+        out.extend_from_slice(&blk);
+    }
+    out
+}
+
+// Shared quant-Linear parity check: Metal dequants `wbytes` (via infr_gguf) and matmuls; compare to
+// a reference that dequants the SAME bytes and matmuls — isolates Metal's quant-weight path.
+fn check_quant_linear_parity(dtype: DType, wbytes: Vec<u8>, m: usize, in_f: usize, out_f: usize) {
+    use infr_gguf::dequant::dequant_block;
+    let xs = rand_f32(m * in_f, 24);
+    let wref = dequant_block(dtype, &wbytes).unwrap();
+    let reference = ref_linear(&xs, &wref, m, in_f, out_f);
+
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], dtype));
+    let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst,
+        m: m as u32,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+    });
+    let bound = vec![(x, f32_bytes(&xs)), (w, wbytes)];
+    let mtl = run(
+        &MetalBackend::new().expect("metal backend"),
+        &g,
+        &bound,
+        dst,
+        m * out_f,
+    );
+    for (i, (r, mm)) in reference.iter().zip(mtl.iter()).enumerate() {
+        let err = (r - mm).abs() / r.abs().max(1.0);
+        assert!(
+            err <= 1e-3,
+            "{dtype:?} elem {i}: ref={r} metal={mm} err={err}"
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_f32_parity() {
+    let (m, in_f, out_f) = (3usize, 512usize, 200usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst,
+        m: m as u32,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(m * in_f, 20))),
+        (w, f32_bytes(&rand_f32(out_f * in_f, 21))),
+    ];
+    assert_parity(&g, &bound, dst, m * out_f, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_f16_parity() {
+    let (m, in_f, out_f) = (2usize, 256usize, 128usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst,
+        m: m as u32,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(m * in_f, 22))),
+        (w, f16_bytes(&rand_f32(out_f * in_f, 23))),
+    ];
+    assert_parity(&g, &bound, dst, m * out_f, 1e-3);
+}
+
+// Quantized Linear: Metal dequants the weight to f32 (via infr_gguf) and matmuls. Compare to a
+// reference that dequants the SAME bytes and matmuls — isolates Metal's quant-weight path.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q8_0_matches_dequant_reference() {
+    use infr_gguf::dequant::dequant_block;
+    let (m, in_f, out_f) = (2usize, 256usize, 96usize);
+    let xs = rand_f32(m * in_f, 24);
+    let wf = rand_f32(out_f * in_f, 25);
+    let wbytes = quantize_q8_0(&wf);
+    let wref = dequant_block(DType::Q8_0, &wbytes).unwrap();
+    let reference = ref_linear(&xs, &wref, m, in_f, out_f);
+
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], DType::Q8_0));
+    let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst,
+        m: m as u32,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+    });
+    let bound = vec![(x, f32_bytes(&xs)), (w, wbytes)];
+    let mtl = run(
+        &MetalBackend::new().expect("metal backend"),
+        &g,
+        &bound,
+        dst,
+        m * out_f,
+    );
+    for (i, (r, mm)) in reference.iter().zip(mtl.iter()).enumerate() {
+        let err = (r - mm).abs() / r.abs().max(1.0);
+        assert!(err <= 1e-3, "elem {i}: ref={r} metal={mm} err={err}");
+    }
+}
+
+// K-quants are the formats real checkpoints actually ship. Exercise the Metal dequant path
+// (`weight_buf` → `dequant_block`) for Q4_K and Q6_K, same dequant-reference comparison as Q8_0.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4k_matches_dequant_reference() {
+    let (m, in_f, out_f) = (2usize, 256usize, 96usize);
+    check_quant_linear_parity(DType::Q4K, synth_q4k(out_f * in_f, 26), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q6k_matches_dequant_reference() {
+    let (m, in_f, out_f) = (2usize, 256usize, 96usize);
+    check_quant_linear_parity(DType::Q6K, synth_q6k(out_f * in_f, 27), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn rmsnorm_parity() {
+    let (rows, dim) = (7usize, 512usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, dim], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![dim], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, dim], DType::F32));
+    g.push(Op::RmsNorm {
+        x,
+        weight: w,
+        dst,
+        rows: rows as u32,
+        dim: dim as u32,
+        eps: 1e-6,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * dim, 10))),
+        (w, f32_bytes(&rand_f32(dim, 11))),
+    ];
+    assert_parity(&g, &bound, dst, rows * dim, 1e-5);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn qknorm_parity() {
+    let (rows, nh, hd) = (5usize, 8usize, 128usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![hd], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::QkNorm {
+        x,
+        weight: w,
+        dst,
+        rows: rows as u32,
+        n_head: nh as u32,
+        head_dim: hd as u32,
+        eps: 1e-6,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * nh * hd, 12))),
+        (w, f32_bytes(&rand_f32(hd, 13))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-5);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn rope_parity() {
+    let (rows, nh, hd, rd) = (4usize, 6usize, 128usize, 128usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let pos = g.input(TensorDesc::new(vec![rows], DType::I32));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Rope {
+        x,
+        positions: pos,
+        dst,
+        rows: rows as u32,
+        n_head: nh as u32,
+        head_dim: hd as u32,
+        rope_dim: rd as u32,
+        theta: 10000.0,
+        freq_factors: None,
+    });
+    let positions: Vec<i32> = (0..rows as i32).map(|i| i + 3).collect();
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * nh * hd, 30))),
+        (pos, i32_bytes(&positions)),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn rope_partial_with_freq_factors_parity() {
+    // rope_dim < head_dim (dims beyond rope_dim pass through) + per-pair freq_factors divisor
+    let (rows, nh, hd, rd) = (3usize, 4usize, 128usize, 64usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let pos = g.input(TensorDesc::new(vec![rows], DType::I32));
+    let ff = g.input(TensorDesc::new(vec![rd / 2], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Rope {
+        x,
+        positions: pos,
+        dst,
+        rows: rows as u32,
+        n_head: nh as u32,
+        head_dim: hd as u32,
+        rope_dim: rd as u32,
+        theta: 1000000.0,
+        freq_factors: Some(ff),
+    });
+    let positions: Vec<i32> = (0..rows as i32).map(|i| i * 2 + 1).collect();
+    let ffv: Vec<f32> = (0..rd / 2).map(|i| 1.0 + i as f32 * 0.1).collect();
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * nh * hd, 31))),
+        (pos, i32_bytes(&positions)),
+        (ff, f32_bytes(&ffv)),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn qknormrope_parity() {
+    let (rows, nh, hd, rd) = (4usize, 8usize, 128usize, 128usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![hd], DType::F32));
+    let pos = g.input(TensorDesc::new(vec![rows], DType::I32));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::QkNormRope {
+        x,
+        weight: w,
+        positions: pos,
+        dst,
+        rows: rows as u32,
+        n_head: nh as u32,
+        head_dim: hd as u32,
+        rope_dim: rd as u32,
+        theta: 10000.0,
+        eps: 1e-6,
+        freq_factors: None,
+    });
+    let positions: Vec<i32> = (0..rows as i32).map(|i| i + 1).collect();
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * nh * hd, 32))),
+        (w, f32_bytes(&rand_f32(hd, 33))),
+        (pos, i32_bytes(&positions)),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn writekv_f16_parity() {
+    // WriteKv casts f32 rows into an f16 cache at row `pos`. Both backends must produce identical
+    // f16 bytes.
+    let (rows, row_stride, max_ctx, pos) = (2usize, 256usize, 8usize, 3usize);
+    let cache_elems = max_ctx * row_stride;
+    let mut g = Graph::new();
+    let src = g.input(TensorDesc::new(vec![rows, row_stride], DType::F32));
+    let cache = g.input(TensorDesc::new(vec![cache_elems], DType::F16));
+    g.push(Op::WriteKv {
+        src,
+        cache,
+        rows: rows as u32,
+        row_stride: row_stride as u32,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (src, f32_bytes(&rand_f32(rows * row_stride, 40))),
+        (cache, vec![0u8; cache_elems * 2]),
+    ];
+    let cpu = run_readback(&CpuBackend::new(), &g, &bound, cache, cache_elems * 2);
+    let mtl = run_readback(
+        &MetalBackend::new().expect("metal backend"),
+        &g,
+        &bound,
+        cache,
+        cache_elems * 2,
+    );
+    assert_eq!(cpu, mtl, "WriteKv f16 cache bytes must be identical");
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_gqa_causal_parity() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (3usize, 6usize, 8usize, 2usize, 64usize, 0usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::Causal,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 41))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 42))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 43))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_sliding_window_parity() {
+    let (rows, kv_len, nh, nkv, hd, pos, win) =
+        (4usize, 10usize, 4usize, 4usize, 64usize, 2usize, 3usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::SlidingWindow(win),
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 44))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 45))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 46))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+fn gated_test(act: infr_core::graph::Activation, up_off: usize, seed: u64) {
+    let (rows, nff) = (3usize, 512usize);
+    let up_len = rows * nff + up_off;
+    let mut g = Graph::new();
+    let gate = g.input(TensorDesc::new(vec![rows, nff], DType::F32));
+    let up = g.input(TensorDesc::new(vec![up_len], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, nff], DType::F32));
+    g.push(Op::GatedAct {
+        gate,
+        up,
+        dst,
+        rows: rows as u32,
+        nff: nff as u32,
+        act,
+        up_off: up_off as u32,
+    });
+    let bound = vec![
+        (gate, f32_bytes(&rand_f32(rows * nff, seed))),
+        (up, f32_bytes(&rand_f32(up_len, seed + 1))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nff, 1e-5);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn gatedact_silu_parity() {
+    gated_test(infr_core::graph::Activation::Silu, 0, 50);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn gatedact_gelu_parity() {
+    gated_test(infr_core::graph::Activation::Gelu, 0, 52);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn gatedact_upoff_parity() {
+    gated_test(infr_core::graph::Activation::Silu, 128, 54);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn moe_ffn_parity() {
+    let (ne, n_expert, n_used, nff) = (64usize, 8usize, 2usize, 128usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![ne], DType::F32));
+    let router = g.weight(TensorDesc::new(vec![n_expert, ne], DType::F32));
+    let gate = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::F32));
+    let up = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::F32));
+    let down = g.weight(TensorDesc::new(vec![n_expert, ne, nff], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![ne], DType::F32));
+    g.push(Op::MoeFfn {
+        x,
+        router,
+        gate_exps: gate,
+        up_exps: up,
+        down_exps: down,
+        dst,
+        ne: ne as u32,
+        n_expert: n_expert as u32,
+        n_used: n_used as u32,
+        n_ff_exp: nff as u32,
+        scale: 1.0,
+        act: infr_core::graph::Activation::Silu,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(ne, 60))),
+        (router, f32_bytes(&rand_f32(n_expert * ne, 61))),
+        (gate, f32_bytes(&rand_f32(n_expert * nff * ne, 62))),
+        (up, f32_bytes(&rand_f32(n_expert * nff * ne, 63))),
+        (down, f32_bytes(&rand_f32(n_expert * ne * nff, 64))),
+    ];
+    assert_parity(&g, &bound, dst, ne, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn conv1d_silu_parity() {
+    let (cc, kk) = (256usize, 4usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![cc], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![cc, kk], DType::F32));
+    let state = g.input(TensorDesc::new(vec![kk - 1, cc], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![cc], DType::F32));
+    g.push(Op::Conv1dSilu {
+        x,
+        weight: w,
+        state,
+        dst,
+        channels: cc as u32,
+        kernel: kk as u32,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(cc, 70))),
+        (w, f32_bytes(&rand_f32(cc * kk, 71))),
+        (state, f32_bytes(&rand_f32((kk - 1) * cc, 72))),
+    ];
+    let reads = [(dst, cc), (state, (kk - 1) * cc)];
+    let cpu = run_multi(&CpuBackend::new(), &g, &bound, &reads);
+    let mtl = run_multi(&MetalBackend::new().expect("metal"), &g, &bound, &reads);
+    assert_close(&cpu[0], &mtl[0], 1e-5, "conv1d dst");
+    assert_close(&cpu[1], &mtl[1], 0.0, "conv1d state"); // shift is exact
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn deltanet_parity() {
+    let (nv, nk, kd, vd) = (4usize, 2usize, 64usize, 64usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![nk * kd], DType::F32));
+    let k = g.input(TensorDesc::new(vec![nk * kd], DType::F32));
+    let v = g.input(TensorDesc::new(vec![nv * vd], DType::F32));
+    let b = g.input(TensorDesc::new(vec![nv], DType::F32));
+    let a = g.input(TensorDesc::new(vec![nv], DType::F32));
+    let a_coef = g.weight(TensorDesc::new(vec![nv], DType::F32));
+    let dt_bias = g.weight(TensorDesc::new(vec![nv], DType::F32));
+    let state = g.input(TensorDesc::new(vec![nv * kd * vd], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![nv * vd], DType::F32));
+    g.push(Op::DeltaNet {
+        q,
+        k,
+        v,
+        b,
+        a,
+        a_coef,
+        dt_bias,
+        state,
+        dst,
+        n_vhead: nv as u32,
+        n_khead: nk as u32,
+        head_k: kd as u32,
+        head_v: vd as u32,
+        eps: 1e-6,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(nk * kd, 80))),
+        (k, f32_bytes(&rand_f32(nk * kd, 81))),
+        (v, f32_bytes(&rand_f32(nv * vd, 82))),
+        (b, f32_bytes(&rand_f32(nv, 83))),
+        (a, f32_bytes(&rand_f32(nv, 84))),
+        (a_coef, f32_bytes(&rand_f32(nv, 85))),
+        (dt_bias, f32_bytes(&rand_f32(nv, 86))),
+        (state, f32_bytes(&rand_f32(nv * kd * vd, 87))),
+    ];
+    let reads = [(dst, nv * vd), (state, nv * kd * vd)];
+    let cpu = run_multi(&CpuBackend::new(), &g, &bound, &reads);
+    let mtl = run_multi(&MetalBackend::new().expect("metal"), &g, &bound, &reads);
+    assert_close(&cpu[0], &mtl[0], 1e-4, "deltanet dst");
+    assert_close(&cpu[1], &mtl[1], 1e-4, "deltanet state");
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn copy_parity() {
+    let n = 4096usize;
+    let (src_off, dst_off, cnt) = (1000usize, 64usize, 2048usize);
+    let mut g = Graph::new();
+    let src = g.input(TensorDesc::new(vec![n], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![n], DType::F32));
+    g.push(Op::Copy {
+        src,
+        src_off: src_off as u32,
+        dst,
+        dst_off: dst_off as u32,
+        n: cnt as u32,
+    });
+    let bound = vec![(src, f32_bytes(&rand_f32(n, 5)))];
+    assert_parity(&g, &bound, dst, n, 0.0);
+}


### PR DESCRIPTION
## What

Adds `infr-metal`, a correctness-first implementation of the `Backend` trait — the same seam `infr-cpu` and `infr-vulkan` implement — on Apple Metal. Models now run on the Apple GPU through the backend-agnostic `Graph`, with no coopmat/portability workarounds needed (MoltenVK exposes neither `VK_KHR_cooperative_matrix` nor the portability enumeration the Vulkan path assumes, so the existing Vulkan backend doesn't come up on macOS).

## Design (perf is explicitly out of scope)

- **Host-orchestrated, GPU-computed.** Graph tensors are staged as f32 exactly like the CPU interpreter (`bytes_to_f32`, `in_place_inputs`, output write-back all mirror `infr-cpu`), and each op's arithmetic runs in a small MSL compute kernel over f32 `MTLBuffer`s. Mirroring the proven CPU dataflow is what keeps it in numeric parity.
- **No quant kernels.** Quantized `Op::Linear` weights are dequantized to f32 on the host (reusing `infr_gguf::dequant::dequant_block`) and cached as device buffers, so the shaders stay format-agnostic — one `linear_f32` kernel covers f32/f16 and every GGUF quant type.
- **Unified memory.** `StorageModeShared` buffers make `upload`/`download` a `memcpy`; one command buffer per op (`commit` + `wait`) guarantees strict graph-order execution with no manual barriers. MSL is compiled at init with fast-math disabled for tighter transcendental parity.

## Ops — full coverage

All 15 graph ops implemented and parity-tested against `infr-cpu`:

- **GPU kernels:** `RmsNorm`, `QkNorm`, `Linear` (f32/f16/quant), `Rope`, `QkNormRope`, `Attention` (GQA + causal & sliding-window, online softmax), `GatedAct`, `Add`, `Scale`, `Softcap`, and the per-expert `MoeFfn` matvecs.
- **Host-side** (data movement / sequential per-token recurrences, like the CPU reference): `Copy`, `WriteKv`, `MoeFfn` router+softmax+top-k, `Conv1dSilu`, `DeltaNet`.

This covers every model family the CPU reference supports: dense (Llama / Qwen3 / Gemma), `qwen3moe` (MoE), and `qwen35` / Qwen3-Next (gated DeltaNet).

## Tests

`crates/infr-metal/tests/parity.rs` runs each op on `infr-cpu` (the trusted reference) and on `infr-metal` and asserts the outputs match; the quantized-Linear test compares against a dequant-then-matmul reference to isolate the quant-weight path. **23 tests pass.**

## Integration

Wired into the CLI behind `INFR_METAL=1`, mirroring the existing `INFR_CPU` / Vulkan routing:
- dense + MoE via a new `generate_dense_metal` over the shared `generate_dense_backend` runner;
- Qwen3-Next via a refactor of `qwen35::generate_cpu` into a backend-generic `generate_seam` + `generate_cpu`/`generate_metal` wrappers.

Verified end-to-end on an Apple M3 Pro:

```
$ INFR_METAL=1 INFR_TEMP=0 infr run unsloth/Qwen3-0.6B-GGUF:Q4_K_M "What is the capital of France? Answer in one word."
[metal backend — dense/MoE forward on Apple GPU via the agnostic compute graph (reference)]
<think>
Okay, the user is asking for the capital of France in one word. Let me think. France's capital is Paris. ...
```

Greedy output matches the `INFR_CPU` reference token-for-token until a late near-tie (expected: the CPU path uses int8-quantized activation dots for k-quant weights, this backend uses full-f32 dequant). MoE and Qwen3-Next are covered by the op parity tests (end-to-end needs the large 30B/80B checkpoints).

## Notes / follow-ups

- Requires only the Metal runtime (present on all macOS); no Vulkan SDK / MoltenVK.
- Future work: keep tensors resident on-device and fuse kernels (drop the per-op host round-trip), MSL quant kernels, and moving the MoE/recurrent ops fully onto the GPU.