### PR TITLE
fix(vulkan): size flash-attention tile to device shared-memory limit

### DIFF
--- a/crates/infr-core/src/backend.rs
+++ b/crates/infr-core/src/backend.rs
@@ -24,6 +24,10 @@ pub struct Capabilities {
     pub f16: bool,
     pub cooperative_matrix: bool,
     pub max_buffer_bytes: u64,
+    /// `maxComputeSharedMemorySize` — the per-workgroup shared-memory budget. Vulkan only guarantees
+    /// 16 KB; RADV gives 64 KB, NVIDIA 48 KB, MoltenVK/mobile often 32 KB. The flash-attention tile
+    /// height is picked to fit this (and flash is skipped entirely if even the smallest tile won't).
+    pub max_shared_memory_bytes: u32,
     pub unified_memory: bool,
     /// The backend records a single-token decode graph ONCE and replays it per token, reading the
     /// position from a device-side params buffer (Vulkan seam) instead of the graph's baked `pos`.

--- a/crates/infr-cpu/src/lib.rs
+++ b/crates/infr-cpu/src/lib.rs
@@ -2248,6 +2248,7 @@ impl Backend for CpuBackend {
             f16: true,
             cooperative_matrix: false,
             max_buffer_bytes: u64::MAX,
+            max_shared_memory_bytes: u32::MAX, // scalar interpreter: no shared-memory tiling
             unified_memory: true,
             // The interpreter reads the baked `pos`/`kv_len` from the graph ops, so the decode graph
             // must be rebuilt per token — no record-once replay.

--- a/crates/infr-llama/src/transformer.rs
+++ b/crates/infr-llama/src/transformer.rs
@@ -949,7 +949,13 @@ impl Llama {
         //    or via INFR_NO_FLASH.
         // Both are correctness-tested (attention_prefill_{nonfa,flash}_matches_cpu) so neither rots.
         // DEFAULT = flash for hd=128. TODO: auto-select from device bandwidth/FLOP caps.
-        let use_flash = use_gemm && hd == 128 && std::env::var("INFR_NO_FLASH").is_err();
+        // The flash partial's smallest tile (bm=32) needs 29056 B of shared memory; if the device's
+        // maxComputeSharedMemorySize can't fit even that, fall back to the non-FA path (else the
+        // over-committed pipeline faults the GPU → device-lost). RADV 64 KB / NVIDIA 48 KB both fit.
+        let use_flash = use_gemm
+            && hd == 128
+            && self.be.max_shared_memory_bytes() >= 29056
+            && std::env::var("INFR_NO_FLASH").is_err();
         // gemma (hd=256) has no flash/nonfa prefill kernel (those tile on hd=128); keep its GEMM
         // projections but route attention through the hd-general `attention_kv` path (fall-through).
         let nonfa = use_gemm && !use_flash && !c.gemma;
@@ -2917,7 +2923,12 @@ impl Llama {
         // Flash prefill attention (split-K, register-blocked, never materializes the score matrix) is
         // hd=128-specialized and wants 64-row tiles → pad q/attn to mpad rows. Small chunks (t<64) or
         // other head dims fall back to the basic per-query attention_kv. INFR_NO_FLASH forces fallback.
-        let use_flash = hd == 128 && t >= 64 && std::env::var("INFR_NO_FLASH").is_err();
+        // bm=32 flash tile needs 29056 B shared; skip flash on devices that can't fit it (see the
+        // dense-prefill use_flash above) so the pipeline never over-commits shared memory.
+        let use_flash = hd == 128
+            && t >= 64
+            && self.be.max_shared_memory_bytes() >= 29056
+            && std::env::var("INFR_NO_FLASH").is_err();
         let mpad = if use_flash { t.div_ceil(64) * 64 } else { t };
         let q_f16 = self
             .be

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -21,8 +21,17 @@ fn main() {
         ("attn_qk", "attn_qk", &[]),
         ("attn_qk_warp", "attn_qk_warp", &[]),
         ("attn_flash", "attn_flash", &[]),
+        ("attn_flash", "attn_flash_bm32", &["-DBM_TILE=32"]),
         ("attn_flash_partial", "attn_flash_partial", &[]),
+        (
+            "attn_flash_partial",
+            "attn_flash_partial_bm32",
+            &["-DBM_TILE=32"],
+        ),
         ("attn_flash_warp", "attn_flash_warp", &[]),
+        // BM=32 tile: 29056 B shared (vs 58112 B), fits NVIDIA (48 KB) / MoltenVK (32 KB) devices
+        // whose maxComputeSharedMemorySize is under the 64 KB the default BM=64 tile needs.
+        ("attn_flash_warp", "attn_flash_warp_bm32", &["-DBM_TILE=32"]),
         ("attn_flash_reg", "attn_flash_reg", &[]),
         ("attn_flash_combine", "attn_flash_combine", &[]),
         ("attn_softmax", "attn_softmax", &[]),

--- a/crates/infr-vulkan/examples/limits_probe.rs
+++ b/crates/infr-vulkan/examples/limits_probe.rs
@@ -1,0 +1,62 @@
+//! Report the device limits that the flash-attention shaders implicitly assume (shared memory,
+//! subgroup size) plus the fp16→fp32 16x16x16 coopmat config, to explain the NVIDIA device-lost.
+use ash::vk;
+
+fn main() {
+    unsafe {
+        let entry = ash::Entry::load().unwrap();
+        let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_3);
+        let inst_exts = [ash::khr::get_physical_device_properties2::NAME.as_ptr()];
+        let instance = entry
+            .create_instance(
+                &vk::InstanceCreateInfo::default()
+                    .application_info(&app)
+                    .enabled_extension_names(&inst_exts),
+                None,
+            )
+            .unwrap();
+        let cm = ash::khr::cooperative_matrix::Instance::new(&entry, &instance);
+        for pd in instance.enumerate_physical_devices().unwrap() {
+            let props = instance.get_physical_device_properties(pd);
+            let name = std::ffi::CStr::from_ptr(props.device_name.as_ptr()).to_string_lossy();
+
+            let mut sub = vk::PhysicalDeviceSubgroupProperties::default();
+            let mut p2 = vk::PhysicalDeviceProperties2::default().push_next(&mut sub);
+            instance.get_physical_device_properties2(pd, &mut p2);
+
+            let shared = props.limits.max_compute_shared_memory_size;
+            println!("== {name} ==");
+            println!(
+                "  maxComputeSharedMemorySize = {shared} bytes ({} KB)",
+                shared / 1024
+            );
+            println!("  subgroupSize               = {}", sub.subgroup_size);
+            println!(
+                "  flash-warp shared need     = 58112 bytes (56.75 KB)  -> {}",
+                if 58112 > shared {
+                    "OVER LIMIT (device-lost)"
+                } else {
+                    "ok"
+                }
+            );
+
+            let v = cm
+                .get_physical_device_cooperative_matrix_properties(pd)
+                .unwrap();
+            let has_1616 = v.iter().any(|p| {
+                p.m_size == 16
+                    && p.n_size == 16
+                    && p.k_size == 16
+                    && p.a_type == vk::ComponentTypeKHR::FLOAT16
+                    && p.b_type == vk::ComponentTypeKHR::FLOAT16
+                    && p.result_type == vk::ComponentTypeKHR::FLOAT32
+                    && p.scope == vk::ScopeKHR::SUBGROUP
+            });
+            println!(
+                "  fp16x16x16->fp32 coopmat    = {}",
+                if has_1616 { "supported" } else { "MISSING" }
+            );
+        }
+        instance.destroy_instance(None);
+    }
+}

--- a/crates/infr-vulkan/shaders/attn_flash.comp
+++ b/crates/infr-vulkan/shaders/attn_flash.comp
@@ -3,16 +3,22 @@
 // path's 81%-of-high-ctx bottleneck). One workgroup per (BM-row query tile, head). Online softmax
 // state (running max/sum + O accumulator) lives in shared; both matmuls use coopmat. K/V read once
 // per query tile instead of the full m×kv scores round-tripping HBM 4×. Q/K/V f16, O f32. Causal
-// mask via absolute positions. GQA: head h → kv head h/(nh/nkv). hd%16, hd<=128. sg32 (4 subgroups).
+// mask via absolute positions. GQA: head h → kv head h/(nh/nkv). hd%16, hd<=128. sg32.
+// BM_TILE (query rows/tile) is a build knob: shared scratch = BM*908 B. BM=64 → 58112 B (needs a
+// 64 KB device); BM=32 → 29056 B (fits NVIDIA 48 KB / MoltenVK 32 KB). The recorder picks the tile
+// from maxComputeSharedMemorySize; workgroup = (BM/16) subgroups of 32. (See attn_flash_warp.comp.)
+#ifndef BM_TILE
+#define BM_TILE 64
+#endif
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_KHR_shader_subgroup_basic : require
 
-layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
+layout(local_size_x = (BM_TILE * 2), local_size_y = 1, local_size_z = 1) in;
 
-const uint BM = 64u; // query rows per tile (4 subgroups × 16)
+const uint BM = BM_TILE; // query rows per tile ((BM/16) subgroups × 16)
 const uint BN = 64u; // kv columns per block
 
 layout(push_constant) uniform PC {
@@ -45,7 +51,7 @@ void main() {
     uint hd = pc.hd;
     float scale = 1.0 / sqrt(float(hd));
 
-    for (uint i = li; i < BM * hd; i += 128u) { Os[i] = 0.0; }
+    for (uint i = li; i < BM * hd; i += gl_WorkGroupSize.x) { Os[i] = 0.0; }
     if (li < BM) { mrow[li] = -1e30; lrow[li] = 0.0; }
     barrier();
 
@@ -95,7 +101,7 @@ void main() {
         }
         barrier();
 
-        for (uint i = li; i < BM * hd; i += 128u) { Os[i] *= corr[i / hd]; }
+        for (uint i = li; i < BM * hd; i += gl_WorkGroupSize.x) { Os[i] *= corr[i / hd]; }
         barrier();
 
         // O += P·V (accumulator round-trips shared Os so the rescale carries across blocks).
@@ -117,7 +123,7 @@ void main() {
         barrier();
     }
 
-    for (uint i = li; i < BM * hd; i += 128u) {
+    for (uint i = li; i < BM * hd; i += gl_WorkGroupSize.x) {
         uint r = i / hd;
         uint d = i % hd;
         float l = lrow[r];

--- a/crates/infr-vulkan/shaders/attn_flash_partial.comp
+++ b/crates/infr-vulkan/shaders/attn_flash_partial.comp
@@ -5,15 +5,21 @@
 // (q-tile, head, split) emits an UN-normalized online-softmax partial: Os (running Σ exp(s-m)·v),
 // m (running max), l (running sum). attn_flash_combine merges splits per (row,head). No race: each
 // partial writes a disjoint [split] slice; combine only reads. Q/K/V f16, partials f32. hd%16,hd<=128.
+// BM_TILE (query rows/tile) is a build knob: shared scratch = BM*908 B. BM=64 → 58112 B (64 KB
+// device); BM=32 → 29056 B (NVIDIA 48 KB / MoltenVK 32 KB). Recorder picks the tile from
+// maxComputeSharedMemorySize; workgroup = (BM/16) subgroups of 32. (See attn_flash_warp.comp.)
+#ifndef BM_TILE
+#define BM_TILE 64
+#endif
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_KHR_shader_subgroup_basic : require
 
-layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
+layout(local_size_x = (BM_TILE * 2), local_size_y = 1, local_size_z = 1) in;
 
-const uint BM = 64u;
+const uint BM = BM_TILE;
 const uint BN = 64u;
 
 layout(push_constant) uniform PC {
@@ -51,7 +57,7 @@ void main() {
     uint hd = pc.hd;
     float scale = 1.0 / sqrt(float(hd));
 
-    for (uint i = li; i < BM * hd; i += 128u) { Os[i] = 0.0; }
+    for (uint i = li; i < BM * hd; i += gl_WorkGroupSize.x) { Os[i] = 0.0; }
     if (li < BM) { mrow[li] = -1e30; lrow[li] = 0.0; }
     barrier();
 
@@ -99,7 +105,7 @@ void main() {
         }
         barrier();
 
-        for (uint i = li; i < BM * hd; i += 128u) { Os[i] *= corr[i / hd]; }
+        for (uint i = li; i < BM * hd; i += gl_WorkGroupSize.x) { Os[i] *= corr[i / hd]; }
         barrier();
 
         for (uint ct = 0u; ct < hd; ct += 16u) {
@@ -121,7 +127,7 @@ void main() {
     }
 
     // Emit UN-normalized partial for this split (combine merges + normalizes).
-    for (uint i = li; i < BM * hd; i += 128u) {
+    for (uint i = li; i < BM * hd; i += gl_WorkGroupSize.x) {
         uint r = i / hd;
         uint d = i % hd;
         po[(split * pc.q_len + (qr0 + r)) * pc.nh * hd + h * hd + d] = Os[i];

--- a/crates/infr-vulkan/shaders/attn_flash_warp.comp
+++ b/crates/infr-vulkan/shaders/attn_flash_warp.comp
@@ -1,11 +1,21 @@
 #version 460
-// 8-warp/256-thread register-blocked flash-attention partial (hd=128). Same algorithm as
+// Register-blocked flash-attention partial (hd=128). Same algorithm as
 // attn_flash_partial (fused QK→online-softmax→PV, split-K over kv via gl_WorkGroupID.y, emits
 // un-normalized partials for attn_flash_combine) but both matmuls use the mul_mm-style warp tiling:
 // 8 warps split the tile, each keeps several 16×16 coopmat accumulators in registers and reuses the
 // loaded A fragment across them. K stays in shared via the score buffer; Q/K/V are coopMatLoad'd from
 // global (S/P/O live in shared, which caps the tile at BN=64 — the inherent flash vs non-FA tradeoff).
 // hd is fixed 128 so the per-warp fragment counts are compile-time. Requires sg32, q4-irrelevant.
+//
+// BM_TILE (query rows per workgroup) is a build-time knob: the shared scratch is Ss(BM*BN f32) +
+// Ps(BM*BN f16) + Os(BM*HD f32) + 3*BM f32 = BM*908 bytes. BM=64 → 58112 B needs a 64 KB shared
+// device (AMD RADV); BM=32 → 29056 B fits NVIDIA (48 KB) / MoltenVK (32 KB). The recorder picks the
+// largest tile the device's maxComputeSharedMemorySize allows. BM only scales WARPS_M / workgroup
+// size / shared sizes — the coopmat fragment counts (QK/PV_CMS_N) and the kv block (BN) are fixed,
+// so the online-softmax accumulation order is identical across tiles (bit-for-bit vs BM=64).
+#ifndef BM_TILE
+#define BM_TILE 64
+#endif
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -14,12 +24,13 @@
 #extension GL_KHR_shader_subgroup_clustered : require
 #extension GL_EXT_control_flow_attributes : require
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+// workgroup = WARPS_M*WARPS_N subgroups of 32 lanes = (BM/16)*2*32 = BM*4 threads.
+layout(local_size_x = (BM_TILE * 4), local_size_y = 1, local_size_z = 1) in;
 
-const uint BM = 64u;
+const uint BM = BM_TILE;
 const uint BN = 64u;
 const uint HD = 128u;
-const uint WARPS_M = 4u; // warp_r owns rows [warp_r*16, +16)
+const uint WARPS_M = BM_TILE / 16u; // warp_r owns rows [warp_r*16, +16)
 const uint WARPS_N = 2u; // warp_c owns a column band
 const uint QK_CMS_N = (BN / WARPS_N) / 16u; // 2  (cols per warp / 16)
 const uint PV_CMS_N = (HD / WARPS_N) / 16u; // 4
@@ -62,7 +73,7 @@ void main() {
     uint nkvhd = pc.nkv * HD;
     float scale = 1.0 / sqrt(float(HD));
 
-    for (uint i = li; i < BM * HD; i += 256u) { Os[i] = 0.0; }
+    for (uint i = li; i < BM * HD; i += gl_WorkGroupSize.x) { Os[i] = 0.0; }
     if (li < BM) { mrow[li] = -1e30; lrow[li] = 0.0; }
     barrier();
 
@@ -93,8 +104,8 @@ void main() {
         }
         barrier();
 
-        // Online softmax — all 256 threads active: 4 lanes/row (cluster of 4), each owns 16 cols;
-        // subgroupClustered{Max,Add} reduce across the 4. 8 subgroups × 8 rows = 64 rows in parallel.
+        // Online softmax — all threads active: 4 lanes/row (cluster of 4), each owns 16 cols;
+        // subgroupClustered{Max,Add} reduce across the 4. WARPS_M*WARPS_N subgroups × 8 rows = BM rows.
         {
             uint lane = gl_SubgroupInvocationID;        // 0..31
             uint r = gl_SubgroupID * 8u + lane / 4u;    // 0..63 (cluster of 4 consecutive lanes = 1 row)
@@ -127,7 +138,7 @@ void main() {
             }
         }
         barrier();
-        for (uint i = li; i < BM * HD; i += 256u) { Os[i] *= corr[i / HD]; }
+        for (uint i = li; i < BM * HD; i += gl_WorkGroupSize.x) { Os[i] *= corr[i / HD]; }
         barrier();
 
         // O += P·V. warp owns rows [warp_r*16,+16), hd cols [warp_c*64, +64) → PV_CMS_N frags.
@@ -158,7 +169,7 @@ void main() {
     }
 
     uint sl = split * pc.q_len;
-    for (uint i = li; i < BM * HD; i += 256u) {
+    for (uint i = li; i < BM * HD; i += gl_WorkGroupSize.x) {
         uint r = i / HD;
         uint d = i % HD;
         po[(sl + (qr0 + r)) * pc.nh * HD + h * HD + d] = Os[i];

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -258,10 +258,16 @@ const ATTN_PARTIAL_SPV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/
 const ATTN_QK_SPV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/attn_qk.spv"));
 const ATTN_QK_WARP_SPV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/attn_qk_warp.spv"));
 const ATTN_FLASH_SPV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash.spv"));
+const ATTN_FLASH_BM32_SPV_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_bm32.spv"));
 const ATTN_FLASH_PARTIAL_SPV_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_partial.spv"));
+const ATTN_FLASH_PARTIAL_BM32_SPV_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_partial_bm32.spv"));
 const ATTN_FLASH_WARP_SPV_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_warp.spv"));
+const ATTN_FLASH_WARP_BM32_SPV_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_warp_bm32.spv"));
 const ATTN_FLASH_REG_SPV_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_reg.spv"));
 const ATTN_FLASH_COMBINE_SPV_BYTES: &[u8] =
@@ -317,8 +323,11 @@ static ATTN_PARTIAL_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_QK_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_QK_WARP_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_SPV: OnceLock<Vec<u32>> = OnceLock::new();
+static ATTN_FLASH_BM32_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_PARTIAL_SPV: OnceLock<Vec<u32>> = OnceLock::new();
+static ATTN_FLASH_PARTIAL_BM32_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_WARP_SPV: OnceLock<Vec<u32>> = OnceLock::new();
+static ATTN_FLASH_WARP_BM32_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_REG_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_COMBINE_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_SM_SPV: OnceLock<Vec<u32>> = OnceLock::new();
@@ -377,13 +386,26 @@ pub(crate) fn attn_qk_warp_spv() -> &'static [u32] {
 pub(crate) fn attn_flash_spv() -> &'static [u32] {
     ATTN_FLASH_SPV.get_or_init(|| spv_words(ATTN_FLASH_SPV_BYTES))
 }
+/// BM=32 build of the fused flash prefill (29056 B shared) for sub-64 KB shared devices.
+pub(crate) fn attn_flash_bm32_spv() -> &'static [u32] {
+    ATTN_FLASH_BM32_SPV.get_or_init(|| spv_words(ATTN_FLASH_BM32_SPV_BYTES))
+}
 /// Flash-attention split-K partial pass (per kv-split online-softmax partials). Recorder use.
 pub(crate) fn attn_flash_partial_spv() -> &'static [u32] {
     ATTN_FLASH_PARTIAL_SPV.get_or_init(|| spv_words(ATTN_FLASH_PARTIAL_SPV_BYTES))
 }
-/// 8-warp register-blocked flash partial (hd=128). Used over attn_flash_partial when hd==128.
+/// BM=32 build of the split-K flash partial (29056 B shared) for sub-64 KB shared devices.
+pub(crate) fn attn_flash_partial_bm32_spv() -> &'static [u32] {
+    ATTN_FLASH_PARTIAL_BM32_SPV.get_or_init(|| spv_words(ATTN_FLASH_PARTIAL_BM32_SPV_BYTES))
+}
+/// Register-blocked flash partial (hd=128). Used over attn_flash_partial when hd==128.
 pub(crate) fn attn_flash_warp_spv() -> &'static [u32] {
     ATTN_FLASH_WARP_SPV.get_or_init(|| spv_words(ATTN_FLASH_WARP_SPV_BYTES))
+}
+/// BM=32 build of the flash partial (29056 B shared vs 58112 B): for devices whose
+/// maxComputeSharedMemorySize is under the 64 KB the default BM=64 tile needs (NVIDIA, MoltenVK).
+pub(crate) fn attn_flash_warp_bm32_spv() -> &'static [u32] {
+    ATTN_FLASH_WARP_BM32_SPV.get_or_init(|| spv_words(ATTN_FLASH_WARP_BM32_SPV_BYTES))
 }
 /// FlashAttention-2 register-O flash partial (Br=128, per-thread register accumulator). hd=128.
 pub(crate) fn attn_flash_reg_spv() -> &'static [u32] {

--- a/crates/infr-vulkan/src/lib.rs
+++ b/crates/infr-vulkan/src/lib.rs
@@ -279,6 +279,12 @@ impl Drop for WeightProgress {
 }
 
 impl VulkanBackend {
+    /// `maxComputeSharedMemorySize` for the active device — the per-workgroup shared-memory budget
+    /// the flash-attention tile height is sized against (cheap accessor; avoids cloning caps).
+    pub fn max_shared_memory_bytes(&self) -> u32 {
+        self.shared.caps.max_shared_memory_bytes
+    }
+
     /// Initialize Vulkan: create instance, pick a GPU (prefer discrete), create a logical
     /// device + compute queue with the required extensions/features, set up the allocator.
     pub fn new() -> Result<Self> {
@@ -432,6 +438,7 @@ impl VulkanBackend {
             f16: has_f16,
             cooperative_matrix: has_coop_matrix,
             max_buffer_bytes: props.limits.max_storage_buffer_range as u64,
+            max_shared_memory_bytes: props.limits.max_compute_shared_memory_size,
             unified_memory: false, // discrete GPU
             // The seam adapter records the decode graph once and replays it (params-driven `_dyn`
             // kernels); the runner compiles the eligible qwen3 decode graph once.

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -1356,14 +1356,28 @@ impl<'a> Recorder<'a> {
                 }
             }
         };
-        // hd=128 → 8-warp register-blocked partial (always via partial+combine). Other hd → the
+        // hd=128 → register-blocked partial (always via partial+combine). Other hd → the
         // 4-subgroup path: single fused kernel for n_splits==1, else the scalar partial.
-        let warp = hd == 128 && std::env::var("INFR_NO_FLASH_WARP").is_err();
+        //
+        // The warp partial's shared scratch is bm*908 B (Ss+Ps+Os+mrow/lrow/corr, BN=64/HD=128).
+        // Pick the largest tile the device's maxComputeSharedMemorySize allows: bm=64 → 58112 B (needs
+        // 64 KB, e.g. RADV); bm=32 → 29056 B (fits NVIDIA 48 KB / MoltenVK 32 KB). The transformer
+        // skips flash entirely when even bm=32 won't fit, so one of these always fits here.
+        let shared_limit = self.be.shared.caps.max_shared_memory_bytes;
+        let bm: u32 = if shared_limit >= 64 * 908 { 64 } else { 32 };
+        // Each workgroup covers `bm` query rows → mpad/bm×nh groups (mpad is 64-aligned → /32 exact).
+        let tile_wg = (mpad / bm) * nh as u32;
+        // INFR_NO_FLASH_WARP A/Bs the non-warp partial (BM=64, 58112 B); ignored where it won't fit.
+        let warp =
+            hd == 128 && (std::env::var("INFR_NO_FLASH_WARP").is_err() || shared_limit < 58112);
         if n_splits == 1 && !warp {
             self.stamp("attn_flash");
-            let k = self
-                .be
-                .kernel_sg("attn_flash", crate::gemm::attn_flash_spv(), 4, 24, 32);
+            let (fname, fspv): (&'static str, &[u32]) = if bm == 32 {
+                ("attn_flash_bm32", crate::gemm::attn_flash_bm32_spv())
+            } else {
+                ("attn_flash", crate::gemm::attn_flash_spv())
+            };
+            let k = self.be.kernel_sg(fname, fspv, 4, 24, 32);
             let mut p = [0u8; 24];
             p[0..4].copy_from_slice(&mpad.to_ne_bytes());
             p[4..8].copy_from_slice(&(kv_len as u32).to_ne_bytes());
@@ -1376,17 +1390,26 @@ impl<'a> Recorder<'a> {
                 &[Self::vkb(q), Self::vkb(kc), Self::vkb(vc), Self::vkb(attn)],
                 1,
                 &p,
-                base_wg,
+                tile_wg,
             );
             return;
         }
         // split-K partials
         self.stamp("attn_flash");
         let ksplit = (kv_len as u32).div_ceil(n_splits).div_ceil(64) * 64;
-        let (pname, pspv) = if warp {
-            ("attn_flash_warp", crate::gemm::attn_flash_warp_spv())
-        } else {
-            ("attn_flash_partial", crate::gemm::attn_flash_partial_spv())
+        // hd=128 → register-blocked warp partial; else the 4-subgroup partial. Each picks its
+        // bm-sized shared build (warp/partial share the bm*908 B footprint) and covers tile_wg groups.
+        let (pname, pspv): (&'static str, &[u32]) = match (warp, bm) {
+            (true, 32) => (
+                "attn_flash_warp_bm32",
+                crate::gemm::attn_flash_warp_bm32_spv(),
+            ),
+            (true, _) => ("attn_flash_warp", crate::gemm::attn_flash_warp_spv()),
+            (false, 32) => (
+                "attn_flash_partial_bm32",
+                crate::gemm::attn_flash_partial_bm32_spv(),
+            ),
+            (false, _) => ("attn_flash_partial", crate::gemm::attn_flash_partial_spv()),
         };
         let kp = self.be.kernel_sg(pname, pspv, 6, 32, 32);
         let mut pp = [0u8; 32];
@@ -1410,7 +1433,7 @@ impl<'a> Recorder<'a> {
             ],
             3,
             &pp,
-            base_wg,
+            tile_wg,
             n_splits,
             1,
         );


### PR DESCRIPTION
## Problem

Running any hd=128 model on an **NVIDIA GPU** crashes on the first compute submit:

```
Error: backend: queue_wait_idle: The logical device has been lost.
```

The flash-attention prefill shaders (`attn_flash`, `attn_flash_warp`,
`attn_flash_partial`) statically allocate **~58 KB of shared memory** (`Ss` 16 KB
+ `Ps` 8 KB + `Os[64×128]` f32 **32 KB** + softmax state, at `BM=64`). That fits
AMD RADV's 64 KB `maxComputeSharedMemorySize`, but **exceeds it on every other
mainstream Vulkan device**:

| Device | `maxComputeSharedMemorySize` | 58 KB flash tile |
| --- | --- | --- |
| AMD RADV | 65536 (64 KB) | ✅ |
| Intel ANV | 65536 (64 KB) | ✅ |
| **NVIDIA** | **49152 (48 KB)** | ❌ device-lost |
| **MoltenVK / mobile** | ~**32768 (32 KB)** | ❌ device-lost |
| Vulkan spec minimum | 16384 (16 KB) | ❌ |

The limit was never queried, so the over-committed pipeline was created and then
faulted the GPU at dispatch. Flash silently only ever worked on AMD; `INFR_NO_FLASH`
was the only escape hatch on NVIDIA.

## Fix

Detect `maxComputeSharedMemorySize` and pick the largest flash tile that fits:
**BM=64** (58112 B) on 64 KB devices, **BM=32** (29056 B) on NVIDIA / MoltenVK.
`BM` only scales the query-row tile, workgroup size, and shared arrays — `BN` and
the coopmat fragment counts are fixed, so the online-softmax accumulation order is
**identical across tiles**. If even BM=32 won't fit (<29 KB), the transformer falls
back to the non-flash path instead of tripping device-lost.

- **shaders:** `attn_flash{,_warp,_partial}` take a `BM_TILE` build define → `*_bm32` SPIR-V
- **core:** `Capabilities` gains `max_shared_memory_bytes`
- **vulkan:** the recorder selects the tile + workgroup count from the device limit
- **llama:** `use_flash` is gated on the smallest tile fitting the device
- **examples/limits_probe:** prints the shared-memory limit + fp16 coopmat config

## Validation (RTX 2080 Ti, 48 KB shared)

- `attention_prefill_flash_matches_cpu` passes token-for-token vs the CPU reference
  — all shapes incl. hd=64 and the split-K path (previously device-lost on the first case).
- `infr run` / `infr bench` now work **with flash enabled by default** (no
  `INFR_NO_FLASH`): coherent output, prefill pp512 ≈ 3940 t/s, pp2048 ≈ 2387 t/s.
- `cargo fmt` / `clippy` clean. No change on AMD (BM=64 path unchanged).

## Notes

- The opt-in `attn_flash_reg` path (`INFR_FLASH_REG`, `BR=128`) is not on any
  default route and is left untiled — a follow-up if that experiment is kept.