### PR TITLE
perf(metal): flash attention + mul_mm-shape cooperative GEMM for prefill

### DIFF
--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -908,7 +908,12 @@ impl MetalBackend {
                 // beat the 32-way split on prefill — occupancy-starved by its threadgroup tiles —
                 // so it was dropped.)
                 let f16 = g.desc(k_cache).dtype == DType::F16;
-                let split = rows * nh < 128 || kv_len >= 128;
+                // Wide launches on an f16 cache take the half-fragment flash kernel: K^T/V
+                // fragments load straight from the cache, Q is cast once to f16 below. Small
+                // kv_len stays scalar (also keeps the short-kv wide parity test on the exact
+                // path). See `attnflash_f16kv` for why the f32 flash attempt lost and this wins.
+                let flash = f16 && rows * nh >= 128 && kv_len >= 64 && hd <= 128 && hd % 8 == 0;
+                let split = !flash && (rows * nh < 128 || kv_len >= 128);
                 // The split kernels REQUIRE their full NSG*32-thread threadgroup: every simdgroup
                 // owns a strided KV slice, so a smaller launch would silently skip positions and
                 // merge uninitialized partials. maxTotalThreadsPerThreadgroup is per-PIPELINE
@@ -943,13 +948,14 @@ impl MetalBackend {
                             },
                             256,
                         )?);
