### PR TITLE
fix(vulkan): size register-O flash tile to device shared-memory limit

### DIFF
--- a/crates/infr-llama/src/transformer.rs
+++ b/crates/infr-llama/src/transformer.rs
@@ -931,14 +931,12 @@ impl Llama {
         // (hd 256/512, nkv 8/1, wv=None → V=K, E2B per-layer FFN/KV-sharing) via the same per-layer
         // args the GEMV path used — see the QKV/FFN blocks below. INFR_NOGEMM restores GEMV.
         let use_gemm = c.qk_norm && n >= 64 && std::env::var("INFR_NOGEMM").is_err();
-        // Register-O flash (FlashAttention-2 layout, Br=128) is opt-in (INFR_FLASH_REG) while it's
-        // A/B'd vs the BM=64 flash; it needs mpad padded to 128 (q/attn/scratch).
-        // The register-O tile statically allocates 58880 B of shared memory (BR=128); skip it when
-        // the device can't fit that (NVIDIA 48 KB / MoltenVK) so it falls back to the size-aware
-        // flash path instead of over-committing shared memory → device-lost. RADV (64 KB) fits.
+        // Register-O flash (FlashAttention-2 layout, Br=128/64) is opt-in (INFR_FLASH_REG) while it's
+        // A/B'd vs the BM=64 flash; it needs mpad padded to 128 (q/attn/scratch). Its smallest tile
+        // (BR=64) needs 29440 B shared — skip it on devices that can't fit that (else device-lost).
         let use_flash_reg = use_gemm
             && hd == 128
-            && self.be.max_shared_memory_bytes() >= 58880
+            && self.be.max_shared_memory_bytes() >= 29440
             && std::env::var("INFR_FLASH_REG").is_ok();
         // gemma prefill attention: the flash warptile is hd=128-only, but the non-FA coopmat path
         // (attn_qk → softmax → attn_pv) is hd-general (256/512), so route gemma's attention through

--- a/crates/infr-llama/src/transformer.rs
+++ b/crates/infr-llama/src/transformer.rs
@@ -936,7 +936,7 @@ impl Llama {
         // (BR=64) needs 29440 B shared — skip it on devices that can't fit that (else device-lost).
         let use_flash_reg = use_gemm
             && hd == 128
-            && self.be.max_shared_memory_bytes() >= 29440
+            && self.be.max_shared_memory_bytes() >= 64 * infr_vulkan::FLASH_REG_SHARED_PER_ROW
             && std::env::var("INFR_FLASH_REG").is_ok();
         // gemma prefill attention: the flash warptile is hd=128-only, but the non-FA coopmat path
         // (attn_qk → softmax → attn_pv) is hd-general (256/512), so route gemma's attention through
@@ -967,7 +967,7 @@ impl Llama {
         // over-committed pipeline faults the GPU → device-lost). RADV 64 KB / NVIDIA 48 KB both fit.
         let use_flash = use_gemm
             && hd == 128
-            && self.be.max_shared_memory_bytes() >= 29056
+            && self.be.max_shared_memory_bytes() >= 32 * infr_vulkan::FLASH_SHARED_PER_ROW
             && std::env::var("INFR_NO_FLASH").is_err();
         // non-FA coopmat attention: qwen3's hd≠128 / INFR_NO_FLASH fallback, OR gemma prefill
         // (hd=256/512). gemma4 has no use_gemm, so the `gemma_prefill_attn` term brings it in.
@@ -2949,7 +2949,7 @@ impl Llama {
         // dense-prefill use_flash above) so the pipeline never over-commits shared memory.
         let use_flash = hd == 128
             && t >= 64
-            && self.be.max_shared_memory_bytes() >= 29056
+            && self.be.max_shared_memory_bytes() >= 32 * infr_vulkan::FLASH_SHARED_PER_ROW
             && std::env::var("INFR_NO_FLASH").is_err();
         let mpad = if use_flash { t.div_ceil(64) * 64 } else { t };
         let q_f16 = self

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -94,6 +94,9 @@ impl Backend for MetalBackend {
             f16: true,
             cooperative_matrix: false,
             max_buffer_bytes: self.device.max_buffer_length(),
+            // Metal's per-threadgroup memory limit (MTLDevice.maxThreadgroupMemoryLength) — the
+            // analogue of Vulkan's maxComputeSharedMemorySize (typically 32 KB, 64 KB on Apple GPUs).
+            max_shared_memory_bytes: self.device.max_threadgroup_memory_length() as u32,
             unified_memory: self.device.has_unified_memory(),
             // Like the CPU interpreter, this backend reads the baked `pos`/`kv_len` from the graph
             // ops each execute, so the decode graph is rebuilt per token (no record-once replay).

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -33,6 +33,8 @@ fn main() {
         // whose maxComputeSharedMemorySize is under the 64 KB the default BM=64 tile needs.
         ("attn_flash_warp", "attn_flash_warp_bm32", &["-DBM_TILE=32"]),
         ("attn_flash_reg", "attn_flash_reg", &[]),
+        // BR=64 tile: 29440 B shared (vs 58880 B) for sub-64 KB shared devices (NVIDIA, MoltenVK).
+        ("attn_flash_reg", "attn_flash_reg_br64", &["-DBR_TILE=64"]),
         ("attn_flash_combine", "attn_flash_combine", &[]),
         ("attn_softmax", "attn_softmax", &[]),
         ("attn_pv", "attn_pv", &[]),

--- a/crates/infr-vulkan/shaders/attn_flash_reg.comp
+++ b/crates/infr-vulkan/shaders/attn_flash_reg.comp
@@ -4,7 +4,15 @@
 // q-tiles → fewer K/V re-reads + bigger GEMM reuse). Thread t owns row (t/2) and dims [cw*64,+64)
 // with cw=t%2; O is Of[16] vec4 in registers. Per-row online-softmax rescale is a trivial register
 // multiply (thread owns its row). hd=128 specialized. Split-K over kv via gl_WorkGroupID.y; emits
-// un-normalized partials (Of, m, l) for attn_flash_combine. sg32, 8 subgroups.
+// un-normalized partials (Of, m, l) for attn_flash_combine. sg32.
+// BR_TILE (query rows/tile) is a build knob: shared = sfsh(BR*BC f32) + Psh(BR*BC f16) +
+// pvsh((BR/16)*256 f32) + 3*BR = BR*460 B. BR=128 → 58880 B (needs a 64 KB device); BR=64 →
+// 29440 B (fits NVIDIA 48 KB / MoltenVK 32 KB). The recorder picks the tile from
+// maxComputeSharedMemorySize. BR only scales WARPS_M / workgroup size / shared arrays — the
+// per-warp 32×32 coopmat work (sacc[2][2]) and BC are fixed, so results are identical across tiles.
+#ifndef BR_TILE
+#define BR_TILE 128
+#endif
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -13,12 +21,14 @@
 #extension GL_KHR_shader_subgroup_clustered : require
 #extension GL_EXT_control_flow_attributes : require
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+// workgroup = WARPS_M*WARPS_N subgroups of 32 = (BR/32)*2*32 = BR*2 threads.
+layout(local_size_x = (BR_TILE * 2), local_size_y = 1, local_size_z = 1) in;
 
-const uint BR = 128u;   // query rows per tile
-const uint BC = 64u;    // kv cols per block
+const uint BR = BR_TILE;        // query rows per tile
+const uint BC = 64u;            // kv cols per block
 const uint HD = 128u;
-const uint DPT = 16u;   // vec4 per thread = (HD/2)/4 — each thread owns 64 dims of its row
+const uint DPT = 16u;           // vec4 per thread = (HD/2)/4 — each thread owns 64 dims of its row
+const uint WARPS_M = BR_TILE / 32u; // QK warptile row-warps (each owns 32 rows); WARPS_N = BC/32 = 2
 
 layout(push_constant) uniform PC {
     uint q_len;     // mpad (multiple of BR)
@@ -39,7 +49,7 @@ layout(binding = 5) writeonly buffer PLB { float pl[]; };    // [n_splits, mpad,
 
 shared float sfsh[BR * BC];      // scores (f32)
 shared float16_t Psh[BR * BC];   // probs (f16) for PV coopmat
-shared float pvsh[8u * 16u * 16u]; // per-subgroup PV tile (16×16)
+shared float pvsh[(BR_TILE / 16u) * 256u]; // per-subgroup PV tile (16×16), one per subgroup (BR/16)
 shared float mrow[BR];
 shared float lrow[BR];
 shared float corr[BR];
@@ -51,10 +61,10 @@ void main() {
     uint qr0 = qt * BR;
     uint kvh = h / (pc.nh / pc.nkv);
     uint tid = gl_LocalInvocationIndex;
-    uint sg = gl_SubgroupID;          // 0..7 → row-panel sg
+    uint sg = gl_SubgroupID;          // 0..(BR/16-1) → row-panel sg
     uint lane = gl_SubgroupInvocationID; // 0..31
-    uint warp_r = sg % 4u;            // QK warptile: 4×2 warps
-    uint warp_c = sg / 4u;
+    uint warp_r = sg % WARPS_M;       // QK warptile: WARPS_M×2 warps
+    uint warp_c = sg / WARPS_M;
     uint nhhd = pc.nh * HD;
     uint nkvhd = pc.nkv * HD;
     float scale = 1.0 / sqrt(float(HD));

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -270,6 +270,8 @@ const ATTN_FLASH_WARP_BM32_SPV_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_warp_bm32.spv"));
 const ATTN_FLASH_REG_SPV_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_reg.spv"));
+const ATTN_FLASH_REG_BR64_SPV_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_reg_br64.spv"));
 const ATTN_FLASH_COMBINE_SPV_BYTES: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/attn_flash_combine.spv"));
 const ATTN_SM_SPV_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/attn_softmax.spv"));
@@ -329,6 +331,7 @@ static ATTN_FLASH_PARTIAL_BM32_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_WARP_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_WARP_BM32_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_REG_SPV: OnceLock<Vec<u32>> = OnceLock::new();
+static ATTN_FLASH_REG_BR64_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_FLASH_COMBINE_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_SM_SPV: OnceLock<Vec<u32>> = OnceLock::new();
 static ATTN_PV_SPV: OnceLock<Vec<u32>> = OnceLock::new();
@@ -410,6 +413,10 @@ pub(crate) fn attn_flash_warp_bm32_spv() -> &'static [u32] {
 /// FlashAttention-2 register-O flash partial (Br=128, per-thread register accumulator). hd=128.
 pub(crate) fn attn_flash_reg_spv() -> &'static [u32] {
     ATTN_FLASH_REG_SPV.get_or_init(|| spv_words(ATTN_FLASH_REG_SPV_BYTES))
+}
+/// BR=64 build of the register-O flash partial (29440 B shared) for sub-64 KB shared devices.
+pub(crate) fn attn_flash_reg_br64_spv() -> &'static [u32] {
+    ATTN_FLASH_REG_BR64_SPV.get_or_init(|| spv_words(ATTN_FLASH_REG_BR64_SPV_BYTES))
 }
 /// Flash-attention split-K combine (merge partials → final O). Recorder use.
 pub(crate) fn attn_flash_combine_spv() -> &'static [u32] {

--- a/crates/infr-vulkan/src/lib.rs
+++ b/crates/infr-vulkan/src/lib.rs
@@ -20,6 +20,15 @@ mod recorder;
 pub use expert_pool::ExpertPool;
 pub use recorder::{RecordedCmd, Recorder};
 
+/// Shared-memory bytes consumed per query row of a flash-attention prefill tile
+/// (`Ss` + `Ps` + `Os` + softmax state, at `BN=64` / `HD=128`). The tile height is chosen so
+/// `rows * FLASH_SHARED_PER_ROW <= maxComputeSharedMemorySize`; `use_flash` needs the smallest
+/// tile (`BM=32`) to fit. Keep in sync with `attn_flash{,_warp,_partial}.comp`.
+pub const FLASH_SHARED_PER_ROW: u32 = 908;
+/// Same, for the register-O flash tile (`sfsh` + `Psh` + `pvsh` + state); smallest tile is `BR=64`.
+/// Keep in sync with `attn_flash_reg.comp`.
+pub const FLASH_REG_SHARED_PER_ROW: u32 = 460;
+
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::mem::ManuallyDrop;

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -1372,11 +1372,12 @@ impl<'a> Recorder<'a> {
         // Pick the largest tile the device's maxComputeSharedMemorySize allows: bm=64 → 58112 B (needs
         // 64 KB, e.g. RADV); bm=32 → 29056 B (fits NVIDIA 48 KB / MoltenVK 32 KB). The transformer
         // skips flash entirely when even bm=32 won't fit, so one of these always fits here.
-        let shared_limit = self.be.shared.caps.max_shared_memory_bytes;
+        let shared_limit = self.be.max_shared_memory_bytes();
+        let bm64_shared = 64 * crate::FLASH_SHARED_PER_ROW; // 58112 B
         // INFR_FLASH_BM=32 forces the small (29056 B) tile even on a 64 KB device, so the bm=32
         // shaders get numeric-parity coverage on any GPU (they otherwise only run on sub-64 KB ones).
         let force_bm32 = std::env::var("INFR_FLASH_BM").ok().as_deref() == Some("32");
-        let bm: u32 = if !force_bm32 && shared_limit >= 64 * 908 {
+        let bm: u32 = if !force_bm32 && shared_limit >= bm64_shared {
             64
         } else {
             32
@@ -1497,10 +1498,12 @@ impl<'a> Recorder<'a> {
         hd: usize,
         pos_offset: usize,
     ) {
-        let mpad = (n.div_ceil(128) * 128) as u32; // mpad is 128-aligned → divisible by both BR tiles
-                                                   // Register-O shared = BR*460 B: BR=128 → 58880 B (needs 64 KB); BR=64 → 29440 B (NVIDIA
-                                                   // 48 KB / MoltenVK 32 KB). Pick the largest that fits; the transformer skips reg if neither.
-        let br: u32 = if self.be.shared.caps.max_shared_memory_bytes >= 128 * 460 {
+        // mpad is 128-aligned → divisible by both BR tiles.
+        let mpad = (n.div_ceil(128) * 128) as u32;
+        // Register-O shared = BR*FLASH_REG_SHARED_PER_ROW: BR=128 → 58880 B (needs 64 KB); BR=64 →
+        // 29440 B (NVIDIA 48 KB / MoltenVK 32 KB). Largest that fits; transformer skips reg if neither.
+        let br: u32 = if self.be.max_shared_memory_bytes() >= 128 * crate::FLASH_REG_SHARED_PER_ROW
+        {
             128
         } else {
             64

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -1374,8 +1374,8 @@ impl<'a> Recorder<'a> {
         // skips flash entirely when even bm=32 won't fit, so one of these always fits here.
         let shared_limit = self.be.max_shared_memory_bytes();
         let bm64_shared = 64 * crate::FLASH_SHARED_PER_ROW; // 58112 B
-        // INFR_FLASH_BM=32 forces the small (29056 B) tile even on a 64 KB device, so the bm=32
-        // shaders get numeric-parity coverage on any GPU (they otherwise only run on sub-64 KB ones).
+                                                            // INFR_FLASH_BM=32 forces the small (29056 B) tile even on a 64 KB device, so the bm=32
+                                                            // shaders get numeric-parity coverage on any GPU (they otherwise only run on sub-64 KB ones).
         let force_bm32 = std::env::var("INFR_FLASH_BM").ok().as_deref() == Some("32");
         let bm: u32 = if !force_bm32 && shared_limit >= bm64_shared {
             64

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -1497,8 +1497,15 @@ impl<'a> Recorder<'a> {
         hd: usize,
         pos_offset: usize,
     ) {
-        let mpad = (n.div_ceil(128) * 128) as u32; // Br=128
-        let base_wg = (mpad / 128) * nh as u32;
+        let mpad = (n.div_ceil(128) * 128) as u32; // mpad is 128-aligned → divisible by both BR tiles
+                                                   // Register-O shared = BR*460 B: BR=128 → 58880 B (needs 64 KB); BR=64 → 29440 B (NVIDIA
+                                                   // 48 KB / MoltenVK 32 KB). Pick the largest that fits; the transformer skips reg if neither.
+        let br: u32 = if self.be.shared.caps.max_shared_memory_bytes >= 128 * 460 {
+            128
+        } else {
+            64
+        };
+        let base_wg = (mpad / br) * nh as u32;
         let n_splits = match std::env::var("INFR_FLASH_SPLITS")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -1516,13 +1523,15 @@ impl<'a> Recorder<'a> {
         };
         let ksplit = (kv_len as u32).div_ceil(n_splits).div_ceil(64) * 64;
         self.stamp("attn_flash");
-        let kp = self.be.kernel_sg(
-            "attn_flash_reg",
-            crate::gemm::attn_flash_reg_spv(),
-            6,
-            32,
-            32,
-        );
+        let (rname, rspv): (&'static str, &[u32]) = if br == 64 {
+            (
+                "attn_flash_reg_br64",
+                crate::gemm::attn_flash_reg_br64_spv(),
+            )
+        } else {
+            ("attn_flash_reg", crate::gemm::attn_flash_reg_spv())
+        };
+        let kp = self.be.kernel_sg(rname, rspv, 6, 32, 32);
         let mut pp = [0u8; 32];
         pp[0..4].copy_from_slice(&mpad.to_ne_bytes());
         pp[4..8].copy_from_slice(&(kv_len as u32).to_ne_bytes());


### PR DESCRIPTION
Follow-up to #2. A shared-memory audit of every compute shader found one more over the budget — `attn_flash_reg`, the opt-in `INFR_FLASH_REG` register-O prefill:

| shader | shared | NVIDIA 48 KB | MoltenVK 32 KB |
| --- | --- | --- | --- |
| **`attn_flash_reg`** (BR=128) | **58,880 B** | ❌ | ❌ |
| `attn_qk_warp` (next largest) | 25,600 B | ✅ | ✅ |
| everything else | ≤ 25,600 B | ✅ | ✅ |

`sfsh`(32 KB) + `Psh`(16 KB) + `pvsh`(8 KB) + state = 58,880 B. It's reachable only via the `INFR_FLASH_REG` env flag (off every default path), so it doesn't hit normal use — but setting that flag on NVIDIA/Apple device-losts exactly like the default flash path did before #2.

## Fix

Same approach as #2: parametrize the tile height `BR` with a `BR_TILE` build define → `attn_flash_reg_br64` SPIR-V (**29,440 B**, fits both NVIDIA and MoltenVK). `BR` only scales `WARPS_M`, workgroup size, and shared arrays — the per-warp 32×32 coopmat work (`sacc[2][2]`) and `BC` are fixed, so results are identical across tiles. The recorder picks BR=128 (≥58,880) else BR=64 from `maxComputeSharedMemorySize`; the transformer skips reg below 29,440 B. `mpad` stays 128-aligned, so scratch buffers are valid for either tile.

## Validation (RTX 2080 Ti, 48 KB)

- `attention_prefill_flash_reg_matches_cpu` passes vs the CPU reference (now BR=64; previously device-lost).
- `INFR_FLASH_REG=1 infr bench` runs end-to-end (pp2048 ≈ 3428 t/s) — was device-lost.
- `cargo fmt` / `clippy` clean. BR=128 path (AMD ≥64 KB) unchanged.

This closes the last shader over the shared-memory budget found in the audit.