### PR TITLE
feat(bench): metal in infr bench + long-context depth sweep findings

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -752,6 +752,21 @@ fn cmd_bench(
             json,
         );
     }
+    // INFR_METAL=1 (or --dev Metal): bench the dense forward on the Metal backend through the
+    // agnostic seam — same pp/tg/pg + depth methodology as the CPU arm, directly comparable to
+    // `llama-bench` on the Metal build.
+    if std::env::var("INFR_METAL").is_ok() || dev.eq_ignore_ascii_case("metal") {
+        return cmd_bench_metal(
+            &gguf,
+            tok.as_deref(),
+            n_prompt,
+            n_gen,
+            depth,
+            pg,
+            reps,
+            json,
+        );
+    }
     let _ = dev; // GPU device selection: VulkanBackend uses the default adapter (--dev reserved for parity).
     let llama = infr_llama::Llama::load_opt(&gguf, tok.as_deref())?;
     let measure_tg = pg.is_none() && n_gen > 0;
@@ -870,6 +885,57 @@ fn print_bench_avg(samples: &[f64], label: &str, depth: usize, tag: &str, reps: 
 /// CPU-backend bench (`infr bench -ngl 0`): the GPU bench's pp/tg/pg metrics on the agnostic CPU
 /// reference path, using `CpuModel`'s token-level timing — directly comparable to `llama-bench -ngl 0`.
 #[allow(clippy::too_many_arguments)]
+/// Metal twin of [`cmd_bench_cpu`]: same pp/tg/pg + depth methodology on the Apple-GPU seam
+/// backend (`CpuModel::bench_metal`). On non-macOS this arm is unreachable (the backend crate
+/// compiles to nothing), so the whole body is cfg-gated.
+#[allow(clippy::too_many_arguments)]
+fn cmd_bench_metal(
+    gguf: &Path,
+    tok: Option<&Path>,
+    n_prompt: usize,
+    n_gen: usize,
+    depth: usize,
+    pg: Option<(usize, usize)>,
+    reps: usize,
+    json: bool,
+) -> anyhow::Result<()> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (gguf, tok, n_prompt, n_gen, depth, pg, reps, json);
+        anyhow::bail!("metal bench requires macOS");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let model = infr_llama::CpuModel::load(gguf, tok)?;
+        let measure_tg = pg.is_none() && n_gen > 0;
+        // One untimed warmup: page-cache the mmap + build the weight caches + compile pipelines.
+        let _ = model.bench_metal(depth.max(1), if measure_tg || pg.is_some() { 1 } else { 0 });
+        let mut samples = Vec::with_capacity(reps);
+        for _ in 0..reps {
+            let ts = if let Some((p, g)) = pg {
+                let s = model.bench_metal(p, g)?;
+                (p + g) as f64 / (s.prompt_secs + s.decode_secs)
+            } else if measure_tg {
+                let s = model.bench_metal(depth.max(1), n_gen)?;
+                n_gen as f64 / s.decode_secs
+            } else {
+                let s = model.bench_metal(n_prompt, 0)?;
+                n_prompt as f64 / s.prompt_secs
+            };
+            samples.push(ts);
+        }
+        let label = if let Some((p, g)) = pg {
+            format!("pg{p}+{g}")
+        } else if measure_tg {
+            format!("tg{n_gen}")
+        } else {
+            format!("pp{n_prompt}")
+        };
+        print_bench_avg(&samples, &label, depth, " [metal]", reps, json);
+        Ok(())
+    }
+}
+
 fn cmd_bench_cpu(
     gguf: &Path,
     tok: Option<&Path>,

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -144,6 +144,27 @@ impl CpuModel {
         Ok(stats)
     }
 
+    /// Token-level bench on the **Metal** backend through the agnostic seam (the Apple-GPU twin of
+    /// [`bench`](Self::bench)): prefill `n_prompt` dummy tokens, decode `n_gen`, return the timing.
+    /// Lets `infr bench` (with `INFR_METAL=1`) measure pp/tg directly comparable to `llama-bench`
+    /// on the Metal build.
+    #[cfg(target_os = "macos")]
+    pub fn bench_metal(&self, n_prompt: usize, n_gen: usize) -> Result<crate::GenStats> {
+        let prompt: Vec<u32> = (0..n_prompt.max(1)).map(|i| (i % 100) as u32).collect();
+        let mtl = infr_metal::MetalBackend::new().map_err(|e| anyhow!("metal init: {e}"))?;
+        let (_, stats) = crate::cpu_backend::generate_dense_metal(
+            &mtl,
+            &self.gguf,
+            &self.cfg,
+            &self.token_embd,
+            self.per_layer_embd.as_ref(),
+            &prompt,
+            n_gen,
+            |_| {},
+        )?;
+        Ok(stats)
+    }
+
     /// Render a user turn with the model's OWN embedded chat template (so an instruct model — Gemma,
     /// Qwen, … — answers coherently). Errors if the GGUF has no `tokenizer.chat_template` or it fails
     /// to render — infr only supports models that ship one (no fabricated-ChatML fallback).

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -643,18 +643,12 @@ impl MetalBackend {
                             >= 128;
                     p.extend_from_slice(&qw.dshift.to_ne_bytes());
                     if cmm_ok {
-                        let xh = Arc::new(self.device.new_buffer(
-                            (m * in_f * 2).max(4) as u64,
-                            MTLResourceOptions::StorageModeShared,
-                        ));
-                        let cast = self.pipelines.get("cast_f32_f16")?;
-                        let n = (m * in_f) as u32;
-                        self.encode(r, &cast, &[bx.as_ref(), &xh], &n.to_ne_bytes(), m * in_f);
+                        // Reads f32 x directly (casts to f16 while staging) — no cast pass.
                         let pso = self.pipelines.get(cmm_kern)?;
                         self.encode_tg(
                             r,
                             &pso,
-                            &[xh.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[bx.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
                             &p,
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -656,7 +656,12 @@ impl MetalBackend {
                             };
                             (rt, m.div_ceil(8) * out_f)
                         } else {
-                            (qw.kern, out_f)
+                            // The native mul_mv-shape GEMVs cover TWO output rows per simdgroup.
+                            let sgs = match qw.kern {
+                                "linear_q4k" | "linear_q6k" => out_f.div_ceil(2),
+                                _ => out_f,
+                            };
+                            (qw.kern, sgs)
                         };
                         let pso = self.pipelines.get(kern)?;
                         self.encode_tg(

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -618,6 +618,22 @@ impl MetalBackend {
                         "linear_q6k" => "linear_q6k_hmm",
                         _ => "linear_quik8_hmm",
                     };
+                    let cmm_kern = match qw.kern {
+                        "linear_quik4" => "linear_quik4_cmm",
+                        "linear_quik6" => "linear_quik6_cmm",
+                        "linear_q4k" => "linear_q4k_cmm",
+                        "linear_q6k" => "linear_q6k_cmm",
+                        _ => "linear_quik8_cmm",
+                    };
+                    // Prefer the cooperative 32x64 threadgroup tile; per-simdgroup HGEMM covers
+                    // the out_f % 64 != 0 leftovers, and both need the full 128-thread group.
+                    let cmm_ok = m >= 16
+                        && out_f % 64 == 0
+                        && self
+                            .pipelines
+                            .get(cmm_kern)?
+                            .max_total_threads_per_threadgroup()
+                            >= 128;
                     let hmm_ok = m >= 16
                         && out_f % 16 == 0
                         && self
@@ -626,7 +642,24 @@ impl MetalBackend {
                             .max_total_threads_per_threadgroup()
                             >= 128;
                     p.extend_from_slice(&qw.dshift.to_ne_bytes());
-                    if hmm_ok {
+                    if cmm_ok {
+                        let xh = Arc::new(self.device.new_buffer(
+                            (m * in_f * 2).max(4) as u64,
+                            MTLResourceOptions::StorageModeShared,
+                        ));
+                        let cast = self.pipelines.get("cast_f32_f16")?;
+                        let n = (m * in_f) as u32;
+                        self.encode(r, &cast, &[bx.as_ref(), &xh], &n.to_ne_bytes(), m * in_f);
+                        let pso = self.pipelines.get(cmm_kern)?;
+                        self.encode_tg(
+                            r,
+                            &pso,
+                            &[xh.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &p,
+                            m.div_ceil(32) * (out_f / 64) * 128,
+                            128,
+                        );
+                    } else if hmm_ok {
                         // Prefill GEMM runs on half fragments (see `HGEMM_KERNEL`): cast x to a
                         // transient f16 buffer first, then one GEMM dispatch reads it.
                         let xh = Arc::new(self.device.new_buffer(

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -593,16 +593,18 @@ RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)
 RT_KERNEL(linear_q4k_rt, DEC16_Q4K)
 RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
-// Cooperative-tile half-fragment GEMM: one 32-row x 64-output tile per 128-thread THREADGROUP
-// (the HGEMM kernels above give each simdgroup a private tile with private staging). Per 16-wide
-// K step, threads 0..63 decode one output row's block each into the shared weight tile while
-// threads 64..127 stage the 32x16 x tile — the two run concurrently — then each simdgroup
-// consumes its 16-output slice against the SHARED x tile (x device traffic /4) with 8 independent
-// f32 accumulators. This is the mul_mm shape: more resident accumulators per threadgroup to hide
-// MMA latency, one x staging for four simdgroups. Requires out_f % 64 == 0 (every dense shape in
-// practice); others fall back to the per-simdgroup HGEMM.
+// Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
+// threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
+// measured and replaced): weights AND activations are staged into threadgroup memory as
+// CONTIGUOUS 8x8 half tiles (stride-8, conflict-free simdgroup_load; the weight tile is written
+// pre-transposed so no transposed loads), each thread dequantizes exactly one 16-element block
+// per K-step (128 threads = the whole 64x32 weight tile), and x is cast f32->f16 inline during
+// staging (no separate cast pass). Each simdgroup owns a 32-output x 16-token quadrant as 8 f32
+// accumulators; a partial token tile stages through threadgroup memory and row-guards the copy,
+// so every tile takes the MMA path. Requires out_f % 64 == 0 and in_f % 32 == 0; other shapes
+// fall back to the per-simdgroup HGEMM.
 #define CMM_KERNEL(NAME, DEC)                                                                     \
-kernel void NAME(device const half*   x     [[buffer(0)]],                                       \
+kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
                  device const uchar*  codes [[buffer(1)]],                                       \
                  device const uchar*  scm   [[buffer(2)]],                                       \
                  device const uchar*  dd    [[buffer(3)]],                                       \
@@ -612,69 +614,81 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
                  uint lane [[thread_index_in_simdgroup]],                                        \
                  uint sgid [[simdgroup_index_in_threadgroup]]) {                                 \
     uint tgix = gid / 128u;                                                                       \
-    uint ntm = (p.m + 31u) / 32u;                                                                 \
     uint nto = p.out_f / 64u;                                                                     \
+    uint ntm = (p.m + 31u) / 32u;                                                                 \
     if (tgix >= ntm * nto) return;                                                                \
-    uint tm = tgix / nto;                                                                         \
     uint to = tgix % nto;                                                                         \
-    uint r0 = tm * 32u;                                                                           \
-    uint o0 = to * 64u;                                                                           \
-    uint os = o0 + sgid * 16u;      /* this simdgroup's 16-output slice */                        \
-    uint nb = p.in_f >> 4;                                                                        \
+    uint tm = tgix / nto;                                                                         \
+    uint ro = to * 64u;                                                                           \
+    uint rt = tm * 32u;                                                                           \
     uint tid = sgid * 32u + lane;                                                                 \
-    threadgroup half tgX[32 * 16];                                                                \
-    threadgroup half tgW[64 * 16];                                                                \
-    if (r0 + 32u <= p.m) {                                                                        \
-        simdgroup_float8x8 acc[4][2];                                                             \
-        for (uint i = 0; i < 4u; i++)                                                             \
-            for (uint jx = 0; jx < 2u; jx++) acc[i][jx] = simdgroup_float8x8(0.0f);               \
-        for (uint kb = 0; kb < nb; kb++) {                                                        \
-            if (tid < 64u) {                                                                      \
-                ulong bi = (ulong)(o0 + tid) * nb + kb;                                           \
-                float wk[16];                                                                     \
-                DEC(wk)                                                                           \
-                for (uint k2 = 0; k2 < 16u; k2++) tgW[tid * 16u + k2] = (half)wk[k2];             \
-            } else {                                                                              \
-                uint t2 = tid - 64u;    /* 8 contiguous halfs each: 64 threads x 8 = 32x16 */     \
-                uint idx = t2 * 8u;                                                               \
-                uint rr = idx >> 4;                                                               \
-                uint e = idx & 15u;                                                               \
-                device const half* xs = x + (ulong)(r0 + rr) * p.in_f + ((ulong)kb << 4) + e;     \
-                for (uint i = 0; i < 8u; i++) tgX[idx + i] = xs[i];                               \
+    uint nr1 = min(32u, p.m - rt);                                                                \
+                                                                                                  \
+    threadgroup float shraw[2048];  /* 8 KB: sa(4K half) + sb(2K half); reused f32 for stores */  \
+    threadgroup half* sa = (threadgroup half*)shraw;                                              \
+    threadgroup half* sb = ((threadgroup half*)shraw) + 2048u;                                    \
+                                                                                                  \
+    uint lr0 = tid >> 1;                 /* weight (output) row 0..63 */                          \
+    uint il0 = tid & 1u;                 /* which 16-element half of the 32-K step */             \
+    uint lr1 = tid >> 2;                 /* token row 0..31 */                                    \
+    uint iyk = (tid & 3u) * 8u;          /* k offset within the 32-K step */                      \
+    uint lr1c = min(lr1, nr1 - 1u);      /* clamp token loads to the matrix edge */               \
+                                                                                                  \
+    simdgroup_half8x8 ma[4];                                                                      \
+    simdgroup_half8x8 mb[2];                                                                      \
+    simdgroup_float8x8 mc[8];                                                                     \
+    for (uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                               \
+                                                                                                  \
+    uint nb = p.in_f >> 4;                                                                        \
+    for (uint k0 = 0; k0 < p.in_f; k0 += 32u) {                                                   \
+        {   /* stage A: one 16-block per thread, into pre-transposed 8x8 tiles */                 \
+            ulong bi = (ulong)(ro + lr0) * nb + (ulong)(k0 >> 4) + il0;                           \
+            float wk[16];                                                                         \
+            DEC(wk)                                                                               \
+            uint sy = lr0 >> 3;                                                                   \
+            uint lx = lr0 & 7u;                                                                   \
+            for (uint i = 0; i < 16u; i++) {                                                      \
+                uint sx = 2u * il0 + (i >> 3);                                                    \
+                sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
             }                                                                                     \
-            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
-            for (uint kh = 0; kh < 2u; kh++) {                                                    \
-                simdgroup_half8x8 wb0, wb1;                                                       \
-                simdgroup_load(wb0, &tgW[(sgid * 16u) * 16u + kh * 8u], 16, ulong2(0, 0), true);  \
-                simdgroup_load(wb1, &tgW[(sgid * 16u + 8u) * 16u + kh * 8u], 16, ulong2(0, 0), true); \
-                for (uint rh = 0; rh < 4u; rh++) {                                                \
-                    simdgroup_half8x8 xa;                                                         \
-                    simdgroup_load(xa, &tgX[(rh * 8u) * 16u + kh * 8u], 16);                      \
-                    simdgroup_multiply_accumulate(acc[rh][0], xa, wb0, acc[rh][0]);               \
-                    simdgroup_multiply_accumulate(acc[rh][1], xa, wb1, acc[rh][1]);               \
-                }                                                                                 \
-            }                                                                                     \
-            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
         }                                                                                         \
-        for (uint rh = 0; rh < 4u; rh++)                                                          \
-            for (uint oh = 0; oh < 2u; oh++)                                                      \
-                simdgroup_store(acc[rh][oh],                                                      \
-                                dst + (ulong)(r0 + rh * 8u) * p.out_f + os + oh * 8u, p.out_f);   \
+        {   /* stage B: 8 activations per thread, f32 -> f16 inline */                            \
+            device const float* yy = x + (ulong)(rt + lr1c) * p.in_f + k0 + iyk;                  \
+            uint ib = 4u * (tid & 3u) + (lr1 >> 3);                                               \
+            uint ly = lr1 & 7u;                                                                   \
+            for (uint i = 0; i < 8u; i++) sb[64u * ib + 8u * ly + i] = (half)yy[i];               \
+        }                                                                                         \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
+        threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
+        for (uint ik = 0; ik < 4u; ik++) {                                                        \
+            for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
+            for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
+            for (uint i = 0; i < 8u; i++)                                                         \
+                simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
+            lsma += 8u * 64u;                                                                     \
+            lsmb += 4u * 64u;                                                                     \
+        }                                                                                         \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+    }                                                                                             \
+                                                                                                  \
+    if (rt + 32u <= p.m) {                                                                        \
+        device float* C = dst + (ro + 32u * (sgid & 1u)) +                                        \
+                          (ulong)(rt + 16u * (sgid >> 1)) * p.out_f;                              \
+        for (uint i = 0; i < 8u; i++)                                                             \
+            simdgroup_store(mc[i], C + 8u * (i & 3u) + 8u * p.out_f * (i >> 2), p.out_f);         \
     } else {                                                                                      \
-        /* partial row tile: scalar dot per (row, output) element on this simdgroup's slice */    \
-        for (uint e = lane; e < 512u; e += 32u) {                                                 \
-            uint rr = r0 + e / 16u;                                                               \
-            uint o = os + (e % 16u);                                                              \
-            if (rr >= p.m) continue;                                                              \
-            float a2 = 0.0f;                                                                      \
-            for (uint kb = 0; kb < nb; kb++) {                                                    \
-                ulong bi = (ulong)o * nb + kb;                                                    \
-                float wk[16];                                                                     \
-                DEC(wk)                                                                           \
-                device const half* xb = x + (ulong)rr * p.in_f + ((ulong)kb << 4);                \
-                for (uint k2 = 0; k2 < 16u; k2++) a2 += (float)xb[k2] * (float)((half)wk[k2]);    \
+        /* partial token tile: stage through threadgroup memory, row-guard the copy-out */        \
+        threadgroup float* tc = shraw + 32u * (sgid & 1u) + (16u * (sgid >> 1)) * 64u;            \
+        for (uint i = 0; i < 8u; i++)                                                             \
+            simdgroup_store(mc[i], tc + 8u * (i & 3u) + 8u * 64u * (i >> 2), 64u);                \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        if (sgid == 0u) {                                                                         \
+            for (uint j = lane; j < nr1; j += 32u) {                                              \
+                device float* d2 = dst + ro + (ulong)(rt + j) * p.out_f;                          \
+                threadgroup const float* c2 = shraw + j * 64u;                                    \
+                for (uint i = 0; i < 64u; i++) d2[i] = c2[i];                                     \
             }                                                                                     \
-            dst[(ulong)rr * p.out_f + o] = a2;                                                    \
         }                                                                                         \
     }                                                                                             \
 }

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -434,11 +434,160 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
     }                                                                                             \
 }
 
+// Decode GEMV for the native K-quant formats, mul_mv shape (ported from llama.cpp's
+// kernel_mul_mv_q4_K_f32 / q6_K and adapted to our buffers): each simdgroup computes TWO output
+// rows; activations load once into registers and are reused across both rows, and the inner loop
+// is decode-free — masked integer nibble ops with the block scales applied once per group (Q4_K
+// splits the affine min out via pre-summed activations; the 1/256 and 1/16 factors are exact
+// power-of-two corrections for the high-nibble/high-byte lanes). Algebraically identical to the
+// reference dequant dot, floating-point reassociated. This access pattern (4 blocks in flight per
+// simdgroup for Q4_K, contiguous 8-element runs per lane) is what the sub-block-scatter DEC16
+// GEMV left on the table.
+kernel void linear_q4k(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    uint first_row = (gid / 32u) * 2u;
+    if (first_row >= p.out_f) return;
+    uint nb = p.in_f >> 8;                 // 256-element blocks per row
+    ulong row_b = (ulong)nb * 144ul;       // row stride in bytes
+    device const uchar* xr = codes + first_row * row_b;
+
+    const ushort kmask1 = 0x3f3f, kmask2 = 0x0f0f, kmask3 = 0xc0c0;
+    uint ix = lane >> 3;                   // 0..3: which of 4 blocks in flight
+    uint it = lane & 7u;
+    uint iq = it >> 2;                     // 0/1: which 128-half
+    uint ir = it & 3u;                     // 0..3: which 8-element run
+
+    float yl[16], yh[16];
+    float sumf[2] = {0.0f, 0.0f};
+    device const float* y4 = x + ix * 256u + 64u * iq + 8u * ir;
+
+    ushort sc16[4];
+    thread const uchar* sc8 = (thread const uchar*)sc16;
+
+    for (uint ib = ix; ib < nb; ib += 4u) {
+        float4 sumy = float4(0.0f);
+        for (uint i = 0; i < 8u; i++) {
+            yl[i]      = y4[i];        sumy[0] += yl[i];
+            yl[i + 8u] = y4[i + 32u];  sumy[1] += yl[i + 8u];
+            yh[i]      = y4[i + 128u]; sumy[2] += yh[i];
+            yh[i + 8u] = y4[i + 160u]; sumy[3] += yh[i + 8u];
+        }
+        device const uchar* blk = xr + (ulong)ib * 144ul;
+        device const ushort* sc = (device const ushort*)(blk + 4u) + iq;
+        device const ushort* q1 = (device const ushort*)(blk + 16u) + 16u * iq + 4u * ir;
+        device const half* dh = (device const half*)blk;
+
+        for (uint row = 0; row < 2u; row++) {
+            sc16[0] = sc[0] & kmask1;
+            sc16[1] = sc[2] & kmask1;
+            sc16[2] = ((sc[4] >> 0) & kmask2) | ((sc[0] & kmask3) >> 2);
+            sc16[3] = ((sc[4] >> 4) & kmask2) | ((sc[2] & kmask3) >> 2);
+            device const ushort* q2 = q1 + 32u;
+            float4 acc1 = float4(0.0f);
+            float4 acc2 = float4(0.0f);
+            for (uint i = 0; i < 4u; i++) {
+                acc1[0] += yl[2u * i]      * (float)(q1[i] & 0x000F);
+                acc1[1] += yl[2u * i + 1u] * (float)(q1[i] & 0x0F00);
+                acc1[2] += yl[2u * i + 8u] * (float)(q1[i] & 0x00F0);
+                acc1[3] += yl[2u * i + 9u] * (float)(q1[i] & 0xF000);
+                acc2[0] += yh[2u * i]      * (float)(q2[i] & 0x000F);
+                acc2[1] += yh[2u * i + 1u] * (float)(q2[i] & 0x0F00);
+                acc2[2] += yh[2u * i + 8u] * (float)(q2[i] & 0x00F0);
+                acc2[3] += yh[2u * i + 9u] * (float)(q2[i] & 0xF000);
+            }
+            sumf[row] += (float)dh[0] * ((acc1[0] + 1.0f/256.0f * acc1[1]) * sc8[0] +
+                                         (acc1[2] + 1.0f/256.0f * acc1[3]) * sc8[1] * 1.0f/16.0f +
+                                         (acc2[0] + 1.0f/256.0f * acc2[1]) * sc8[4] +
+                                         (acc2[2] + 1.0f/256.0f * acc2[3]) * sc8[5] * 1.0f/16.0f) -
+                         (float)dh[1] * (sumy[0] * sc8[2] + sumy[1] * sc8[3] +
+                                         sumy[2] * sc8[6] + sumy[3] * sc8[7]);
+            q1 += row_b / 2u;
+            sc += row_b / 2u;
+            dh += row_b / 2u;
+        }
+        y4 += 4u * 256u;
+    }
+    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
+        float s = simd_sum(sumf[row]);
+        if (lane == 0u) dst[first_row + row] = s;
+    }
+}
+
+kernel void linear_q6k(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    uint first_row = (gid / 32u) * 2u;
+    if (first_row >= p.out_f) return;
+    uint nb = p.in_f >> 8;
+    ulong row_b = (ulong)nb * 210ul;
+    device const uchar* xr = codes + first_row * row_b;
+
+    const uchar kmask1 = 0x03, kmask2 = 0x0C, kmask3 = 0x30, kmask4 = 0xC0;
+    uint tid2 = lane >> 1;
+    uint ix = lane & 1u;                   // 0/1: which of 2 blocks in flight
+    uint ip = tid2 >> 3;                   // 0/1: which 128-half
+    uint il = tid2 & 7u;
+    uint l0 = 4u * il;
+    uint is = 8u * ip + (l0 >> 4);
+    uint y_off = 128u * ip + l0;
+    uint ql_off = 64u * ip + l0;
+    uint qh_off = 32u * ip + l0;
+
+    float sumf[2] = {0.0f, 0.0f};
+    float yl[16];
+
+    for (uint i = ix; i < nb; i += 2u) {
+        device const uchar* blk = xr + (ulong)i * 210ul;
+        device const uchar* q1 = blk + ql_off;
+        device const uchar* q2 = q1 + 32u;
+        device const uchar* qh = blk + 128u + qh_off;
+        device const char* sc = (device const char*)(blk + 192u) + is;
+        device const half* dh = (device const half*)(blk + 208u);
+        device const float* y = x + i * 256u + y_off;
+
+        for (uint l = 0; l < 4u; l++) {
+            yl[4u * l]      = y[l];
+            yl[4u * l + 1u] = y[l + 32u];
+            yl[4u * l + 2u] = y[l + 64u];
+            yl[4u * l + 3u] = y[l + 96u];
+        }
+        for (uint row = 0; row < 2u; row++) {
+            float4 sums = float4(0.0f);
+            for (uint l = 0; l < 4u; l++) {
+                sums[0] += yl[4u * l]      * (float)((char)((q1[l] & 0xF) | ((qh[l] & kmask1) << 4)) - 32);
+                sums[1] += yl[4u * l + 1u] * (float)((char)((q2[l] & 0xF) | ((qh[l] & kmask2) << 2)) - 32);
+                sums[2] += yl[4u * l + 2u] * (float)((char)((q1[l] >> 4)  | ((qh[l] & kmask3) << 0)) - 32);
+                sums[3] += yl[4u * l + 3u] * (float)((char)((q2[l] >> 4)  | ((qh[l] & kmask4) >> 2)) - 32);
+            }
+            sumf[row] += (float)dh[0] * (sums[0] * sc[0] + sums[1] * sc[2] +
+                                         sums[2] * sc[4] + sums[3] * sc[6]);
+            q1 += row_b;
+            q2 += row_b;
+            qh += row_b;
+            sc += row_b;
+            dh += row_b / 2u;
+        }
+    }
+    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
+        float s = simd_sum(sumf[row]);
+        if (lane == 0u) dst[first_row + row] = s;
+    }
+}
+
 GEMV_KERNEL(linear_quik4, DEC16_K4)
 GEMV_KERNEL(linear_quik6, DEC16_K6)
 GEMV_KERNEL(linear_quik8, DEC16_K8)
-GEMV_KERNEL(linear_q4k, DEC16_Q4K)
-GEMV_KERNEL(linear_q6k, DEC16_Q6K)
 RT_KERNEL(linear_quik4_rt, DEC16_K4)
 RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -593,6 +593,98 @@ RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)
 RT_KERNEL(linear_q4k_rt, DEC16_Q4K)
 RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
+// Cooperative-tile half-fragment GEMM: one 32-row x 64-output tile per 128-thread THREADGROUP
+// (the HGEMM kernels above give each simdgroup a private tile with private staging). Per 16-wide
+// K step, threads 0..63 decode one output row's block each into the shared weight tile while
+// threads 64..127 stage the 32x16 x tile — the two run concurrently — then each simdgroup
+// consumes its 16-output slice against the SHARED x tile (x device traffic /4) with 8 independent
+// f32 accumulators. This is the mul_mm shape: more resident accumulators per threadgroup to hide
+// MMA latency, one x staging for four simdgroups. Requires out_f % 64 == 0 (every dense shape in
+// practice); others fall back to the per-simdgroup HGEMM.
+#define CMM_KERNEL(NAME, DEC)                                                                     \
+kernel void NAME(device const half*   x     [[buffer(0)]],                                       \
+                 device const uchar*  codes [[buffer(1)]],                                       \
+                 device const uchar*  scm   [[buffer(2)]],                                       \
+                 device const uchar*  dd    [[buffer(3)]],                                       \
+                 device float*        dst   [[buffer(4)]],                                       \
+                 constant QLinParams& p     [[buffer(5)]],                                       \
+                 uint gid  [[thread_position_in_grid]],                                          \
+                 uint lane [[thread_index_in_simdgroup]],                                        \
+                 uint sgid [[simdgroup_index_in_threadgroup]]) {                                 \
+    uint tgix = gid / 128u;                                                                       \
+    uint ntm = (p.m + 31u) / 32u;                                                                 \
+    uint nto = p.out_f / 64u;                                                                     \
+    if (tgix >= ntm * nto) return;                                                                \
+    uint tm = tgix / nto;                                                                         \
+    uint to = tgix % nto;                                                                         \
+    uint r0 = tm * 32u;                                                                           \
+    uint o0 = to * 64u;                                                                           \
+    uint os = o0 + sgid * 16u;      /* this simdgroup's 16-output slice */                        \
+    uint nb = p.in_f >> 4;                                                                        \
+    uint tid = sgid * 32u + lane;                                                                 \
+    threadgroup half tgX[32 * 16];                                                                \
+    threadgroup half tgW[64 * 16];                                                                \
+    if (r0 + 32u <= p.m) {                                                                        \
+        simdgroup_float8x8 acc[4][2];                                                             \
+        for (uint i = 0; i < 4u; i++)                                                             \
+            for (uint jx = 0; jx < 2u; jx++) acc[i][jx] = simdgroup_float8x8(0.0f);               \
+        for (uint kb = 0; kb < nb; kb++) {                                                        \
+            if (tid < 64u) {                                                                      \
+                ulong bi = (ulong)(o0 + tid) * nb + kb;                                           \
+                float wk[16];                                                                     \
+                DEC(wk)                                                                           \
+                for (uint k2 = 0; k2 < 16u; k2++) tgW[tid * 16u + k2] = (half)wk[k2];             \
+            } else {                                                                              \
+                uint t2 = tid - 64u;    /* 8 contiguous halfs each: 64 threads x 8 = 32x16 */     \
+                uint idx = t2 * 8u;                                                               \
+                uint rr = idx >> 4;                                                               \
+                uint e = idx & 15u;                                                               \
+                device const half* xs = x + (ulong)(r0 + rr) * p.in_f + ((ulong)kb << 4) + e;     \
+                for (uint i = 0; i < 8u; i++) tgX[idx + i] = xs[i];                               \
+            }                                                                                     \
+            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
+            for (uint kh = 0; kh < 2u; kh++) {                                                    \
+                simdgroup_half8x8 wb0, wb1;                                                       \
+                simdgroup_load(wb0, &tgW[(sgid * 16u) * 16u + kh * 8u], 16, ulong2(0, 0), true);  \
+                simdgroup_load(wb1, &tgW[(sgid * 16u + 8u) * 16u + kh * 8u], 16, ulong2(0, 0), true); \
+                for (uint rh = 0; rh < 4u; rh++) {                                                \
+                    simdgroup_half8x8 xa;                                                         \
+                    simdgroup_load(xa, &tgX[(rh * 8u) * 16u + kh * 8u], 16);                      \
+                    simdgroup_multiply_accumulate(acc[rh][0], xa, wb0, acc[rh][0]);               \
+                    simdgroup_multiply_accumulate(acc[rh][1], xa, wb1, acc[rh][1]);               \
+                }                                                                                 \
+            }                                                                                     \
+            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
+        }                                                                                         \
+        for (uint rh = 0; rh < 4u; rh++)                                                          \
+            for (uint oh = 0; oh < 2u; oh++)                                                      \
+                simdgroup_store(acc[rh][oh],                                                      \
+                                dst + (ulong)(r0 + rh * 8u) * p.out_f + os + oh * 8u, p.out_f);   \
+    } else {                                                                                      \
+        /* partial row tile: scalar dot per (row, output) element on this simdgroup's slice */    \
+        for (uint e = lane; e < 512u; e += 32u) {                                                 \
+            uint rr = r0 + e / 16u;                                                               \
+            uint o = os + (e % 16u);                                                              \
+            if (rr >= p.m) continue;                                                              \
+            float a2 = 0.0f;                                                                      \
+            for (uint kb = 0; kb < nb; kb++) {                                                    \
+                ulong bi = (ulong)o * nb + kb;                                                    \
+                float wk[16];                                                                     \
+                DEC(wk)                                                                           \
+                device const half* xb = x + (ulong)rr * p.in_f + ((ulong)kb << 4);                \
+                for (uint k2 = 0; k2 < 16u; k2++) a2 += (float)xb[k2] * (float)((half)wk[k2]);    \
+            }                                                                                     \
+            dst[(ulong)rr * p.out_f + o] = a2;                                                    \
+        }                                                                                         \
+    }                                                                                             \
+}
+
+CMM_KERNEL(linear_quik4_cmm, DEC16_K4)
+CMM_KERNEL(linear_quik6_cmm, DEC16_K6)
+CMM_KERNEL(linear_quik8_cmm, DEC16_K8)
+CMM_KERNEL(linear_q4k_cmm, DEC16_Q4K)
+CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
+
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
 HGEMM_KERNEL(linear_quik6_hmm, DEC16_K6)
 HGEMM_KERNEL(linear_quik8_hmm, DEC16_K8)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -978,8 +978,11 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
     uint sg = gid / 32u;
     uint ntq = (p.rows + 7u) / 8u;
     if (sg >= ntq * p.n_head) return;
-    uint qt = sg / p.n_head;
-    uint h = sg % p.n_head;
+    /* same-head query tiles are ADJACENT simdgroups: concurrent tiles then stream the SAME
+       head's KV region and hit the SLC, instead of 16 heads' regions at once (measured: the
+       head-fastest order collapsed pp8k to ~1/3 of llama.cpp) */
+    uint qt = sg % ntq;
+    uint h = sg / ntq;
     uint group = p.n_head / p.n_kv;
     uint kvh = h / group;
     uint hd = p.head_dim;

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1016,7 +1016,8 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
         return;
     }
 
-    threadgroup half tgP[64];
+    threadgroup half tgP[128];
+    threadgroup float tgS16[128];
     threadgroup float tgD[64];
     threadgroup float tgM[8], tgL[8];
     uint abs0 = p.pos + r0;                 // row i sees positions <= abs0 + i
@@ -1032,16 +1033,23 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
     uint nfrag = hd / 8u;
     for (uint i = 0; i < nfrag; i++) oa[i] = simdgroup_float8x8(0.0f);
 
-    for (uint j0 = lo_min & ~7u; j0 <= abs_max; j0 += 8u) {
+    for (uint j0 = lo_min & ~15u; j0 <= abs_max; j0 += 16u) {
+        /* two 8-position score fragments per iteration: one scalar softmax phase and one
+           rescale per 16 KV positions instead of per 8 — the scalar phase and its barriers,
+           not KV bandwidth, are what this kernel waits on */
         device const half* kb = k + ((ulong)j0 * p.n_kv + kvh) * hd;
-        simdgroup_float8x8 sf = simdgroup_float8x8(0.0f);
+        simdgroup_float8x8 sf0 = simdgroup_float8x8(0.0f);
+        simdgroup_float8x8 sf1 = simdgroup_float8x8(0.0f);
         for (uint e0 = 0; e0 < hd; e0 += 8u) {
             simdgroup_half8x8 qa, kt;
             simdgroup_load(qa, qbase + e0, qstride);
             simdgroup_load(kt, kb + e0, kvstride, ulong2(0, 0), true);
-            simdgroup_multiply_accumulate(sf, qa, kt, sf);
+            simdgroup_multiply_accumulate(sf0, qa, kt, sf0);
+            simdgroup_load(kt, kb + 8u * kvstride + e0, kvstride, ulong2(0, 0), true);
+            simdgroup_multiply_accumulate(sf1, qa, kt, sf1);
         }
-        simdgroup_store(sf, tgD, 8);        // reuse tgD as the f32 score scratch
+        simdgroup_store(sf0, tgS16, 16);      // f32 score scratch, 8 rows x 16 cols
+        simdgroup_store(sf1, tgS16 + 8u, 16);
         simdgroup_barrier(mem_flags::mem_threadgroup);
         if (lane < 8u) {
             uint r = lane;
@@ -1049,18 +1057,18 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
             uint lor = (p.window > 0u && absr + 1u > p.window) ? (absr + 1u - p.window) : 0u;
             float mr = tgM[r];
             float mnew = mr;
-            float s[8];
-            for (uint c = 0; c < 8u; c++) {
+            float s[16];
+            for (uint c = 0; c < 16u; c++) {
                 uint j = j0 + c;
                 bool valid = (j >= lor) && (j <= absr);
-                s[c] = valid ? tgD[r * 8u + c] * p.scale : -INFINITY;
+                s[c] = valid ? tgS16[r * 16u + c] * p.scale : -INFINITY;
                 mnew = max(mnew, s[c]);
             }
             float corr = (mr == mnew) ? 1.0f : exp(mr - mnew);
             float lsum = 0.0f;
-            for (uint c = 0; c < 8u; c++) {
+            for (uint c = 0; c < 16u; c++) {
                 float pw = (s[c] == -INFINITY) ? 0.0f : exp(s[c] - mnew);
-                tgP[r * 8u + c] = (half)pw;
+                tgP[r * 16u + c] = (half)pw;
                 lsum += pw;
             }
             tgL[r] = tgL[r] * corr + lsum;
@@ -1069,16 +1077,19 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
         }
         simdgroup_barrier(mem_flags::mem_threadgroup);
         simdgroup_float8x8 df;
-        simdgroup_half8x8 pf;
+        simdgroup_half8x8 pf0, pf1;
         simdgroup_load(df, tgD, 8);
-        simdgroup_load(pf, tgP, 8);
+        simdgroup_load(pf0, tgP, 16);
+        simdgroup_load(pf1, tgP + 8u, 16);
         device const half* vb = v + ((ulong)j0 * p.n_kv + kvh) * hd;
         for (uint i = 0; i < nfrag; i++) {
             simdgroup_float8x8 tmp;
             simdgroup_multiply(tmp, df, oa[i]);
             simdgroup_half8x8 vf;
             simdgroup_load(vf, vb + i * 8u, kvstride);
-            simdgroup_multiply_accumulate(oa[i], pf, vf, tmp);
+            simdgroup_multiply_accumulate(tmp, pf0, vf, tmp);
+            simdgroup_load(vf, vb + 8u * kvstride + i * 8u, kvstride);
+            simdgroup_multiply_accumulate(oa[i], pf1, vf, tmp);
         }
         simdgroup_barrier(mem_flags::mem_threadgroup);
     }

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -506,6 +506,38 @@ fn linear_q4k_gemm_matches_dequant_reference() {
     );
 }
 
+// out_f % 64 == 0 routes to the cooperative-tile GEMM (`linear_*_cmm`); m=40 covers one full
+// 32-row tile plus a partial one. Same f16-operand reference as the other GEMM tests.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4k_coop_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    check_quant_linear_parity_impl(
+        DType::Q4K,
+        synth_q4k(out_f * in_f, 32),
+        m,
+        in_f,
+        out_f,
+        1e-3,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q6k_coop_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    check_quant_linear_parity_impl(
+        DType::Q6K,
+        synth_q6k(out_f * in_f, 33),
+        m,
+        in_f,
+        out_f,
+        1e-3,
+        true,
+    );
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn linear_q6k_gemm_matches_dequant_reference() {


### PR DESCRIPTION
Stacked on #8 (contains its commits until it merges; review the top commit).

**Metal in `infr bench`** (`INFR_METAL=1` or `--dev Metal`): same pp/tg/pg + depth methodology as the CPU arm through the agnostic seam. Metal numbers are now llama-bench-comparable; sanity-checked against the run-path figures.

**First depth sweep** (Qwen3-0.6B, M3 Pro, vs llama.cpp Metal, same GGUF):

| shape | infr | llama.cpp | gap |
|---|---|---|---|
| tg128 @ d4096 | 68.0 | 98.8 | 1.45× |
| tg128 @ d16384 | 25.5 | 46.1 | 1.81× |
| tg128 @ d32768 | 13.9 | 23.4 | 1.68× |
| pp8192 | 785 → **875** | 2336 | 2.7× |

Long context — the north star — is the weakest axis. Profiling: prefill attention = **80% of pp8192 GPU** (7.5 s vs Linear's 1.6 s).

**One fix landed from the evidence**: the flash grid ran heads fastest, so concurrent query tiles streamed 16 per-head KV regions (~64 MB) and thrashed the SLC; same-head tiles are now adjacent (+11% pp8k, short prefill unchanged, parity 32/32).

**Identified next arc**: port `flash_attn_ext`'s structure (KV split across simdgroups within the tile, half-precision S/P, deeper pipelining) — same FLOPs, ~4× faster at depth. Decode at depth points at the same class (attnsplit32's serial chains).