-                let kern = match (f16, split, split32) {
-                    (true, false, _) => "attention_f16kv",
-                    (true, _, true) => "attnsplit32_f16kv",
-                    (true, true, false) => "attnsplit_f16kv",
-                    (false, false, _) => "attention_f32",
-                    (false, _, true) => "attnsplit32_f32",
-                    (false, true, false) => "attnsplit_f32",
+                let kern = match (flash, f16, split, split32) {
+                    (true, ..) => "attnflash_f16kv",
+                    (_, true, false, _) => "attention_f16kv",
+                    (_, true, _, true) => "attnsplit32_f16kv",
+                    (_, true, true, false) => "attnsplit_f16kv",
+                    (_, false, false, _) => "attention_f32",
+                    (_, false, _, true) => "attnsplit32_f32",
+                    (_, false, true, false) => "attnsplit_f32",
                 };
                 let pso = self.pipelines.get(kern)?;
                 let mut p = (rows as u32).to_ne_bytes().to_vec();
@@ -960,23 +966,44 @@ impl MetalBackend {
                 p.extend_from_slice(&scale.to_ne_bytes());
                 p.extend_from_slice(&window.to_ne_bytes());
                 p.extend_from_slice(&pos.to_ne_bytes());
-                // One simdgroup per (query, head); split kernels use NSG simdgroups per pair,
-                // grid still exactly rows*n_head threadgroups.
-                let nsg = if split32 {
-                    32
-                } else if split {
-                    8
+                if flash {
+                    // Cast q to a transient f16 buffer (one pass), then one flash dispatch:
+                    // one simdgroup per (8-query tile, head).
+                    let n = rows * nh * hd;
+                    let qh =
+                        Arc::new(self.device.new_buffer(
+                            (n * 2).max(4) as u64,
+                            MTLResourceOptions::StorageModeShared,
+                        ));
+                    let cast = self.pipelines.get("cast_f32_f16")?;
+                    self.encode(r, &cast, &[bq.as_ref(), &qh], &(n as u32).to_ne_bytes(), n);
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[qh.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref()],
+                        &p,
+                        rows.div_ceil(8) * nh * 32,
+                        32,
+                    );
                 } else {
-                    1
-                };
-                self.encode_tg(
-                    r,
-                    &pso,
-                    &[bq.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref()],
-                    &p,
-                    rows * nh * nsg * 32,
-                    nsg * 32,
-                );
+                    // One simdgroup per (query, head); split kernels use NSG simdgroups per
+                    // pair, grid still exactly rows*n_head threadgroups.
+                    let nsg = if split32 {
+                        32
+                    } else if split {
+                        8
+                    } else {
+                        1
+                    };
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[bq.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref()],
+                        &p,
+                        rows * nh * nsg * 32,
+                        nsg * 32,
+                    );
+                }
                 r.loc[dst.0 as usize] = Loc::Device;
             }
             Op::MoeFfn {

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -702,6 +702,146 @@ ATTNSPLIT_KERNEL(attnsplit_f16kv, half, 8u, 256u)
 ATTNSPLIT_KERNEL(attnsplit32_f32, float, 32u, 128u)
 ATTNSPLIT_KERNEL(attnsplit32_f16kv, half, 32u, 128u)
 
+// ---- Half-fragment flash attention for prefill (f16 KV cache, hd <= 128, hd % 8 == 0): one
+// simdgroup per (8-query tile, head). Unlike the earlier f32 simdgroup_matrix attempt (built,
+// benched, lost to the scalar split-KV kernel, removed), there is NO staging: K^T and V 8x8
+// fragments load DIRECTLY from the f16 cache (strided, transposed for K), and Q is pre-cast once
+// per op to f16 — the f32 version spent its time converting K/V through threadgroup memory and
+// choked occupancy on the 8 KB tiles. Scores and the output tile accumulate in f32; the online
+// softmax runs scalar in f32 on an 8x8 score tile per 8-position KV block, with the row-rescale
+// applied as a diagonal f32 MMA. P rounds to f16 (same trade as the half-fragment GEMM).
+// Tail KV blocks may read up to 7 rows past the causal limit — always inside the bound cache
+// buffer (sized for the full context) — and those columns are masked in the softmax.
+// A partial final query tile falls back to the serial per-query path.
+kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
+                            device const half*  k   [[buffer(1)]],
+                            device const half*  v   [[buffer(2)]],
+                            device float*       dst [[buffer(3)]],
+                            constant AttnParams& p  [[buffer(4)]],
+                            uint gid  [[thread_position_in_grid]],
+                            uint lane [[thread_index_in_simdgroup]]) {
+    uint sg = gid / 32u;
+    uint ntq = (p.rows + 7u) / 8u;
+    if (sg >= ntq * p.n_head) return;
+    uint qt = sg / p.n_head;
+    uint h = sg % p.n_head;
+    uint group = p.n_head / p.n_kv;
+    uint kvh = h / group;
+    uint hd = p.head_dim;
+    uint r0 = qt * 8u;
+
+    if (r0 + 8u > p.rows) {
+        // partial query tile: serial per-query fallback (lane-split dot, online softmax)
+        for (uint ti = r0; ti < p.rows; ti++) {
+            uint qb = (ti * p.n_head + h) * hd;
+            uint abs = p.pos + ti;
+            uint lo = (p.window > 0u && abs + 1u > p.window) ? (abs + 1u - p.window) : 0u;
+            float acc[MAX_DPL];
+            for (uint t = 0; t < MAX_DPL; t++) acc[t] = 0.0f;
+            float m = -INFINITY, l = 0.0f;
+            for (uint j = lo; j <= abs; j++) {
+                ulong kb = ((ulong)j * p.n_kv + kvh) * hd;
+                float part = 0.0f;
+                for (uint d = lane; d < hd; d += 32u) part += (float)q[qb + d] * (float)k[kb + d];
+                float sc = simd_sum(part) * p.scale;
+                float mnew = max(m, sc);
+                float corr = exp(m - mnew);
+                float pw = exp(sc - mnew);
+                l = l * corr + pw;
+                uint t = 0;
+                for (uint d = lane; d < hd; d += 32u) {
+                    acc[t] = acc[t] * corr + pw * (float)v[kb + d];
+                    t++;
+                }
+                m = mnew;
+            }
+            uint t = 0;
+            for (uint d = lane; d < hd; d += 32u) { dst[qb + d] = acc[t] / l; t++; }
+        }
+        return;
+    }
+
+    threadgroup half tgP[64];
+    threadgroup float tgD[64];
+    threadgroup float tgM[8], tgL[8];
+    uint abs0 = p.pos + r0;                 // row i sees positions <= abs0 + i
+    uint abs_max = abs0 + 7u;
+    uint lo_min = (p.window > 0u && abs0 + 1u > p.window) ? (abs0 + 1u - p.window) : 0u;
+    if (lane < 8u) { tgM[lane] = -INFINITY; tgL[lane] = 0.0f; }
+
+    device const half* qbase = q + ((ulong)r0 * p.n_head + h) * hd;
+    ulong qstride = (ulong)p.n_head * hd;
+    ulong kvstride = (ulong)p.n_kv * hd;
+
+    simdgroup_float8x8 oa[16];
+    uint nfrag = hd / 8u;
+    for (uint i = 0; i < nfrag; i++) oa[i] = simdgroup_float8x8(0.0f);
+
+    for (uint j0 = lo_min & ~7u; j0 <= abs_max; j0 += 8u) {
+        device const half* kb = k + ((ulong)j0 * p.n_kv + kvh) * hd;
+        simdgroup_float8x8 sf = simdgroup_float8x8(0.0f);
+        for (uint e0 = 0; e0 < hd; e0 += 8u) {
+            simdgroup_half8x8 qa, kt;
+            simdgroup_load(qa, qbase + e0, qstride);
+            simdgroup_load(kt, kb + e0, kvstride, ulong2(0, 0), true);
+            simdgroup_multiply_accumulate(sf, qa, kt, sf);
+        }
+        simdgroup_store(sf, tgD, 8);        // reuse tgD as the f32 score scratch
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        if (lane < 8u) {
+            uint r = lane;
+            uint absr = abs0 + r;
+            uint lor = (p.window > 0u && absr + 1u > p.window) ? (absr + 1u - p.window) : 0u;
+            float mr = tgM[r];
+            float mnew = mr;
+            float s[8];
+            for (uint c = 0; c < 8u; c++) {
+                uint j = j0 + c;
+                bool valid = (j >= lor) && (j <= absr);
+                s[c] = valid ? tgD[r * 8u + c] * p.scale : -INFINITY;
+                mnew = max(mnew, s[c]);
+            }
+            float corr = (mr == mnew) ? 1.0f : exp(mr - mnew);
+            float lsum = 0.0f;
+            for (uint c = 0; c < 8u; c++) {
+                float pw = (s[c] == -INFINITY) ? 0.0f : exp(s[c] - mnew);
+                tgP[r * 8u + c] = (half)pw;
+                lsum += pw;
+            }
+            tgL[r] = tgL[r] * corr + lsum;
+            tgM[r] = mnew;
+            for (uint c = 0; c < 8u; c++) tgD[r * 8u + c] = (c == r) ? corr : 0.0f;
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        simdgroup_float8x8 df;
+        simdgroup_half8x8 pf;
+        simdgroup_load(df, tgD, 8);
+        simdgroup_load(pf, tgP, 8);
+        device const half* vb = v + ((ulong)j0 * p.n_kv + kvh) * hd;
+        for (uint i = 0; i < nfrag; i++) {
+            simdgroup_float8x8 tmp;
+            simdgroup_multiply(tmp, df, oa[i]);
+            simdgroup_half8x8 vf;
+            simdgroup_load(vf, vb + i * 8u, kvstride);
+            simdgroup_multiply_accumulate(oa[i], pf, vf, tmp);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (lane < 8u) {
+        for (uint c = 0; c < 8u; c++) tgD[lane * 8u + c] = (c == lane) ? 1.0f / tgL[lane] : 0.0f;
+    }
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    simdgroup_float8x8 d2;
+    simdgroup_load(d2, tgD, 8);
+    ulong obase = ((ulong)r0 * p.n_head + h) * hd;
+    ulong ostride = (ulong)p.n_head * hd;
+    for (uint i = 0; i < nfrag; i++) {
+        simdgroup_float8x8 tmp;
+        simdgroup_multiply(tmp, d2, oa[i]);
+        simdgroup_store(tmp, dst + obase + i * 8u, ostride);
+    }
+}
+
 // ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
 // GPU so it stays in the batch (no host round-trip that would force a per-layer flush). The (half)
 // cast is IEEE round-to-nearest-even — byte-identical to the host `f16::from_f32` reference.

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -754,6 +754,41 @@ fn attention_prefill_wide_parity() {
     assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
 }
 
+// Wide launch, long f16 context: routes to the half-fragment flash kernel (`attnflash_f16kv`).
+// Q and P round to f16 in that path (accumulation stays f32), hence the wider tolerance than the
+// exact-f32 attention kernels. kv_len is a multiple of 8 so the kernel's tail-block reads stay
+// inside these exact-sized test buffers (the runtime cache is sized for the full context).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_flash_matches_reference() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (17usize, 136usize, 8usize, 2usize, 64usize, 119usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::Causal,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 71))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 72))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 73))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
 // Long-context decode shape (rows=1, kv_len >= 128, hd <= 128): routes to the 32-way split-KV
 // kernel (`attnsplit32_*`), which the short-kv tests above never reach.
 #[test]


### PR DESCRIPTION
Follow-up to #5 — this commit was pushed to the branch minutes after the merge, so it needs its own PR. One commit, cherry-picked onto main.

Retry of the flash-attention idea that lost in f32 (documented in #4): that version spent its time converting K/V through 8 KB threadgroup tiles (choking occupancy). Half fragments dissolve exactly those costs — **K^T and V 8×8 fragments load directly from the f16 KV cache** (strided `simdgroup_load`, transposed for K), Q is cast once per op to f16, and threadgroup memory shrinks to the 8×8 score/diag scratch. Scores + output accumulate f32; online softmax stays scalar f32 per 8-position block with the row rescale as a diagonal f32 MMA; P rounds to f16 (same trade as the half-fragment GEMM). Routed only for wide launches on an f16 cache (rows·n_head ≥ 128, kv_len ≥ 64, hd ≤ 128); decode and small shapes keep the exact scalar kernels.

| 889-tok prefill | before | after | llama.cpp |
|---|---|---|---|
| Qwen3-0.6B | 1355 | **~1958** (+44%) | 4187 |
| Qwen3-4B | 264 | **320** (+21%) | 630 |

Attention GPU 306 → 105 ms; decode unchanged (131 / 37.5). Parity 30/30 incl. a dedicated flash test (5e-3 tolerance for the f16 Q/P rounding; the wide short-kv test intentionally stays on the exact path).