### PR TITLE
perf(metal): flash_attn_ext ports — long-context prefill 2.5x, decode at depth 1.9x

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -858,6 +858,21 @@ fn cmd_bench(
             json,
         );
     }
+    // INFR_METAL=1 (or --dev Metal): bench the dense forward on the Metal backend through the
+    // agnostic seam — same pp/tg/pg + depth methodology as the CPU arm, directly comparable to
+    // `llama-bench` on the Metal build.
+    if std::env::var("INFR_METAL").is_ok() || dev.eq_ignore_ascii_case("metal") {
+        return cmd_bench_metal(
+            &gguf,
+            tok.as_deref(),
+            n_prompt,
+            n_gen,
+            depth,
+            pg,
+            reps,
+            json,
+        );
+    }
     let _ = dev; // GPU device selection: VulkanBackend uses the default adapter (--dev reserved for parity).
     let llama = infr_llama::Llama::load_opt(&gguf, tok.as_deref())?;
     let measure_tg = pg.is_none() && n_gen > 0;
@@ -976,6 +991,57 @@ fn print_bench_avg(samples: &[f64], label: &str, depth: usize, tag: &str, reps: 
 /// CPU-backend bench (`infr bench -ngl 0`): the GPU bench's pp/tg/pg metrics on the agnostic CPU
 /// reference path, using `CpuModel`'s token-level timing — directly comparable to `llama-bench -ngl 0`.
 #[allow(clippy::too_many_arguments)]
+/// Metal twin of [`cmd_bench_cpu`]: same pp/tg/pg + depth methodology on the Apple-GPU seam
+/// backend (`CpuModel::bench_metal`). On non-macOS this arm is unreachable (the backend crate
+/// compiles to nothing), so the whole body is cfg-gated.
+#[allow(clippy::too_many_arguments)]
+fn cmd_bench_metal(
+    gguf: &Path,
+    tok: Option<&Path>,
+    n_prompt: usize,
+    n_gen: usize,
+    depth: usize,
+    pg: Option<(usize, usize)>,
+    reps: usize,
+    json: bool,
+) -> anyhow::Result<()> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (gguf, tok, n_prompt, n_gen, depth, pg, reps, json);
+        anyhow::bail!("metal bench requires macOS");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let model = infr_llama::CpuModel::load(gguf, tok)?;
+        let measure_tg = pg.is_none() && n_gen > 0;
+        // One untimed warmup: page-cache the mmap + build the weight caches + compile pipelines.
+        let _ = model.bench_metal(depth.max(1), if measure_tg || pg.is_some() { 1 } else { 0 });
+        let mut samples = Vec::with_capacity(reps);
+        for _ in 0..reps {
+            let ts = if let Some((p, g)) = pg {
+                let s = model.bench_metal(p, g)?;
+                (p + g) as f64 / (s.prompt_secs + s.decode_secs)
+            } else if measure_tg {
+                let s = model.bench_metal(depth.max(1), n_gen)?;
+                n_gen as f64 / s.decode_secs
+            } else {
+                let s = model.bench_metal(n_prompt, 0)?;
+                n_prompt as f64 / s.prompt_secs
+            };
+            samples.push(ts);
+        }
+        let label = if let Some((p, g)) = pg {
+            format!("pg{p}+{g}")
+        } else if measure_tg {
+            format!("tg{n_gen}")
+        } else {
+            format!("pp{n_prompt}")
+        };
+        print_bench_avg(&samples, &label, depth, " [metal]", reps, json);
+        Ok(())
+    }
+}
+
 fn cmd_bench_cpu(
     gguf: &Path,
     tok: Option<&Path>,

--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -988,9 +988,6 @@ fn print_bench_avg(samples: &[f64], label: &str, depth: usize, tag: &str, reps: 
     }
 }
 
-/// CPU-backend bench (`infr bench -ngl 0`): the GPU bench's pp/tg/pg metrics on the agnostic CPU
-/// reference path, using `CpuModel`'s token-level timing — directly comparable to `llama-bench -ngl 0`.
-#[allow(clippy::too_many_arguments)]
 /// Metal twin of [`cmd_bench_cpu`]: same pp/tg/pg + depth methodology on the Apple-GPU seam
 /// backend (`CpuModel::bench_metal`). On non-macOS this arm is unreachable (the backend crate
 /// compiles to nothing), so the whole body is cfg-gated.
@@ -1042,6 +1039,9 @@ fn cmd_bench_metal(
     }
 }
 
+/// CPU-backend bench (`infr bench -ngl 0`): the GPU bench's pp/tg/pg metrics on the agnostic CPU
+/// reference path, using `CpuModel`'s token-level timing — directly comparable to `llama-bench -ngl 0`.
+#[allow(clippy::too_many_arguments)]
 fn cmd_bench_cpu(
     gguf: &Path,
     tok: Option<&Path>,

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -211,6 +211,27 @@ impl CpuModel {
         Ok(stats)
     }
 
+    /// Token-level bench on the **Metal** backend through the agnostic seam (the Apple-GPU twin of
+    /// [`bench`](Self::bench)): prefill `n_prompt` dummy tokens, decode `n_gen`, return the timing.
+    /// Lets `infr bench` (with `INFR_METAL=1`) measure pp/tg directly comparable to `llama-bench`
+    /// on the Metal build.
+    #[cfg(target_os = "macos")]
+    pub fn bench_metal(&self, n_prompt: usize, n_gen: usize) -> Result<crate::GenStats> {
+        let prompt: Vec<u32> = (0..n_prompt.max(1)).map(|i| (i % 100) as u32).collect();
+        let mtl = infr_metal::MetalBackend::new().map_err(|e| anyhow!("metal init: {e}"))?;
+        let (_, stats) = crate::cpu_backend::generate_dense_metal(
+            &mtl,
+            &self.gguf,
+            &self.cfg,
+            &self.token_embd,
+            self.per_layer_embd.as_ref(),
+            &prompt,
+            n_gen,
+            |_| {},
+        )?;
+        Ok(stats)
+    }
+
     /// Render a user turn with the model's OWN embedded chat template (so an instruct model — Gemma,
     /// Qwen, … — answers coherently). Errors if the GGUF has no `tokenizer.chat_template` or it fails
     /// to render — infr only supports models that ship one (no fabricated-ChatML fallback).

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -643,18 +643,12 @@ impl MetalBackend {
                             >= 128;
                     p.extend_from_slice(&qw.dshift.to_ne_bytes());
                     if cmm_ok {
-                        let xh = Arc::new(self.device.new_buffer(
-                            (m * in_f * 2).max(4) as u64,
-                            MTLResourceOptions::StorageModeShared,
-                        ));
-                        let cast = self.pipelines.get("cast_f32_f16")?;
-                        let n = (m * in_f) as u32;
-                        self.encode(r, &cast, &[bx.as_ref(), &xh], &n.to_ne_bytes(), m * in_f);
+                        // Reads f32 x directly (casts to f16 while staging) — no cast pass.
                         let pso = self.pipelines.get(cmm_kern)?;
                         self.encode_tg(
                             r,
                             &pso,
-                            &[xh.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[bx.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
                             &p,
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -656,7 +656,12 @@ impl MetalBackend {
                             };
                             (rt, m.div_ceil(8) * out_f)
                         } else {
-                            (qw.kern, out_f)
+                            // The native mul_mv-shape GEMVs cover TWO output rows per simdgroup.
+                            let sgs = match qw.kern {
+                                "linear_q4k" | "linear_q6k" => out_f.div_ceil(2),
+                                _ => out_f,
+                            };
+                            (qw.kern, sgs)
                         };
                         let pso = self.pipelines.get(kern)?;
                         self.encode_tg(

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -86,10 +86,7 @@ fn linear_add_peephole(
             continue;
         }
         if let Some(Op::Add {
-            a,
-            b,
-            dst: add_dst,
-            ..
+            a, b, dst: add_dst, ..
         }) = g.ops.get(i + 1)
         {
             let residual = if a == dst {
@@ -400,10 +397,7 @@ impl MetalBackend {
                 }
                 let cap = e.pso.max_total_threads_per_threadgroup() as usize;
                 let tg = if e.tg == 0 { cap } else { e.tg.min(cap) }.min(e.threads.max(1)) as u64;
-                enc.dispatch_threads(
-                    MTLSize::new(e.threads as u64, 1, 1),
-                    MTLSize::new(tg, 1, 1),
-                );
+                enc.dispatch_threads(MTLSize::new(e.threads as u64, 1, 1), MTLSize::new(tg, 1, 1));
             }
             enc.end_encoding();
             let t0 = self.profiling.then(std::time::Instant::now);

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -946,6 +946,16 @@ impl MetalBackend {
                 // path). See `attnflash_f16kv` for why the f32 flash attempt lost and this wins.
                 let flash = f16 && rows * nh >= 128 && kv_len >= 64 && hd <= 128 && hd % 8 == 0;
                 let split = !flash && (rows * nh < 128 || kv_len >= 128);
+                // The cooperative flash kernel (4 simdgroups per query tile, llama.cpp
+                // flash_attn_ext structure) needs hd % 32 == 0 for its per-simdgroup O
+                // fragment split and a 128-thread threadgroup (pipeline-cap gated like the
+                // split kernels); otherwise the single-simdgroup flash still applies.
+                let flash2 = flash && hd % 32 == 0 && {
+                    self.pipelines
+                        .get("attnflash2_f16kv")?
+                        .max_total_threads_per_threadgroup()
+                        >= 128
+                };
                 // The split kernels REQUIRE their full NSG*32-thread threadgroup: every simdgroup
                 // owns a strided KV slice, so a smaller launch would silently skip positions and
                 // merge uninitialized partials. maxTotalThreadsPerThreadgroup is per-PIPELINE
@@ -981,6 +991,7 @@ impl MetalBackend {
                             256,
                         )?);
                 let kern = match (flash, f16, split, split32) {
+                    (true, ..) if flash2 => "attnflash2_f16kv",
                     (true, ..) => "attnflash_f16kv",
                     (_, true, false, _) => "attention_f16kv",
                     (_, true, _, true) => "attnsplit32_f16kv",
@@ -1009,13 +1020,15 @@ impl MetalBackend {
                         ));
                     let cast = self.pipelines.get("cast_f32_f16")?;
                     self.encode(r, &cast, &[bq.as_ref(), &qh], &(n as u32).to_ne_bytes(), n);
+                    // flash2 runs 4 cooperating simdgroups per (query tile, head) threadgroup
+                    let tgw = if flash2 { 128 } else { 32 };
                     self.encode_tg(
                         r,
                         &pso,
                         &[qh.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref()],
                         &p,
-                        rows.div_ceil(8) * nh * 32,
-                        32,
+                        rows.div_ceil(8) * nh * tgw,
+                        tgw,
                     );
                 } else {
                     // One simdgroup per (query, head); split kernels use NSG simdgroups per

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -52,6 +52,58 @@ struct Resident {
     enc: Option<ComputeCommandEncoder>,
     tape: Option<Vec<TapeEntry>>,
     posbuf: Option<MtlBuffer>,
+    /// Linear→Add residual fusion (see `linear_add_peephole`): Linear op index → (residual
+    /// tensor, final dst); the absorbed Adds are in `skip`.
+    fused: std::collections::HashMap<usize, (TensorId, TensorId)>,
+    skip: std::collections::HashSet<usize>,
+}
+
+/// Fuse `Linear (m==1, Q4_K/Q6_K weight, Internal dst) → Add(residual)` into the fused-residual
+/// GEMV (`linear_q4k_add`/`linear_q6k_add`) — one dispatch + one dependency stage instead of two,
+/// and no round-trip of the sublayer output (the decode o_proj/down_proj shape; mirrors the
+/// Vulkan adapter's peephole). Only the IMMEDIATELY following Add fuses: the seam builder emits
+/// the pair adjacent for non-gemma models, and gemma's sandwich norm sits between and correctly
+/// blocks it.
+fn linear_add_peephole(
+    g: &infr_core::graph::Graph,
+) -> (
+    std::collections::HashMap<usize, (TensorId, TensorId)>,
+    std::collections::HashSet<usize>,
+) {
+    let mut fused = std::collections::HashMap::new();
+    let mut skip = std::collections::HashSet::new();
+    for (i, op) in g.ops.iter().enumerate() {
+        let Op::Linear {
+            dst, m: 1, weight, ..
+        } = op
+        else {
+            continue;
+        };
+        if !matches!(g.tensors[dst.0 as usize].kind, TensorKind::Internal) {
+            continue;
+        }
+        if !matches!(g.desc(*weight).dtype, DType::Q4K | DType::Q6K) {
+            continue;
+        }
+        if let Some(Op::Add {
+            a,
+            b,
+            dst: add_dst,
+            ..
+        }) = g.ops.get(i + 1)
+        {
+            let residual = if a == dst {
+                *b
+            } else if b == dst {
+                *a
+            } else {
+                continue;
+            };
+            fused.insert(i, (residual, *add_dst));
+            skip.insert(i + 1);
+        }
+    }
+    (fused, skip)
 }
 
 /// One recorded dispatch: everything `encode_tg` needs to re-encode it verbatim. The buffer clones
@@ -477,7 +529,14 @@ impl MetalBackend {
             enc: None,
             tape: record.then(Vec::new),
             posbuf: None,
+            fused: std::collections::HashMap::new(),
+            skip: std::collections::HashSet::new(),
         };
+        {
+            let (fused, skip) = linear_add_peephole(g);
+            r.fused = fused;
+            r.skip = skip;
+        }
         if record {
             // Recording (`replay_shape` held): the tape must read/write the BOUND buffers, not
             // per-execute host-mirror copies — the engine mutates the bound hidden/positions
@@ -533,9 +592,12 @@ impl MetalBackend {
         }
 
         if self.profiling {
-            for op in &g.ops {
+            for (idx, op) in g.ops.iter().enumerate() {
+                if r.skip.contains(&idx) {
+                    continue;
+                }
                 let t0 = std::time::Instant::now();
-                self.run_op(op, g, bindings, &mut r)?;
+                self.run_op(op, idx, g, bindings, &mut r)?;
                 let enc = t0.elapsed();
                 // Per-op mode: flush now so this op's GPU wall is isolable (breaks batching).
                 let gpu = if self.prof_ops {
@@ -553,8 +615,11 @@ impl MetalBackend {
             }
             self.prof.lock().unwrap().add_forward();
         } else {
-            for op in &g.ops {
-                self.run_op(op, g, bindings, &mut r)?;
+            for (idx, op) in g.ops.iter().enumerate() {
+                if r.skip.contains(&idx) {
+                    continue;
+                }
+                self.run_op(op, idx, g, bindings, &mut r)?;
             }
         }
 
@@ -745,6 +810,7 @@ impl MetalBackend {
     fn run_op(
         &self,
         op: &Op,
+        idx: usize,
         g: &infr_core::graph::Graph,
         bindings: &Bindings,
         r: &mut Resident,
@@ -913,6 +979,34 @@ impl MetalBackend {
                             };
                             (qw.kern, sgs)
                         };
+                        // Residual peephole: this Linear absorbed the following Add — take the
+                        // fused-residual variant and write the Add's dst directly.
+                        if let Some(&(res, fdst)) = r.fused.get(&idx) {
+                            let fk = match kern {
+                                "linear_q4k" => "linear_q4k_add",
+                                _ => "linear_q6k_add",
+                            };
+                            let bres = self.ensure_device(r, res);
+                            let bfd = self.dev_dst(r, fdst, out_f);
+                            let pso = self.pipelines.get(fk)?;
+                            self.encode_tg(
+                                r,
+                                &pso,
+                                &[
+                                    bx.as_ref(),
+                                    &qw.codes,
+                                    &qw.scm,
+                                    &qw.dd,
+                                    bfd.as_ref(),
+                                    bres.as_ref(),
+                                ],
+                                &p,
+                                sgs * 32,
+                                32,
+                            );
+                            r.loc[fdst.0 as usize] = Loc::Device;
+                            return Ok(());
+                        }
                         let pso = self.pipelines.get(kern)?;
                         self.encode_tg(
                             r,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -41,13 +41,108 @@ enum Loc {
 
 /// Per-forward execution state: the host mirror (`vals`), a device buffer per tensor (`dev`), where
 /// each tensor currently lives (`loc`), and the open command buffer that batches consecutive GPU ops
-/// so they share a single commit + wait instead of one per op.
+/// so they share a single commit + wait instead of one per op. When `tape` is armed, every encoded
+/// dispatch is also recorded for decode replay (see [`Tape`]), and `posbuf` carries the bound
+/// positions buffer the dynamic-pos kernels read.
 struct Resident {
     vals: Vec<Vec<f32>>,
     dev: Vec<Option<Arc<MtlBuffer>>>,
     loc: Vec<Loc>,
     cb: Option<CommandBuffer>,
     enc: Option<ComputeCommandEncoder>,
+    tape: Option<Vec<TapeEntry>>,
+    posbuf: Option<MtlBuffer>,
+}
+
+/// One recorded dispatch: everything `encode_tg` needs to re-encode it verbatim. The buffer clones
+/// are retains, so the tape keeps every transient (intermediate activations, cached weights) alive
+/// across replays — replaying reuses the exact buffers the recording ran on.
+pub(crate) struct TapeEntry {
+    pso: ComputePipelineState,
+    bufs: Vec<MtlBuffer>,
+    params: Vec<u8>,
+    threads: usize,
+    tg: usize,
+}
+
+/// A recorded decode forward for the seam's record-once replay (`Capabilities::decode_replay`):
+/// the engine compiles the decode graph once (baked pos=0), binds everything once, and re-executes
+/// the same plan per token after uploading the new embedding + position. Metal command buffers are
+/// single-use, so "replay" here is re-encoding this flat dispatch list — no graph walk, no host
+/// mirror, no transient allocation, no routing. Ops whose behavior depends on the position use
+/// DYNAMIC-POS kernels that read the bound positions buffer (`attnvec_dyn_*`, `writekv_dyn_f16`;
+/// RoPE already reads it), so the recorded params stay valid for every token.
+pub(crate) struct Tape {
+    /// Fingerprint of (op discriminants, tensor count, bound buffer addresses): a tape is replayed
+    /// only for a graph with the identical op sequence over the identical bindings. Baked pos /
+    /// kv_len MAY differ across tokens — the dynamic-pos kernels ignore them by construction.
+    fp: u64,
+    entries: Vec<TapeEntry>,
+}
+
+/// Fingerprint the (graph shape, bindings) pair for tape matching. Op kind + tensor count pins the
+/// graph structure; the bound buffer addresses pin the weights/caches/IO. Two graphs that agree on
+/// all of that and pass [`replay_shape`] differ at most in baked positions, which replay reads
+/// dynamically.
+fn replay_fp(g: &infr_core::graph::Graph, bindings: &Bindings) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    let mut mix = |v: u64| {
+        h ^= v;
+        h = h.wrapping_mul(0x100000001b3);
+    };
+    mix(g.tensors.len() as u64);
+    for op in &g.ops {
+        mix(op_name(op).as_ptr() as u64);
+    }
+    for i in 0..g.tensors.len() {
+        if let Some(b) = bindings.get(TensorId(i as u32)) {
+            mix(metal_buf(b) as *const _ as u64);
+        }
+    }
+    h
+}
+
+/// Is this graph the decode shape the replay tape supports? Every op must be one the recorder
+/// handles fully on-device, attention must be the rows=1 f16 shape with a dynamic-pos kernel
+/// instantiation (hd 64/128), and a QkNormRope must exist to name the positions buffer.
+fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
+    use infr_core::graph::TensorKind;
+    let mut has_rope = false;
+    let mut has_attn = false;
+    for op in &g.ops {
+        match op {
+            Op::RmsNorm { .. } | Op::Linear { .. } | Op::GatedAct { .. } | Op::Add { .. } => {}
+            Op::QkNormRope { .. } => has_rope = true,
+            Op::WriteKv { cache, .. } => {
+                if g.desc(*cache).dtype != DType::F16 {
+                    return false;
+                }
+            }
+            Op::Attention {
+                rows,
+                head_dim,
+                k_cache,
+                ..
+            } => {
+                has_attn = true;
+                if *rows != 1
+                    || !matches!(*head_dim, 64 | 128)
+                    || g.desc(*k_cache).dtype != DType::F16
+                {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    // Every non-in-place tensor the recording direct-binds must actually be bound.
+    for (i, decl) in g.tensors.iter().enumerate() {
+        let needs_binding = matches!(decl.kind, TensorKind::Input | TensorKind::Output);
+        if needs_binding && bindings.get(TensorId(i as u32)).is_none() {
+            return false;
+        }
+    }
+    has_rope && has_attn
 }
 
 /// Reinterpret raw buffer bytes as `f32` per `dtype` (dequantizing quant/f16/bf16, widening integer
@@ -219,8 +314,55 @@ impl MetalBackend {
             );
         }
         let cap = pso.max_total_threads_per_threadgroup() as usize;
-        let tg = if tg == 0 { cap } else { tg.min(cap) }.min(threads.max(1)) as u64;
-        enc.dispatch_threads(MTLSize::new(threads as u64, 1, 1), MTLSize::new(tg, 1, 1));
+        let tgw = if tg == 0 { cap } else { tg.min(cap) }.min(threads.max(1)) as u64;
+        enc.dispatch_threads(MTLSize::new(threads as u64, 1, 1), MTLSize::new(tgw, 1, 1));
+        if let Some(tape) = r.tape.as_mut() {
+            tape.push(TapeEntry {
+                pso: pso.clone(),
+                bufs: bufs.iter().map(|b| (*b).clone()).collect(),
+                params: params.to_vec(),
+                threads,
+                tg,
+            });
+        }
+    }
+
+    /// Re-encode a recorded tape: one command buffer, the flat dispatch list, commit + wait.
+    /// This IS the per-token decode cost on the replay path — no graph walk, no host mirror,
+    /// no allocation.
+    fn replay_tape(&self, tape: &Tape) {
+        objc::rc::autoreleasepool(|| {
+            let cb = self.queue.new_command_buffer();
+            let enc = cb.new_compute_command_encoder();
+            for e in &tape.entries {
+                enc.set_compute_pipeline_state(&e.pso);
+                for (i, b) in e.bufs.iter().enumerate() {
+                    enc.set_buffer(i as u64, Some(b), 0);
+                }
+                if !e.params.is_empty() {
+                    enc.set_bytes(
+                        e.bufs.len() as u64,
+                        e.params.len() as u64,
+                        e.params.as_ptr() as *const c_void,
+                    );
+                }
+                let cap = e.pso.max_total_threads_per_threadgroup() as usize;
+                let tg = if e.tg == 0 { cap } else { e.tg.min(cap) }.min(e.threads.max(1)) as u64;
+                enc.dispatch_threads(
+                    MTLSize::new(e.threads as u64, 1, 1),
+                    MTLSize::new(tg, 1, 1),
+                );
+            }
+            enc.end_encoding();
+            let t0 = self.profiling.then(std::time::Instant::now);
+            cb.commit();
+            cb.wait_until_completed();
+            if let Some(t0) = t0 {
+                let mut pr = self.prof.lock().unwrap();
+                pr.add_dispatch(t0.elapsed());
+                pr.add_forward();
+            }
+        });
     }
 
     /// Close the open batch: end encoding, commit, and wait. A no-op if nothing is buffered.
@@ -277,12 +419,51 @@ impl MetalBackend {
             .expect("metal backend: plan is not a GraphPlan")
             .graph;
 
+        // Decode replay: if this exact (graph shape, bindings) pair was recorded, re-encode the
+        // tape and skip the graph walk entirely (see `Tape`). The engine's replay loop re-executes
+        // one compiled plan with stable bindings, so after the first recorded token every
+        // subsequent token takes this path. The dynamic-pos vector kernel REQUIRES its full
+        // 1024-thread threadgroup (same silent-clamp hazard as the split kernels), so recording is
+        // gated on its pipeline cap — a capped device (CI paravirtual) keeps the per-token path.
+        let dyn_cap_ok = || -> bool {
+            let kern = g.ops.iter().find_map(|op| match op {
+                Op::Attention { head_dim: 64, .. } => Some("attnvec_dyn_f16kv_hd64"),
+                Op::Attention { head_dim: 128, .. } => Some("attnvec_dyn_f16kv_hd128"),
+                _ => None,
+            });
+            kern.is_some_and(|kn| {
+                self.pipelines
+                    .get(kn)
+                    .map(|pl| pl.max_total_threads_per_threadgroup() >= 1024)
+                    .unwrap_or(false)
+            })
+        };
+        if replay_shape(g, bindings) && dyn_cap_ok() {
+            let fp = replay_fp(g, bindings);
+            if let Some(tape) = self.replay.lock().unwrap().as_ref() {
+                if tape.fp == fp {
+                    self.replay_tape(tape);
+                    return Ok(());
+                }
+            }
+            let entries = objc::rc::autoreleasepool(|| self.run_graph(g, bindings, true))?;
+            if let Some(entries) = entries {
+                *self.replay.lock().unwrap() = Some(Tape { fp, entries });
+            }
+            return Ok(());
+        }
+
         // Wrap the whole forward in one autorelease pool: the batched command buffers/encoders are
         // retained owned handles, so we drain the pool once per forward instead of once per op.
-        objc::rc::autoreleasepool(|| self.run_graph(g, bindings))
+        objc::rc::autoreleasepool(|| self.run_graph(g, bindings, false).map(|_| ()))
     }
 
-    fn run_graph(&self, g: &infr_core::graph::Graph, bindings: &Bindings) -> Result<()> {
+    fn run_graph(
+        &self,
+        g: &infr_core::graph::Graph,
+        bindings: &Bindings,
+        record: bool,
+    ) -> Result<Option<Vec<TapeEntry>>> {
         // f32 host mirror for every Input/Internal/Output handle (mirrors the CPU interpreter); GPU
         // results stay on-device until a host op or the write-back needs them (see `Loc`/`Resident`).
         // KV caches are written/read in place from their bound buffers (see `direct`).
@@ -294,13 +475,50 @@ impl MetalBackend {
             loc: vec![Loc::Host; n],
             cb: None,
             enc: None,
+            tape: record.then(Vec::new),
+            posbuf: None,
         };
+        if record {
+            // Recording (`replay_shape` held): the tape must read/write the BOUND buffers, not
+            // per-execute host-mirror copies — the engine mutates the bound hidden/positions
+            // buffers between replays and reads logits from its bound buffer. So f32 Inputs and
+            // Outputs are direct-bound as the tensor's device buffer, and the positions buffer
+            // (i32, named by the graph's QkNormRope) is stashed for the dynamic-pos kernels.
+            for (i, decl) in g.tensors.iter().enumerate() {
+                let id = TensorId(i as u32);
+                if direct.contains(&id) {
+                    continue;
+                }
+                let bound = match decl.kind {
+                    TensorKind::Input if decl.desc.dtype == DType::F32 => true,
+                    TensorKind::Output => true,
+                    _ => false,
+                };
+                if bound {
+                    let buf = metal_buf(bindings.get(id).expect("replay_shape checked bindings"));
+                    r.dev[i] = Some(Arc::new(buf.raw.clone()));
+                    if decl.kind == TensorKind::Input {
+                        r.loc[i] = Loc::Device;
+                    }
+                }
+            }
+            let positions = g
+                .ops
+                .iter()
+                .find_map(|op| match op {
+                    Op::QkNormRope { positions, .. } => Some(*positions),
+                    _ => None,
+                })
+                .expect("replay_shape checked QkNormRope");
+            r.posbuf = Some(metal_buf(bindings.get(positions).unwrap()).raw.clone());
+        }
         for (i, decl) in g.tensors.iter().enumerate() {
             match decl.kind {
                 TensorKind::Internal | TensorKind::Output => {
                     r.vals[i] = vec![0f32; decl.desc.numel()]
                 }
                 TensorKind::Input if direct.contains(&TensorId(i as u32)) => {}
+                TensorKind::Input if record && decl.desc.dtype == DType::F32 => {}
                 TensorKind::Input => {
                     let buf = metal_buf(
                         bindings
@@ -350,9 +568,14 @@ impl MetalBackend {
                 continue;
             }
             if bindings.get(TensorId(i as u32)).is_some() {
+                let b = metal_buf(bindings.get(TensorId(i as u32)).unwrap());
+                // Direct-bound (recording): the GPU already wrote the bound buffer — nothing to
+                // copy, the trailing flush below makes it visible.
+                if matches!(&r.dev[i], Some(d) if d.contents() == b.raw.contents()) {
+                    continue;
+                }
                 // Pull the value back to the host mirror (flushes the batch if it's still on-device).
                 self.ensure_host(&mut r, g, TensorId(i as u32));
-                let b = metal_buf(bindings.get(TensorId(i as u32)).unwrap());
                 let src: &[u8] = bytemuck::cast_slice(&r.vals[i]);
                 unsafe {
                     std::ptr::copy_nonoverlapping(
@@ -365,7 +588,7 @@ impl MetalBackend {
         }
         // Close any trailing batch (an Internal-only tail never pulled to host).
         self.flush(&mut r);
-        Ok(())
+        Ok(r.tape.take())
     }
 
     /// Fetch a dequantized weight as a device f32 buffer, cached by bound-buffer address.
@@ -766,7 +989,18 @@ impl MetalBackend {
                 let (rows, nh, hd) = (rows as usize, n_head as usize, head_dim as usize);
                 let bx = self.ensure_device(r, x);
                 let bw = self.weight_buf(weight, g, bindings);
-                let bpos = self.ensure_device(r, positions);
+                // The kernel reads the bound i32 positions buffer directly (exact widening in
+                // the shader) — no host round-trip, and the decode-replay tape stays valid when
+                // the engine rewrites the position between replays.
+                let bpos = Arc::new(
+                    metal_buf(
+                        bindings
+                            .get(positions)
+                            .expect("metal backend: unbound positions"),
+                    )
+                    .raw
+                    .clone(),
+                );
                 let bff = match freq_factors {
                     Some(f) => self.ensure_device(r, f),
                     None => Arc::new(self.zeros_buf(1)),
@@ -883,14 +1117,23 @@ impl MetalBackend {
                 );
                 let base = pos * rs;
                 let n = rows * rs;
-                let kern = match g.desc(cache).dtype {
-                    DType::F16 => "writekv_f16",
-                    _ => "writekv_f32",
-                };
-                let pso = self.pipelines.get(kern)?;
-                let mut p = (n as u32).to_ne_bytes().to_vec();
-                p.extend_from_slice(&(base as u32).to_ne_bytes());
-                self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw], &p, n);
+                if let Some(posbuf) = r.posbuf.clone() {
+                    // Recording a replay tape: the row offset must come from the positions buffer
+                    // (the baked `pos` is this token's only) — f16 cache guaranteed by the gate.
+                    let pso = self.pipelines.get("writekv_dyn_f16")?;
+                    let mut p = (n as u32).to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(rs as u32).to_ne_bytes());
+                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw, &posbuf], &p, n);
+                } else {
+                    let kern = match g.desc(cache).dtype {
+                        DType::F16 => "writekv_f16",
+                        _ => "writekv_f32",
+                    };
+                    let pso = self.pipelines.get(kern)?;
+                    let mut p = (n as u32).to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(base as u32).to_ne_bytes());
+                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw], &p, n);
+                }
             }
             Op::Attention {
                 q,
@@ -929,6 +1172,37 @@ impl MetalBackend {
                     infr_core::graph::AttnMask::Causal => 0,
                     infr_core::graph::AttnMask::SlidingWindow(w) => w as u32,
                 };
+                if let Some(posbuf) = r.posbuf.clone() {
+                    // Recording a replay tape (rows==1, f16 cache, hd 64/128 — checked by the
+                    // gate): route straight to the dynamic-pos vector flash kernel, which reads
+                    // pos from the positions buffer and covers every kv_len from 1 up. The usual
+                    // shape routing below would bake this token's kv_len into the kernel CHOICE,
+                    // which is exactly what a replayed tape can't have.
+                    let kern = if hd == 64 {
+                        "attnvec_dyn_f16kv_hd64"
+                    } else {
+                        "attnvec_dyn_f16kv_hd128"
+                    };
+                    let pso = self.pipelines.get(kern)?;
+                    let mut p = (rows as u32).to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(kv_len as u32).to_ne_bytes());
+                    p.extend_from_slice(&(nh as u32).to_ne_bytes());
+                    p.extend_from_slice(&(nkv as u32).to_ne_bytes());
+                    p.extend_from_slice(&(hd as u32).to_ne_bytes());
+                    p.extend_from_slice(&scale.to_ne_bytes());
+                    p.extend_from_slice(&window.to_ne_bytes());
+                    p.extend_from_slice(&pos.to_ne_bytes());
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[bq.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref(), &posbuf],
+                        &p,
+                        rows * nh * 32 * 32,
+                        32 * 32,
+                    );
+                    r.loc[dst.0 as usize] = Loc::Device;
+                    return Ok(());
+                }
                 // Route by kernel-latency shape. The one-simdgroup-per-(query, head) kernels are
                 // latency-bound on their serial O(kv_len) online-softmax chain, so any long
                 // context takes a split-KV kernel — NSG simdgroups per (query, head) merged in

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -947,15 +947,22 @@ impl MetalBackend {
                 let flash = f16 && rows * nh >= 128 && kv_len >= 64 && hd <= 128 && hd % 8 == 0;
                 let split = !flash && (rows * nh < 128 || kv_len >= 128);
                 // The cooperative flash kernel (4 simdgroups per query tile, llama.cpp
-                // flash_attn_ext structure) needs hd % 32 == 0 for its per-simdgroup O
-                // fragment split and a 128-thread threadgroup (pipeline-cap gated like the
-                // split kernels); otherwise the single-simdgroup flash still applies.
-                let flash2 = flash && hd % 32 == 0 && {
-                    self.pipelines
-                        .get("attnflash2_f16kv")?
-                        .max_total_threads_per_threadgroup()
-                        >= 128
+                // flash_attn_ext structure) is instantiated per compile-time head size
+                // (fully unrolled QK/PV loops) and needs a 128-thread threadgroup
+                // (pipeline-cap gated like the split kernels); other head sizes keep the
+                // single-simdgroup flash.
+                let flash2_kern = match hd {
+                    64 => Some("attnflash2_f16kv_hd64"),
+                    128 => Some("attnflash2_f16kv_hd128"),
+                    _ => None,
                 };
+                let flash2 = flash
+                    && flash2_kern.is_some_and(|kn| {
+                        self.pipelines
+                            .get(kn)
+                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                            .unwrap_or(false)
+                    });
                 // The split kernels REQUIRE their full NSG*32-thread threadgroup: every simdgroup
                 // owns a strided KV slice, so a smaller launch would silently skip positions and
                 // merge uninitialized partials. maxTotalThreadsPerThreadgroup is per-PIPELINE
@@ -991,7 +998,7 @@ impl MetalBackend {
                             256,
                         )?);
                 let kern = match (flash, f16, split, split32) {
-                    (true, ..) if flash2 => "attnflash2_f16kv",
+                    (true, ..) if flash2 => flash2_kern.unwrap(),
                     (true, ..) => "attnflash_f16kv",
                     (_, true, false, _) => "attention_f16kv",
                     (_, true, _, true) => "attnsplit32_f16kv",

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -56,6 +56,12 @@ struct Resident {
     /// tensor, final dst); the absorbed Adds are in `skip`.
     fused: std::collections::HashMap<usize, (TensorId, TensorId)>,
     skip: std::collections::HashSet<usize>,
+    /// Host-read override of the graph's baked position (see `run_graph`): the seam's replay
+    /// loop re-executes one compiled decode graph (baked pos=0) and only rewrites the bound
+    /// positions buffer, so on any decode-shaped graph the position-consuming ops (Attention,
+    /// WriteKv) must take the CURRENT position — the tape path reads it on the GPU; this covers
+    /// every graph the tape can't (MoE, gemma shapes, hd without a dyn instantiation).
+    dynpos: Option<u32>,
 }
 
 /// Fuse `Linear (m==1, Q4_K/Q6_K weight, Internal dst) → Add(residual)` into the fused-residual
@@ -525,7 +531,33 @@ impl MetalBackend {
             posbuf: None,
             fused: std::collections::HashMap::new(),
             skip: std::collections::HashSet::new(),
+            dynpos: None,
         };
+        // Decode-shaped graph (a rows==1 Attention) with a bound positions buffer: read the
+        // CURRENT position off the shared-memory buffer and override the baked pos/kv_len in
+        // the position-consuming arms. Single-execute callers bind positions equal to the baked
+        // value, so this is the identity for them; the seam's replay loop is where they differ.
+        let decode_shaped = g
+            .ops
+            .iter()
+            .any(|op| matches!(op, Op::Attention { rows: 1, .. }));
+        if decode_shaped {
+            let positions = g.ops.iter().find_map(|op| match op {
+                Op::QkNormRope { positions, .. } | Op::Rope { positions, .. } => Some(*positions),
+                _ => None,
+            });
+            if let Some(pid) = positions {
+                if let Some(b) = bindings.get(pid) {
+                    let buf = metal_buf(b);
+                    if buf.len >= 4 {
+                        let v = unsafe { *(buf.raw.contents() as *const i32) };
+                        if v >= 0 {
+                            r.dynpos = Some(v as u32);
+                        }
+                    }
+                }
+            }
+        }
         {
             let (fused, skip) = linear_add_peephole(g);
             r.fused = fused;
@@ -1196,7 +1228,10 @@ impl MetalBackend {
                 // Stateful cast-copy of `rows` rows into the persistent KV buffer, on the GPU so it
                 // stays in the batch (a host write would force a per-layer flush). Metal's hazard
                 // tracking orders this write before the Attention that reads the same cache buffer.
-                let (rows, rs, pos) = (rows as usize, row_stride as usize, pos as usize);
+                let (rows, rs, mut pos) = (rows as usize, row_stride as usize, pos as usize);
+                if let (Some(dp), 1) = (r.dynpos, rows) {
+                    pos = dp as usize;
+                }
                 let bsrc = self.ensure_device(r, src);
                 let cbuf = metal_buf(
                     bindings
@@ -1244,6 +1279,12 @@ impl MetalBackend {
                     n_kv as usize,
                     head_dim as usize,
                 );
+                // Replayed decode graph: the baked pos/kv_len are the compile-time token's;
+                // take the current position (also steers the kv_len-based kernel routing).
+                let (pos, kv_len) = match r.dynpos {
+                    Some(dp) if rows == 1 => (dp, dp as usize + 1),
+                    _ => (pos, kv_len),
+                };
                 if hd > 256 {
                     return Err(Error::Unsupported(format!(
                         "metal attention: head_dim {hd} exceeds MAX_HD 256 (shader acc[] cap)"

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -618,6 +618,22 @@ impl MetalBackend {
                         "linear_q6k" => "linear_q6k_hmm",
                         _ => "linear_quik8_hmm",
                     };
+                    let cmm_kern = match qw.kern {
+                        "linear_quik4" => "linear_quik4_cmm",
+                        "linear_quik6" => "linear_quik6_cmm",
+                        "linear_q4k" => "linear_q4k_cmm",
+                        "linear_q6k" => "linear_q6k_cmm",
+                        _ => "linear_quik8_cmm",
+                    };
+                    // Prefer the cooperative 32x64 threadgroup tile; per-simdgroup HGEMM covers
+                    // the out_f % 64 != 0 leftovers, and both need the full 128-thread group.
+                    let cmm_ok = m >= 16
+                        && out_f % 64 == 0
+                        && self
+                            .pipelines
+                            .get(cmm_kern)?
+                            .max_total_threads_per_threadgroup()
+                            >= 128;
                     let hmm_ok = m >= 16
                         && out_f % 16 == 0
                         && self
@@ -626,7 +642,24 @@ impl MetalBackend {
                             .max_total_threads_per_threadgroup()
                             >= 128;
                     p.extend_from_slice(&qw.dshift.to_ne_bytes());
-                    if hmm_ok {
+                    if cmm_ok {
+                        let xh = Arc::new(self.device.new_buffer(
+                            (m * in_f * 2).max(4) as u64,
+                            MTLResourceOptions::StorageModeShared,
+                        ));
+                        let cast = self.pipelines.get("cast_f32_f16")?;
+                        let n = (m * in_f) as u32;
+                        self.encode(r, &cast, &[bx.as_ref(), &xh], &n.to_ne_bytes(), m * in_f);
+                        let pso = self.pipelines.get(cmm_kern)?;
+                        self.encode_tg(
+                            r,
+                            &pso,
+                            &[xh.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &p,
+                            m.div_ceil(32) * (out_f / 64) * 128,
+                            128,
+                        );
+                    } else if hmm_ok {
                         // Prefill GEMM runs on half fragments (see `HGEMM_KERNEL`): cast x to a
                         // transient f16 buffer first, then one GEMM dispatch reads it.
                         let xh = Arc::new(self.device.new_buffer(

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -976,7 +976,26 @@ impl MetalBackend {
                         .max_total_threads_per_threadgroup()
                         >= threads)
                 };
+                // The vector flash kernel (llama.cpp flash_attn_ext_vec structure) covers the
+                // long-context decode shape split32 serves, at 32 KV positions per simdgroup
+                // step instead of 1 — same head-size instantiations and cap gating as flash2.
+                let vec_kern = match hd {
+                    64 => Some("attnvec_f16kv_hd64"),
+                    128 => Some("attnvec_f16kv_hd128"),
+                    _ => None,
+                };
+                let vec = !flash
+                    && f16
+                    && split
+                    && kv_len >= 128
+                    && vec_kern.is_some_and(|kn| {
+                        self.pipelines
+                            .get(kn)
+                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 1024)
+                            .unwrap_or(false)
+                    });
                 let split32 = split
+                    && !vec
                     && kv_len >= 128
                     && hd <= 128
                     && fits(
@@ -988,7 +1007,8 @@ impl MetalBackend {
                         1024,
                     )?;
                 let split = split
-                    && (split32
+                    && (vec
+                        || split32
                         || fits(
                             if f16 {
                                 "attnsplit_f16kv"
@@ -1000,6 +1020,7 @@ impl MetalBackend {
                 let kern = match (flash, f16, split, split32) {
                     (true, ..) if flash2 => flash2_kern.unwrap(),
                     (true, ..) => "attnflash_f16kv",
+                    (_, true, true, _) if vec => vec_kern.unwrap(),
                     (_, true, false, _) => "attention_f16kv",
                     (_, true, _, true) => "attnsplit32_f16kv",
                     (_, true, true, false) => "attnsplit_f16kv",
@@ -1038,9 +1059,9 @@ impl MetalBackend {
                         tgw,
                     );
                 } else {
-                    // One simdgroup per (query, head); split kernels use NSG simdgroups per
-                    // pair, grid still exactly rows*n_head threadgroups.
-                    let nsg = if split32 {
+                    // One simdgroup per (query, head); split/vec kernels use NSG simdgroups
+                    // per pair, grid still exactly rows*n_head threadgroups.
+                    let nsg = if vec || split32 {
                         32
                     } else if split {
                         8

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -81,6 +81,10 @@ pub struct MetalBackend {
     pub(crate) profiling: bool,
     pub(crate) prof_ops: bool,
     pub(crate) prof: std::sync::Mutex<profile::Profile>,
+    /// The recorded decode tape for the seam's record-once replay (`Capabilities::decode_replay`);
+    /// single slot, same single-generation lifetime as the weight caches (one backend per
+    /// generation, bindings stable across the decode loop).
+    pub(crate) replay: std::sync::Mutex<Option<exec::Tape>>,
 }
 
 // MTLDevice / MTLCommandQueue are documented thread-safe; the pipeline states are immutable after
@@ -102,6 +106,7 @@ impl MetalBackend {
             profiling: std::env::var("INFR_METAL_PROFILE").is_ok(),
             prof_ops: std::env::var("INFR_METAL_PROFILE").as_deref() == Ok("2"),
             prof: std::sync::Mutex::new(profile::Profile::default()),
+            replay: std::sync::Mutex::new(None),
         })
     }
 }
@@ -129,9 +134,11 @@ impl Backend for MetalBackend {
             // analogue of Vulkan's maxComputeSharedMemorySize (typically 32 KB, 64 KB on Apple GPUs).
             max_shared_memory_bytes: self.device.max_threadgroup_memory_length() as u32,
             unified_memory: self.device.has_unified_memory(),
-            // Like the CPU interpreter, this backend reads the baked `pos`/`kv_len` from the graph
-            // ops each execute, so the decode graph is rebuilt per token (no record-once replay).
-            decode_replay: false,
+            // Eligible decode graphs are recorded once as a flat dispatch tape and re-encoded
+            // per token, with position-dependent ops on dynamic-pos kernels that read the bound
+            // positions buffer (see `exec::Tape`). The engine may compile the decode graph once
+            // and re-execute it across the whole decode loop.
+            decode_replay: true,
         }
     }
 

--- a/crates/infr-metal/src/profile.rs
+++ b/crates/infr-metal/src/profile.rs
@@ -47,7 +47,7 @@ impl Profile {
         let total: Duration = self.per_op.values().map(|(_, d)| *d).sum();
         let total_s = total.as_secs_f64().max(1e-9);
         let mut rows: Vec<_> = self.per_op.iter().collect();
-        rows.sort_by(|a, b| b.1 .1.cmp(&a.1 .1));
+        rows.sort_by_key(|r| std::cmp::Reverse(r.1 .1));
 
         // Per-op GPU wall (populated only in per-op mode): the share of GPU time each op costs.
         let gpu_total: Duration = self.per_op_gpu.values().copied().sum();

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1111,7 +1111,7 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
     }
 }
 
-// ---- Cooperative flash attention for prefill (f16 KV cache, hd % 32 == 0, hd <= 128): the
+// ---- Cooperative flash attention for prefill (f16 KV cache, hd 64 or 128 instantiations): the
 // llama.cpp `kernel_flash_attn_ext` structure — NSG=4 simdgroups cooperate on ONE (8-query tile,
 // head) threadgroup, processing C=64 KV positions per iteration. The phases split the work along
 // different axes so every lane stays busy (the single-simdgroup attnflash_f16kv above stalls in
@@ -1130,25 +1130,25 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
 // P rounds through f32 shared and enters the V MMA as an f32 fragment against half V fragments.
 // Tail KV blocks read up to 7 rows past the causal limit (same in-buffer contract as above);
 // 8-row blocks entirely past it are skipped, so reads never go further.
-kernel void attnflash2_f16kv(device const half*  q   [[buffer(0)]],
-                             device const half*  k   [[buffer(1)]],
-                             device const half*  v   [[buffer(2)]],
-                             device float*       dst [[buffer(3)]],
-                             constant AttnParams& p  [[buffer(4)]],
-                             uint3  tgpig [[threadgroup_position_in_grid]],
-                             ushort sgitg [[simdgroup_index_in_threadgroup]],
-                             ushort tiisg [[thread_index_in_simdgroup]]) {
+template<uint hd>       // compile-time head_dim: fully unrolled QK/PV loops, exact shared sizing
+kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
+                               device const half*  k   [[buffer(1)]],
+                               device const half*  v   [[buffer(2)]],
+                               device float*       dst [[buffer(3)]],
+                               constant AttnParams& p  [[buffer(4)]],
+                               uint3  tgpig [[threadgroup_position_in_grid]],
+                               ushort sgitg [[simdgroup_index_in_threadgroup]],
+                               ushort tiisg [[thread_index_in_simdgroup]]) {
     constexpr uint QT = 8, C = 64, NSG = 4, NQ = QT / NSG, SH = C;
-    threadgroup half  sq[QT * 128];   // Q tile (rows x hd, half)
-    threadgroup float so[QT * 128];   // O accumulator (rows x hd, f32)
+    threadgroup half  sq[QT * hd];    // Q tile (rows x hd, half)
+    threadgroup float so[QT * hd];    // O accumulator (rows x hd, f32)
     threadgroup float ss[QT * SH];    // scores, then P, per KV block (rows x C, f32)
 
     uint ntq = (p.rows + QT - 1u) / QT;
     uint qt = tgpig.x % ntq;          // same-head tiles adjacent (SLC — see attnflash_f16kv)
     uint h  = tgpig.x / ntq;
-    uint hd = p.head_dim;
-    uint hd4 = hd / 4u;
-    uint no = hd / (8u * NSG);        // O column fragments owned per simdgroup (1..4)
+    constexpr uint hd4 = hd / 4u;
+    constexpr uint no = hd / (8u * NSG);   // O column fragments owned per simdgroup (2 or 4)
     uint kvh = h / (p.n_head / p.n_kv);
     uint r0 = qt * QT;
     uint abs0 = p.pos + r0;
@@ -1231,17 +1231,30 @@ kernel void attnflash2_f16kv(device const half*  q   [[buffer(0)]],
             threadgroup float* sot = so + 8u * sgitg;
             for (uint ii = 0; ii < no; ii++) simdgroup_load(lo[ii], sot + 8u * NSG * ii, hd);
             device const half* pv = v + ((ulong)ic * p.n_kv + kvh) * hd + 8u * sgitg;
-            for (uint cc = 0; cc < C / 8u; cc++) {
-                if (ic + 8u * cc <= abs_max) {
-                    simdgroup_float8x8 vs;
-                    simdgroup_load(vs, ss + 8u * cc, SH);
-                    for (uint ii = 0; ii < no; ii++) {
-                        simdgroup_half8x8 mv;
-                        simdgroup_load(mv, pv + 8u * NSG * ii, kvstride);
-                        simdgroup_multiply_accumulate(lo[ii], vs, mv, lo[ii]);
-                    }
+            // only KV blocks up to the causal limit (P is zero past it, and skipping keeps
+            // reads within 7 rows); paired blocks keep 2 P and 2*no V loads in flight
+            uint nblk = min(C / 8u, (abs_max - ic) / 8u + 1u);
+            for (uint cc = 0; cc + 1u < nblk; cc += 2u) {
+                simdgroup_float8x8 vs[2];
+                simdgroup_load(vs[0], ss + 8u * cc, SH);
+                simdgroup_load(vs[1], ss + 8u * cc + 8u, SH);
+                for (uint ii = 0; ii < no; ii++) {
+                    simdgroup_half8x8 mv[2];
+                    simdgroup_load(mv[0], pv + 8u * NSG * ii, kvstride);
+                    simdgroup_load(mv[1], pv + 8u * NSG * ii + 8u * kvstride, kvstride);
+                    simdgroup_multiply_accumulate(lo[ii], vs[0], mv[0], lo[ii]);
+                    simdgroup_multiply_accumulate(lo[ii], vs[1], mv[1], lo[ii]);
                 }
-                pv += 8u * kvstride;
+                pv += 16u * kvstride;
+            }
+            if (nblk & 1u) {
+                simdgroup_float8x8 vs;
+                simdgroup_load(vs, ss + 8u * (nblk - 1u), SH);
+                for (uint ii = 0; ii < no; ii++) {
+                    simdgroup_half8x8 mv;
+                    simdgroup_load(mv, pv + 8u * NSG * ii, kvstride);
+                    simdgroup_multiply_accumulate(lo[ii], vs, mv, lo[ii]);
+                }
             }
             for (uint ii = 0; ii < no; ii++) simdgroup_store(lo[ii], sot + 8u * NSG * ii, hd);
         }
@@ -1258,6 +1271,10 @@ kernel void attnflash2_f16kv(device const half*  q   [[buffer(0)]],
         for (uint i = tiisg; i < hd4; i += 32u) out[i] = so4[i] * sc;
     }
 }
+
+typedef decltype(attnflash2_f16kv_t<64>) attnflash2_t;
+template [[host_name("attnflash2_f16kv_hd64")]]  kernel attnflash2_t attnflash2_f16kv_t<64>;
+template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_f16kv_t<128>;
 
 // ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
 // GPU so it stays in the batch (no host round-trip that would force a per-layer flush). The (half)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -443,14 +443,15 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
 // reference dequant dot, floating-point reassociated. This access pattern (4 blocks in flight per
 // simdgroup for Q4_K, contiguous 8-element runs per lane) is what the sub-block-scatter DEC16
 // GEMV left on the table.
-kernel void linear_q4k(device const float*  x     [[buffer(0)]],
-                       device const uchar*  codes [[buffer(1)]],
-                       device const uchar*  scm   [[buffer(2)]],
-                       device const uchar*  dd    [[buffer(3)]],
-                       device float*        dst   [[buffer(4)]],
-                       constant QLinParams& p     [[buffer(5)]],
-                       uint gid  [[thread_position_in_grid]],
-                       uint lane [[thread_index_in_simdgroup]]) {
+// Body shared by the plain GEMV and the fused-residual variant (`FADD`: dst = W·x + res, the
+// decode o_proj/down_proj + Add peephole — one dispatch and no sublayer-output round-trip).
+template<bool FADD>
+inline void linear_q4k_body(device const float*  x,
+                            device const uchar*  codes,
+                            device float*        dst,
+                            device const float*  res,
+                            constant QLinParams& p,
+                            uint gid, uint lane) {
     uint first_row = (gid / 32u) * 2u;
     if (first_row >= p.out_f) return;
     uint nb = p.in_f >> 8;                 // 256-element blocks per row
@@ -515,11 +516,11 @@ kernel void linear_q4k(device const float*  x     [[buffer(0)]],
     }
     for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
         float s = simd_sum(sumf[row]);
-        if (lane == 0u) dst[first_row + row] = s;
+        if (lane == 0u) dst[first_row + row] = FADD ? s + res[first_row + row] : s;
     }
 }
 
-kernel void linear_q6k(device const float*  x     [[buffer(0)]],
+kernel void linear_q4k(device const float*  x     [[buffer(0)]],
                        device const uchar*  codes [[buffer(1)]],
                        device const uchar*  scm   [[buffer(2)]],
                        device const uchar*  dd    [[buffer(3)]],
@@ -527,6 +528,27 @@ kernel void linear_q6k(device const float*  x     [[buffer(0)]],
                        constant QLinParams& p     [[buffer(5)]],
                        uint gid  [[thread_position_in_grid]],
                        uint lane [[thread_index_in_simdgroup]]) {
+    linear_q4k_body<false>(x, codes, dst, x, p, gid, lane);
+}
+kernel void linear_q4k_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    linear_q4k_body<true>(x, codes, dst, res, p, gid, lane);
+}
+
+template<bool FADD>
+inline void linear_q6k_body(device const float*  x,
+                            device const uchar*  codes,
+                            device float*        dst,
+                            device const float*  res,
+                            constant QLinParams& p,
+                            uint gid, uint lane) {
     uint first_row = (gid / 32u) * 2u;
     if (first_row >= p.out_f) return;
     uint nb = p.in_f >> 8;
@@ -581,8 +603,30 @@ kernel void linear_q6k(device const float*  x     [[buffer(0)]],
     }
     for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
         float s = simd_sum(sumf[row]);
-        if (lane == 0u) dst[first_row + row] = s;
+        if (lane == 0u) dst[first_row + row] = FADD ? s + res[first_row + row] : s;
     }
+}
+
+kernel void linear_q6k(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    linear_q6k_body<false>(x, codes, dst, x, p, gid, lane);
+}
+kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    linear_q6k_body<true>(x, codes, dst, res, p, gid, lane);
 }
 
 GEMV_KERNEL(linear_quik4, DEC16_K4)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -593,16 +593,18 @@ RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)
 RT_KERNEL(linear_q4k_rt, DEC16_Q4K)
 RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
-// Cooperative-tile half-fragment GEMM: one 32-row x 64-output tile per 128-thread THREADGROUP
-// (the HGEMM kernels above give each simdgroup a private tile with private staging). Per 16-wide
-// K step, threads 0..63 decode one output row's block each into the shared weight tile while
-// threads 64..127 stage the 32x16 x tile — the two run concurrently — then each simdgroup
-// consumes its 16-output slice against the SHARED x tile (x device traffic /4) with 8 independent
-// f32 accumulators. This is the mul_mm shape: more resident accumulators per threadgroup to hide
-// MMA latency, one x staging for four simdgroups. Requires out_f % 64 == 0 (every dense shape in
-// practice); others fall back to the per-simdgroup HGEMM.
+// Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
+// threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
+// measured and replaced): weights AND activations are staged into threadgroup memory as
+// CONTIGUOUS 8x8 half tiles (stride-8, conflict-free simdgroup_load; the weight tile is written
+// pre-transposed so no transposed loads), each thread dequantizes exactly one 16-element block
+// per K-step (128 threads = the whole 64x32 weight tile), and x is cast f32->f16 inline during
+// staging (no separate cast pass). Each simdgroup owns a 32-output x 16-token quadrant as 8 f32
+// accumulators; a partial token tile stages through threadgroup memory and row-guards the copy,
+// so every tile takes the MMA path. Requires out_f % 64 == 0 and in_f % 32 == 0; other shapes
+// fall back to the per-simdgroup HGEMM.
 #define CMM_KERNEL(NAME, DEC)                                                                     \
-kernel void NAME(device const half*   x     [[buffer(0)]],                                       \
+kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
                  device const uchar*  codes [[buffer(1)]],                                       \
                  device const uchar*  scm   [[buffer(2)]],                                       \
                  device const uchar*  dd    [[buffer(3)]],                                       \
@@ -612,69 +614,81 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
                  uint lane [[thread_index_in_simdgroup]],                                        \
                  uint sgid [[simdgroup_index_in_threadgroup]]) {                                 \
     uint tgix = gid / 128u;                                                                       \
-    uint ntm = (p.m + 31u) / 32u;                                                                 \
     uint nto = p.out_f / 64u;                                                                     \
+    uint ntm = (p.m + 31u) / 32u;                                                                 \
     if (tgix >= ntm * nto) return;                                                                \
-    uint tm = tgix / nto;                                                                         \
     uint to = tgix % nto;                                                                         \
-    uint r0 = tm * 32u;                                                                           \
-    uint o0 = to * 64u;                                                                           \
-    uint os = o0 + sgid * 16u;      /* this simdgroup's 16-output slice */                        \
-    uint nb = p.in_f >> 4;                                                                        \
+    uint tm = tgix / nto;                                                                         \
+    uint ro = to * 64u;                                                                           \
+    uint rt = tm * 32u;                                                                           \
     uint tid = sgid * 32u + lane;                                                                 \
-    threadgroup half tgX[32 * 16];                                                                \
-    threadgroup half tgW[64 * 16];                                                                \
-    if (r0 + 32u <= p.m) {                                                                        \
-        simdgroup_float8x8 acc[4][2];                                                             \
-        for (uint i = 0; i < 4u; i++)                                                             \
-            for (uint jx = 0; jx < 2u; jx++) acc[i][jx] = simdgroup_float8x8(0.0f);               \
-        for (uint kb = 0; kb < nb; kb++) {                                                        \
-            if (tid < 64u) {                                                                      \
-                ulong bi = (ulong)(o0 + tid) * nb + kb;                                           \
-                float wk[16];                                                                     \
-                DEC(wk)                                                                           \
-                for (uint k2 = 0; k2 < 16u; k2++) tgW[tid * 16u + k2] = (half)wk[k2];             \
-            } else {                                                                              \
-                uint t2 = tid - 64u;    /* 8 contiguous halfs each: 64 threads x 8 = 32x16 */     \
-                uint idx = t2 * 8u;                                                               \
-                uint rr = idx >> 4;                                                               \
-                uint e = idx & 15u;                                                               \
-                device const half* xs = x + (ulong)(r0 + rr) * p.in_f + ((ulong)kb << 4) + e;     \
-                for (uint i = 0; i < 8u; i++) tgX[idx + i] = xs[i];                               \
+    uint nr1 = min(32u, p.m - rt);                                                                \
+                                                                                                  \
+    threadgroup float shraw[2048];  /* 8 KB: sa(4K half) + sb(2K half); reused f32 for stores */  \
+    threadgroup half* sa = (threadgroup half*)shraw;                                              \
+    threadgroup half* sb = ((threadgroup half*)shraw) + 2048u;                                    \
+                                                                                                  \
+    uint lr0 = tid >> 1;                 /* weight (output) row 0..63 */                          \
+    uint il0 = tid & 1u;                 /* which 16-element half of the 32-K step */             \
+    uint lr1 = tid >> 2;                 /* token row 0..31 */                                    \
+    uint iyk = (tid & 3u) * 8u;          /* k offset within the 32-K step */                      \
+    uint lr1c = min(lr1, nr1 - 1u);      /* clamp token loads to the matrix edge */               \
+                                                                                                  \
+    simdgroup_half8x8 ma[4];                                                                      \
+    simdgroup_half8x8 mb[2];                                                                      \
+    simdgroup_float8x8 mc[8];                                                                     \
+    for (uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                               \
+                                                                                                  \
+    uint nb = p.in_f >> 4;                                                                        \
+    for (uint k0 = 0; k0 < p.in_f; k0 += 32u) {                                                   \
+        {   /* stage A: one 16-block per thread, into pre-transposed 8x8 tiles */                 \
+            ulong bi = (ulong)(ro + lr0) * nb + (ulong)(k0 >> 4) + il0;                           \
+            float wk[16];                                                                         \
+            DEC(wk)                                                                               \
+            uint sy = lr0 >> 3;                                                                   \
+            uint lx = lr0 & 7u;                                                                   \
+            for (uint i = 0; i < 16u; i++) {                                                      \
+                uint sx = 2u * il0 + (i >> 3);                                                    \
+                sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
             }                                                                                     \
-            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
-            for (uint kh = 0; kh < 2u; kh++) {                                                    \
-                simdgroup_half8x8 wb0, wb1;                                                       \
-                simdgroup_load(wb0, &tgW[(sgid * 16u) * 16u + kh * 8u], 16, ulong2(0, 0), true);  \
-                simdgroup_load(wb1, &tgW[(sgid * 16u + 8u) * 16u + kh * 8u], 16, ulong2(0, 0), true); \
-                for (uint rh = 0; rh < 4u; rh++) {                                                \
-                    simdgroup_half8x8 xa;                                                         \
-                    simdgroup_load(xa, &tgX[(rh * 8u) * 16u + kh * 8u], 16);                      \
-                    simdgroup_multiply_accumulate(acc[rh][0], xa, wb0, acc[rh][0]);               \
-                    simdgroup_multiply_accumulate(acc[rh][1], xa, wb1, acc[rh][1]);               \
-                }                                                                                 \
-            }                                                                                     \
-            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
         }                                                                                         \
-        for (uint rh = 0; rh < 4u; rh++)                                                          \
-            for (uint oh = 0; oh < 2u; oh++)                                                      \
-                simdgroup_store(acc[rh][oh],                                                      \
-                                dst + (ulong)(r0 + rh * 8u) * p.out_f + os + oh * 8u, p.out_f);   \
+        {   /* stage B: 8 activations per thread, f32 -> f16 inline */                            \
+            device const float* yy = x + (ulong)(rt + lr1c) * p.in_f + k0 + iyk;                  \
+            uint ib = 4u * (tid & 3u) + (lr1 >> 3);                                               \
+            uint ly = lr1 & 7u;                                                                   \
+            for (uint i = 0; i < 8u; i++) sb[64u * ib + 8u * ly + i] = (half)yy[i];               \
+        }                                                                                         \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
+        threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
+        for (uint ik = 0; ik < 4u; ik++) {                                                        \
+            for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
+            for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
+            for (uint i = 0; i < 8u; i++)                                                         \
+                simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
+            lsma += 8u * 64u;                                                                     \
+            lsmb += 4u * 64u;                                                                     \
+        }                                                                                         \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+    }                                                                                             \
+                                                                                                  \
+    if (rt + 32u <= p.m) {                                                                        \
+        device float* C = dst + (ro + 32u * (sgid & 1u)) +                                        \
+                          (ulong)(rt + 16u * (sgid >> 1)) * p.out_f;                              \
+        for (uint i = 0; i < 8u; i++)                                                             \
+            simdgroup_store(mc[i], C + 8u * (i & 3u) + 8u * p.out_f * (i >> 2), p.out_f);         \
     } else {                                                                                      \
-        /* partial row tile: scalar dot per (row, output) element on this simdgroup's slice */    \
-        for (uint e = lane; e < 512u; e += 32u) {                                                 \
-            uint rr = r0 + e / 16u;                                                               \
-            uint o = os + (e % 16u);                                                              \
-            if (rr >= p.m) continue;                                                              \
-            float a2 = 0.0f;                                                                      \
-            for (uint kb = 0; kb < nb; kb++) {                                                    \
-                ulong bi = (ulong)o * nb + kb;                                                    \
-                float wk[16];                                                                     \
-                DEC(wk)                                                                           \
-                device const half* xb = x + (ulong)rr * p.in_f + ((ulong)kb << 4);                \
-                for (uint k2 = 0; k2 < 16u; k2++) a2 += (float)xb[k2] * (float)((half)wk[k2]);    \
+        /* partial token tile: stage through threadgroup memory, row-guard the copy-out */        \
+        threadgroup float* tc = shraw + 32u * (sgid & 1u) + (16u * (sgid >> 1)) * 64u;            \
+        for (uint i = 0; i < 8u; i++)                                                             \
+            simdgroup_store(mc[i], tc + 8u * (i & 3u) + 8u * 64u * (i >> 2), 64u);                \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        if (sgid == 0u) {                                                                         \
+            for (uint j = lane; j < nr1; j += 32u) {                                              \
+                device float* d2 = dst + ro + (ulong)(rt + j) * p.out_f;                          \
+                threadgroup const float* c2 = shraw + j * 64u;                                    \
+                for (uint i = 0; i < 64u; i++) d2[i] = c2[i];                                     \
             }                                                                                     \
-            dst[(ulong)rr * p.out_f + o] = a2;                                                    \
         }                                                                                         \
     }                                                                                             \
 }

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1111,6 +1111,154 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
     }
 }
 
+// ---- Cooperative flash attention for prefill (f16 KV cache, hd % 32 == 0, hd <= 128): the
+// llama.cpp `kernel_flash_attn_ext` structure — NSG=4 simdgroups cooperate on ONE (8-query tile,
+// head) threadgroup, processing C=64 KV positions per iteration. The phases split the work along
+// different axes so every lane stays busy (the single-simdgroup attnflash_f16kv above stalls in
+// its scalar softmax, 8 of 32 lanes active, one phase per 16 KV):
+//   QK^T    — the 8 score fragments (64 KV cols x 8 queries) split across simdgroups, 2 each;
+//             K^T fragments load DIRECTLY from the f16 cache (transposed, no staging).
+//   softmax — split by query ROWS (2 rows per simdgroup); each row's 64 scores are one float2
+//             per lane, so all 32 lanes work; the online max/sum (M/S) stats live in that
+//             simdgroup's registers for the whole KV loop — no cross-simdgroup stat merges.
+//   P*V     — split by output COLUMNS (hd/32 8x8 O fragments per simdgroup) held in registers
+//             across the MMA, staged through threadgroup `so` only for the softmax rescale.
+// Masking is analytic (causal + window per row) — no mask buffer, no -inf staging; masked lanes
+// force pw=0, and M is floored at -MAXFLOAT/2 so an all-masked block leaves S/O untouched.
+// A partial final query tile zero-pads Q rows in shared memory and skips their output store
+// (the fallback serial path in attnflash_f16kv is not needed here). Score/O accumulation is f32;
+// P rounds through f32 shared and enters the V MMA as an f32 fragment against half V fragments.
+// Tail KV blocks read up to 7 rows past the causal limit (same in-buffer contract as above);
+// 8-row blocks entirely past it are skipped, so reads never go further.
+kernel void attnflash2_f16kv(device const half*  q   [[buffer(0)]],
+                             device const half*  k   [[buffer(1)]],
+                             device const half*  v   [[buffer(2)]],
+                             device float*       dst [[buffer(3)]],
+                             constant AttnParams& p  [[buffer(4)]],
+                             uint3  tgpig [[threadgroup_position_in_grid]],
+                             ushort sgitg [[simdgroup_index_in_threadgroup]],
+                             ushort tiisg [[thread_index_in_simdgroup]]) {
+    constexpr uint QT = 8, C = 64, NSG = 4, NQ = QT / NSG, SH = C;
+    threadgroup half  sq[QT * 128];   // Q tile (rows x hd, half)
+    threadgroup float so[QT * 128];   // O accumulator (rows x hd, f32)
+    threadgroup float ss[QT * SH];    // scores, then P, per KV block (rows x C, f32)
+
+    uint ntq = (p.rows + QT - 1u) / QT;
+    uint qt = tgpig.x % ntq;          // same-head tiles adjacent (SLC — see attnflash_f16kv)
+    uint h  = tgpig.x / ntq;
+    uint hd = p.head_dim;
+    uint hd4 = hd / 4u;
+    uint no = hd / (8u * NSG);        // O column fragments owned per simdgroup (1..4)
+    uint kvh = h / (p.n_head / p.n_kv);
+    uint r0 = qt * QT;
+    uint abs0 = p.pos + r0;
+    uint abs_max = p.pos + min(p.rows - 1u, r0 + QT - 1u);
+    uint lo_min = (p.window > 0u && abs0 + 1u > p.window) ? (abs0 + 1u - p.window) : 0u;
+    ulong qstride = (ulong)p.n_head * hd;
+    ulong kvstride = (ulong)p.n_kv * hd;
+
+    // stage Q rows to shared (zero rows past p.rows), zero the O accumulator
+    for (uint jj = 0; jj < NQ; jj++) {
+        uint j = jj * NSG + sgitg;
+        bool live = r0 + j < p.rows;
+        // clamp the dead-row pointer (a select may still speculate the load)
+        device const half4* q4 =
+            (device const half4*)(q + (ulong)min(r0 + j, p.rows - 1u) * qstride + (ulong)h * hd);
+        threadgroup half4*  sq4 = (threadgroup half4*)sq + j * hd4;
+        threadgroup float4* so4 = (threadgroup float4*)so + j * hd4;
+        for (uint i = tiisg; i < hd4; i += 32u) {
+            sq4[i] = live ? q4[i] : half4(0.0h);
+            so4[i] = float4(0.0f);
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float S[NQ] = {0.0f, 0.0f};
+    float M[NQ] = {-MAXFLOAT / 2, -MAXFLOAT / 2};
+
+    for (uint ic = lo_min & ~(C - 1u); ic <= abs_max; ic += C) {
+        // Q*K^T — 8 score fragments split across simdgroups (fragment f covers KV rows
+        // ic+8f, columns interleaved so each simdgroup's two fragments are NSG apart)
+        {
+            device const half* pk = k + ((ulong)(ic + 8u * sgitg) * p.n_kv + kvh) * hd;
+            threadgroup float* ps = ss + 8u * sgitg;
+            for (uint cc = 0; cc < 2u; cc++) {
+                simdgroup_float8x8 mqk = simdgroup_float8x8(0.0f);
+                if (ic + 8u * (sgitg + cc * NSG) <= abs_max) {
+                    for (uint i = 0; i < hd; i += 16u) {
+                        simdgroup_half8x8 mq, mk;
+                        simdgroup_load(mq, sq + i, hd);
+                        simdgroup_load(mk, pk + i, kvstride, ulong2(0, 0), true);
+                        simdgroup_multiply_accumulate(mqk, mq, mk, mqk);
+                        simdgroup_load(mq, sq + i + 8u, hd);
+                        simdgroup_load(mk, pk + i + 8u, kvstride, ulong2(0, 0), true);
+                        simdgroup_multiply_accumulate(mqk, mq, mk, mqk);
+                    }
+                }
+                simdgroup_store(mqk, ps, SH);
+                pk += (ulong)(8u * NSG) * kvstride;
+                ps += 8u * NSG;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // online softmax — rows split across simdgroups, 2 scores (one float2) per lane
+        for (uint jj = 0; jj < NQ; jj++) {
+            uint j = jj * NSG + sgitg;
+            uint absr = abs0 + j;   // rows past p.rows compute junk, never stored
+            uint lor = (p.window > 0u && absr + 1u > p.window) ? (absr + 1u - p.window) : 0u;
+            threadgroup float2* ss2 = (threadgroup float2*)(ss + j * SH);
+            float2 s2 = ss2[tiisg] * p.scale;
+            uint c0 = ic + 2u * tiisg;
+            bool v0 = (c0 >= lor) && (c0 <= absr);
+            bool v1 = (c0 + 1u >= lor) && (c0 + 1u <= absr);
+            float m = M[jj];
+            float mnew = simd_max(max(m, max(v0 ? s2.x : -MAXFLOAT / 2, v1 ? s2.y : -MAXFLOAT / 2)));
+            float ms = exp(m - mnew);
+            float pw0 = v0 ? exp(s2.x - mnew) : 0.0f;
+            float pw1 = v1 ? exp(s2.y - mnew) : 0.0f;
+            S[jj] = S[jj] * ms + simd_sum(pw0 + pw1);
+            M[jj] = mnew;
+            ss2[tiisg] = float2(pw0, pw1);
+            threadgroup float4* so4 = (threadgroup float4*)so + j * hd4;
+            for (uint i = tiisg; i < hd4; i += 32u) so4[i] *= ms;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // O += P*V — O column fragments split across simdgroups, held in registers; V fragments
+        // load directly from the f16 cache; fully-causal-masked 8-row KV blocks skipped (their
+        // P is all zero, and skipping keeps reads within 7 rows of the limit)
+        {
+            simdgroup_float8x8 lo[4];
+            threadgroup float* sot = so + 8u * sgitg;
+            for (uint ii = 0; ii < no; ii++) simdgroup_load(lo[ii], sot + 8u * NSG * ii, hd);
+            device const half* pv = v + ((ulong)ic * p.n_kv + kvh) * hd + 8u * sgitg;
+            for (uint cc = 0; cc < C / 8u; cc++) {
+                if (ic + 8u * cc <= abs_max) {
+                    simdgroup_float8x8 vs;
+                    simdgroup_load(vs, ss + 8u * cc, SH);
+                    for (uint ii = 0; ii < no; ii++) {
+                        simdgroup_half8x8 mv;
+                        simdgroup_load(mv, pv + 8u * NSG * ii, kvstride);
+                        simdgroup_multiply_accumulate(lo[ii], vs, mv, lo[ii]);
+                    }
+                }
+                pv += 8u * kvstride;
+            }
+            for (uint ii = 0; ii < no; ii++) simdgroup_store(lo[ii], sot + 8u * NSG * ii, hd);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // O / S — same row split as the softmax (that simdgroup holds the row's S)
+    for (uint jj = 0; jj < NQ; jj++) {
+        uint j = jj * NSG + sgitg;
+        if (r0 + j >= p.rows) continue;
+        float sc = S[jj] == 0.0f ? 0.0f : 1.0f / S[jj];
+        device float4* out = (device float4*)(dst + ((ulong)(r0 + j)) * qstride + (ulong)h * hd);
+        threadgroup const float4* so4 = (threadgroup const float4*)so + j * hd4;
+        for (uint i = tiisg; i < hd4; i += 32u) out[i] = so4[i] * sc;
+    }
+}
+
 // ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
 // GPU so it stays in the batch (no host round-trip that would force a per-layer flush). The (half)
 // cast is IEEE round-to-nearest-even — byte-identical to the host `f16::from_f32` reference.

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -739,7 +739,7 @@ kernel void rope_f32(device const float* x   [[buffer(0)]],
 struct QkRopeParams { uint rows; uint n_head; uint head_dim; uint rope_dim; float theta; float eps; uint has_ff; };
 kernel void qknormrope_f32(device const float* x   [[buffer(0)]],
                            device const float* w   [[buffer(1)]],
-                           device const float* pos [[buffer(2)]],
+                           device const int*   pos [[buffer(2)]],
                            device const float* ff  [[buffer(3)]],
                            device float*       dst [[buffer(4)]],
                            constant QkRopeParams& p [[buffer(5)]],
@@ -754,7 +754,7 @@ kernel void qknormrope_f32(device const float* x   [[buffer(0)]],
     ss = simd_sum(ss) / (float)p.head_dim;
     float s = 1.0f / sqrt(ss + p.eps);
     uint hf = p.rope_dim / 2;
-    float p0 = pos[r];
+    float p0 = (float)pos[r];  // bound i32 read directly; exact widening
     for (uint pp = lane; pp < hf; pp += 32u) {
         uint i0 = pp, i1 = pp + hf;
         float ang = p0 * pow(p.theta, -2.0f * (float)pp / (float)p.rope_dim);
@@ -1290,27 +1290,30 @@ template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_
 // as attnsplit32, only reassociated). Tail positions clamp their row pointer to kv_len-1 and are
 // masked in the softmax, so reads never leave the cache. O accumulates in shared per simdgroup
 // (ty==0 lanes own hd/32 float4 columns each after the fold).
+// The body is a plain inline function so the static kernel (baked pos/kv_len from AttnParams)
+// and the DYNAMIC-POS kernel (pos read from the bound positions buffer — the decode-replay
+// contract, where one recorded dispatch is replayed every token) share it exactly.
 template<uint hd, uint NSG>
-kernel void attnvec_f16kv_t(device const float* q   [[buffer(0)]],
-                            device const half*  k   [[buffer(1)]],
-                            device const half*  v   [[buffer(2)]],
-                            device float*       dst [[buffer(3)]],
-                            constant AttnParams& p  [[buffer(4)]],
-                            uint3  tgpig [[threadgroup_position_in_grid]],
-                            ushort sgitg [[simdgroup_index_in_threadgroup]],
-                            ushort tiisg [[thread_index_in_simdgroup]]) {
+inline void attnvec_body(device const float* q,
+                         device const half*  k,
+                         device const half*  v,
+                         device float*       dst,
+                         constant AttnParams& p,
+                         uint abs, uint kvl,
+                         threadgroup float* sq,
+                         threadgroup float* ssc,
+                         threadgroup float* so,
+                         uint3  tgpig,
+                         ushort sgitg,
+                         ushort tiisg) {
     constexpr uint C = 32, NE = 4, NL = 32u / NE;  // 4 KV rows x 8-lane dots per simdgroup pass
     constexpr uint hd4 = hd / 4u;
     constexpr uint NI = hd4 / NL;                  // float4s per lane per row (2 or 4)
-    threadgroup float sq[hd];
-    threadgroup float ssc[NSG * C];                // per-simdgroup scores, then P; (S, M) at merge
-    threadgroup float so[NSG * hd];                // per-simdgroup O partials
 
     uint tg = tgpig.x;
     uint ti = tg / p.n_head;
     uint h  = tg % p.n_head;
     uint kvh = h / (p.n_head / p.n_kv);
-    uint abs = p.pos + ti;
     uint lo = (p.window > 0u && abs + 1u > p.window) ? (abs + 1u - p.window) : 0u;
     uint tx = tiisg % NL, ty = tiisg / NL;
 
@@ -1339,7 +1342,7 @@ kernel void attnvec_f16kv_t(device const float* q   [[buffer(0)]],
             float mqk[C / NE];
             for (uint cc = 0; cc < C / NE; cc++) {
                 // clamp tail rows into the cache; their scores are masked below
-                uint rc = min(ic + NE * cc + ty, p.kv_len - 1u);
+                uint rc = min(ic + NE * cc + ty, kvl - 1u);
                 device const half4* pk = k4 + ((ulong)rc * p.n_kv + kvh) * hd4;
                 float acc = 0.0f;
                 for (uint ii = 0; ii < NI; ii++)
@@ -1376,7 +1379,7 @@ kernel void attnvec_f16kv_t(device const float* q   [[buffer(0)]],
             float4 lov[NI];
             for (uint ii = 0; ii < NI; ii++) lov[ii] = float4(0.0f);
             for (uint cc = 0; cc < C / NE; cc++) {
-                uint rc = min(ic + NE * cc + ty, p.kv_len - 1u);
+                uint rc = min(ic + NE * cc + ty, kvl - 1u);
                 device const half4* pv = v4 + ((ulong)rc * p.n_kv + kvh) * hd4;
                 float pw = ss[NE * cc + ty];
                 for (uint ii = 0; ii < NI; ii++)
@@ -1417,9 +1420,48 @@ kernel void attnvec_f16kv_t(device const float* q   [[buffer(0)]],
     }
 }
 
+template<uint hd, uint NSG>
+kernel void attnvec_f16kv_t(device const float* q   [[buffer(0)]],
+                            device const half*  k   [[buffer(1)]],
+                            device const half*  v   [[buffer(2)]],
+                            device float*       dst [[buffer(3)]],
+                            constant AttnParams& p  [[buffer(4)]],
+                            uint3  tgpig [[threadgroup_position_in_grid]],
+                            ushort sgitg [[simdgroup_index_in_threadgroup]],
+                            ushort tiisg [[thread_index_in_simdgroup]]) {
+    threadgroup float sq[hd];
+    threadgroup float ssc[NSG * 32];               // per-simdgroup scores, then P; (S, M) at merge
+    threadgroup float so[NSG * hd];                // per-simdgroup O partials
+    uint abs = p.pos + tgpig.x / p.n_head;
+    attnvec_body<hd, NSG>(q, k, v, dst, p, abs, p.kv_len, sq, ssc, so, tgpig, sgitg, tiisg);
+}
+
+// Dynamic-pos variant for decode replay: `pos` comes from the bound positions buffer (updated by
+// the host every token) instead of the recorded AttnParams, whose baked pos/kv_len are stale by
+// the second replay. rows is 1 on this path, so kv_len is exactly pos + 1.
+template<uint hd, uint NSG>
+kernel void attnvec_dyn_f16kv_t(device const float* q    [[buffer(0)]],
+                                device const half*  k    [[buffer(1)]],
+                                device const half*  v    [[buffer(2)]],
+                                device float*       dst  [[buffer(3)]],
+                                device const int*   posb [[buffer(4)]],
+                                constant AttnParams& p   [[buffer(5)]],
+                                uint3  tgpig [[threadgroup_position_in_grid]],
+                                ushort sgitg [[simdgroup_index_in_threadgroup]],
+                                ushort tiisg [[thread_index_in_simdgroup]]) {
+    threadgroup float sq[hd];
+    threadgroup float ssc[NSG * 32];
+    threadgroup float so[NSG * hd];
+    uint abs = (uint)posb[0];
+    attnvec_body<hd, NSG>(q, k, v, dst, p, abs, abs + 1u, sq, ssc, so, tgpig, sgitg, tiisg);
+}
+
 typedef decltype(attnvec_f16kv_t<64, 32>) attnvec_t;
 template [[host_name("attnvec_f16kv_hd64")]]  kernel attnvec_t attnvec_f16kv_t<64, 32>;
 template [[host_name("attnvec_f16kv_hd128")]] kernel attnvec_t attnvec_f16kv_t<128, 32>;
+typedef decltype(attnvec_dyn_f16kv_t<64, 32>) attnvec_dyn_t;
+template [[host_name("attnvec_dyn_f16kv_hd64")]]  kernel attnvec_dyn_t attnvec_dyn_f16kv_t<64, 32>;
+template [[host_name("attnvec_dyn_f16kv_hd128")]] kernel attnvec_dyn_t attnvec_dyn_f16kv_t<128, 32>;
 
 // ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
 // GPU so it stays in the batch (no host round-trip that would force a per-layer flush). The (half)
@@ -1438,5 +1480,17 @@ kernel void writekv_f32(device const float* src   [[buffer(0)]],
                         uint gid [[thread_position_in_grid]]) {
     if (gid >= p.n) return;
     cache[p.base + gid] = src[gid];
+}
+// Dynamic-pos WriteKv for decode replay: the row offset is pos*row_stride with pos read from the
+// bound positions buffer per token (`base` in a recorded params blob would be stale). f16 cache
+// only (the replay gate requires it).
+struct WriteKvDynParams { uint n; uint row_stride; };
+kernel void writekv_dyn_f16(device const float* src   [[buffer(0)]],
+                            device half*        cache [[buffer(1)]],
+                            device const int*   posb  [[buffer(2)]],
+                            constant WriteKvDynParams& p [[buffer(3)]],
+                            uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.n) return;
+    cache[(uint)posb[0] * p.row_stride + gid] = (half)src[gid];
 }
 "#;

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1130,7 +1130,7 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
 // P rounds through f32 shared and enters the V MMA as an f32 fragment against half V fragments.
 // Tail KV blocks read up to 7 rows past the causal limit (same in-buffer contract as above);
 // 8-row blocks entirely past it are skipped, so reads never go further.
-template<uint hd>       // compile-time head_dim: fully unrolled QK/PV loops, exact shared sizing
+template<uint hd, uint NSG>   // compile-time head_dim + simdgroup count: fully unrolled, exact shared sizing
 kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
                                device const half*  k   [[buffer(1)]],
                                device const half*  v   [[buffer(2)]],
@@ -1139,7 +1139,7 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
                                uint3  tgpig [[threadgroup_position_in_grid]],
                                ushort sgitg [[simdgroup_index_in_threadgroup]],
                                ushort tiisg [[thread_index_in_simdgroup]]) {
-    constexpr uint QT = 8, C = 64, NSG = 4, NQ = QT / NSG, SH = C;
+    constexpr uint QT = 8, C = 64, NQ = QT / NSG, SH = C;
     threadgroup half  sq[QT * hd];    // Q tile (rows x hd, half)
     threadgroup float so[QT * hd];    // O accumulator (rows x hd, f32)
     threadgroup float ss[QT * SH];    // scores, then P, per KV block (rows x C, f32)
@@ -1148,7 +1148,8 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
     uint qt = tgpig.x % ntq;          // same-head tiles adjacent (SLC — see attnflash_f16kv)
     uint h  = tgpig.x / ntq;
     constexpr uint hd4 = hd / 4u;
-    constexpr uint no = hd / (8u * NSG);   // O column fragments owned per simdgroup (2 or 4)
+    constexpr uint no = hd / (8u * NSG);   // O column fragments owned per simdgroup
+    constexpr uint NC = (C / 8u) / NSG;    // score fragments owned per simdgroup
     uint kvh = h / (p.n_head / p.n_kv);
     uint r0 = qt * QT;
     uint abs0 = p.pos + r0;
@@ -1173,8 +1174,9 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    float S[NQ] = {0.0f, 0.0f};
-    float M[NQ] = {-MAXFLOAT / 2, -MAXFLOAT / 2};
+    float S[NQ];
+    float M[NQ];
+    for (uint jj = 0; jj < NQ; jj++) { S[jj] = 0.0f; M[jj] = -MAXFLOAT / 2; }
 
     for (uint ic = lo_min & ~(C - 1u); ic <= abs_max; ic += C) {
         // Q*K^T — 8 score fragments split across simdgroups (fragment f covers KV rows
@@ -1182,7 +1184,7 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
         {
             device const half* pk = k + ((ulong)(ic + 8u * sgitg) * p.n_kv + kvh) * hd;
             threadgroup float* ps = ss + 8u * sgitg;
-            for (uint cc = 0; cc < 2u; cc++) {
+            for (uint cc = 0; cc < NC; cc++) {
                 simdgroup_float8x8 mqk = simdgroup_float8x8(0.0f);
                 if (ic + 8u * (sgitg + cc * NSG) <= abs_max) {
                     for (uint i = 0; i < hd; i += 16u) {
@@ -1272,9 +1274,9 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
     }
 }
 
-typedef decltype(attnflash2_f16kv_t<64>) attnflash2_t;
-template [[host_name("attnflash2_f16kv_hd64")]]  kernel attnflash2_t attnflash2_f16kv_t<64>;
-template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_f16kv_t<128>;
+typedef decltype(attnflash2_f16kv_t<64, 4>) attnflash2_t;
+template [[host_name("attnflash2_f16kv_hd64")]]  kernel attnflash2_t attnflash2_f16kv_t<64, 4>;
+template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_f16kv_t<128, 4>;
 
 // ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
 // GPU so it stays in the batch (no host round-trip that would force a per-layer flush). The (half)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -434,11 +434,160 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
     }                                                                                             \
 }
 
+// Decode GEMV for the native K-quant formats, mul_mv shape (ported from llama.cpp's
+// kernel_mul_mv_q4_K_f32 / q6_K and adapted to our buffers): each simdgroup computes TWO output
+// rows; activations load once into registers and are reused across both rows, and the inner loop
+// is decode-free — masked integer nibble ops with the block scales applied once per group (Q4_K
+// splits the affine min out via pre-summed activations; the 1/256 and 1/16 factors are exact
+// power-of-two corrections for the high-nibble/high-byte lanes). Algebraically identical to the
+// reference dequant dot, floating-point reassociated. This access pattern (4 blocks in flight per
+// simdgroup for Q4_K, contiguous 8-element runs per lane) is what the sub-block-scatter DEC16
+// GEMV left on the table.
+kernel void linear_q4k(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    uint first_row = (gid / 32u) * 2u;
+    if (first_row >= p.out_f) return;
+    uint nb = p.in_f >> 8;                 // 256-element blocks per row
+    ulong row_b = (ulong)nb * 144ul;       // row stride in bytes
+    device const uchar* xr = codes + first_row * row_b;
+
+    const ushort kmask1 = 0x3f3f, kmask2 = 0x0f0f, kmask3 = 0xc0c0;
+    uint ix = lane >> 3;                   // 0..3: which of 4 blocks in flight
+    uint it = lane & 7u;
+    uint iq = it >> 2;                     // 0/1: which 128-half
+    uint ir = it & 3u;                     // 0..3: which 8-element run
+
+    float yl[16], yh[16];
+    float sumf[2] = {0.0f, 0.0f};
+    device const float* y4 = x + ix * 256u + 64u * iq + 8u * ir;
+
+    ushort sc16[4];
+    thread const uchar* sc8 = (thread const uchar*)sc16;
+
+    for (uint ib = ix; ib < nb; ib += 4u) {
+        float4 sumy = float4(0.0f);
+        for (uint i = 0; i < 8u; i++) {
+            yl[i]      = y4[i];        sumy[0] += yl[i];
+            yl[i + 8u] = y4[i + 32u];  sumy[1] += yl[i + 8u];
+            yh[i]      = y4[i + 128u]; sumy[2] += yh[i];
+            yh[i + 8u] = y4[i + 160u]; sumy[3] += yh[i + 8u];
+        }
+        device const uchar* blk = xr + (ulong)ib * 144ul;
+        device const ushort* sc = (device const ushort*)(blk + 4u) + iq;
+        device const ushort* q1 = (device const ushort*)(blk + 16u) + 16u * iq + 4u * ir;
+        device const half* dh = (device const half*)blk;
+
+        for (uint row = 0; row < 2u; row++) {
+            sc16[0] = sc[0] & kmask1;
+            sc16[1] = sc[2] & kmask1;
+            sc16[2] = ((sc[4] >> 0) & kmask2) | ((sc[0] & kmask3) >> 2);
+            sc16[3] = ((sc[4] >> 4) & kmask2) | ((sc[2] & kmask3) >> 2);
+            device const ushort* q2 = q1 + 32u;
+            float4 acc1 = float4(0.0f);
+            float4 acc2 = float4(0.0f);
+            for (uint i = 0; i < 4u; i++) {
+                acc1[0] += yl[2u * i]      * (float)(q1[i] & 0x000F);
+                acc1[1] += yl[2u * i + 1u] * (float)(q1[i] & 0x0F00);
+                acc1[2] += yl[2u * i + 8u] * (float)(q1[i] & 0x00F0);
+                acc1[3] += yl[2u * i + 9u] * (float)(q1[i] & 0xF000);
+                acc2[0] += yh[2u * i]      * (float)(q2[i] & 0x000F);
+                acc2[1] += yh[2u * i + 1u] * (float)(q2[i] & 0x0F00);
+                acc2[2] += yh[2u * i + 8u] * (float)(q2[i] & 0x00F0);
+                acc2[3] += yh[2u * i + 9u] * (float)(q2[i] & 0xF000);
+            }
+            sumf[row] += (float)dh[0] * ((acc1[0] + 1.0f/256.0f * acc1[1]) * sc8[0] +
+                                         (acc1[2] + 1.0f/256.0f * acc1[3]) * sc8[1] * 1.0f/16.0f +
+                                         (acc2[0] + 1.0f/256.0f * acc2[1]) * sc8[4] +
+                                         (acc2[2] + 1.0f/256.0f * acc2[3]) * sc8[5] * 1.0f/16.0f) -
+                         (float)dh[1] * (sumy[0] * sc8[2] + sumy[1] * sc8[3] +
+                                         sumy[2] * sc8[6] + sumy[3] * sc8[7]);
+            q1 += row_b / 2u;
+            sc += row_b / 2u;
+            dh += row_b / 2u;
+        }
+        y4 += 4u * 256u;
+    }
+    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
+        float s = simd_sum(sumf[row]);
+        if (lane == 0u) dst[first_row + row] = s;
+    }
+}
+
+kernel void linear_q6k(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    uint first_row = (gid / 32u) * 2u;
+    if (first_row >= p.out_f) return;
+    uint nb = p.in_f >> 8;
+    ulong row_b = (ulong)nb * 210ul;
+    device const uchar* xr = codes + first_row * row_b;
+
+    const uchar kmask1 = 0x03, kmask2 = 0x0C, kmask3 = 0x30, kmask4 = 0xC0;
+    uint tid2 = lane >> 1;
+    uint ix = lane & 1u;                   // 0/1: which of 2 blocks in flight
+    uint ip = tid2 >> 3;                   // 0/1: which 128-half
+    uint il = tid2 & 7u;
+    uint l0 = 4u * il;
+    uint is = 8u * ip + (l0 >> 4);
+    uint y_off = 128u * ip + l0;
+    uint ql_off = 64u * ip + l0;
+    uint qh_off = 32u * ip + l0;
+
+    float sumf[2] = {0.0f, 0.0f};
+    float yl[16];
+
+    for (uint i = ix; i < nb; i += 2u) {
+        device const uchar* blk = xr + (ulong)i * 210ul;
+        device const uchar* q1 = blk + ql_off;
+        device const uchar* q2 = q1 + 32u;
+        device const uchar* qh = blk + 128u + qh_off;
+        device const char* sc = (device const char*)(blk + 192u) + is;
+        device const half* dh = (device const half*)(blk + 208u);
+        device const float* y = x + i * 256u + y_off;
+
+        for (uint l = 0; l < 4u; l++) {
+            yl[4u * l]      = y[l];
+            yl[4u * l + 1u] = y[l + 32u];
+            yl[4u * l + 2u] = y[l + 64u];
+            yl[4u * l + 3u] = y[l + 96u];
+        }
+        for (uint row = 0; row < 2u; row++) {
+            float4 sums = float4(0.0f);
+            for (uint l = 0; l < 4u; l++) {
+                sums[0] += yl[4u * l]      * (float)((char)((q1[l] & 0xF) | ((qh[l] & kmask1) << 4)) - 32);
+                sums[1] += yl[4u * l + 1u] * (float)((char)((q2[l] & 0xF) | ((qh[l] & kmask2) << 2)) - 32);
+                sums[2] += yl[4u * l + 2u] * (float)((char)((q1[l] >> 4)  | ((qh[l] & kmask3) << 0)) - 32);
+                sums[3] += yl[4u * l + 3u] * (float)((char)((q2[l] >> 4)  | ((qh[l] & kmask4) >> 2)) - 32);
+            }
+            sumf[row] += (float)dh[0] * (sums[0] * sc[0] + sums[1] * sc[2] +
+                                         sums[2] * sc[4] + sums[3] * sc[6]);
+            q1 += row_b;
+            q2 += row_b;
+            qh += row_b;
+            sc += row_b;
+            dh += row_b / 2u;
+        }
+    }
+    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
+        float s = simd_sum(sumf[row]);
+        if (lane == 0u) dst[first_row + row] = s;
+    }
+}
+
 GEMV_KERNEL(linear_quik4, DEC16_K4)
 GEMV_KERNEL(linear_quik6, DEC16_K6)
 GEMV_KERNEL(linear_quik8, DEC16_K8)
-GEMV_KERNEL(linear_q4k, DEC16_Q4K)
-GEMV_KERNEL(linear_q6k, DEC16_Q6K)
 RT_KERNEL(linear_quik4_rt, DEC16_K4)
 RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -241,15 +241,16 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
         sc6 = (scb[jj + 4u] & 0x0Fu) | ((scb[jj - 4u] >> 6) << 4);                                \
         m6 = (scb[jj + 4u] >> 4) | ((scb[jj] >> 6) << 4);                                         \
     }                                                                                             \
-    float scale = d * (float)sc6;                                                                 \
+    /* high nibble stays in place (values 16x) and the scale absorbs the /16 — no per-element  */ \
+    /* shift/select, just a mask (the reference dequantize_q4_K trick)                         */ \
+    float scale = (hi != 0u ? d * (1.0f / 16.0f) : d) * (float)sc6;                               \
     float mn = -(dmin * (float)m6);                                                               \
+    uint nibmask = hi != 0u ? 0xF0F0F0F0u : 0x0F0F0F0Fu;                                          \
     device const uint* qw4 = (device const uint*)(blk + 16u + j * 32u + l0);                      \
     for (uint w = 0; w < 4u; w++) {                                                               \
-        uint u = qw4[w];                                                                          \
+        uint u = qw4[w] & nibmask;                                                                \
         for (uint k2 = 0; k2 < 4u; k2++) {                                                        \
-            uint byt = (u >> (8u * k2)) & 0xFFu;                                                  \
-            uint q = hi ? (byt >> 4) : (byt & 0xFu);                                              \
-            wk[w * 4u + k2] = scale * (float)q + mn;                                              \
+            wk[w * 4u + k2] = scale * (float)((u >> (8u * k2)) & 0xFFu) + mn;                     \
         }                                                                                         \
     }
 
@@ -271,16 +272,31 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
     float d = (float)as_type<half>((ushort)(blk[208] | ((ushort)blk[209] << 8)));                 \
     float scale = d * (float)(char)scs[h6 * 8u + (off >> 4) + is];                                \
     float mn = -32.0f * scale;                                                                    \
-    uint lb = is * 16u;                                                                           \
-    /* branch-free (lanes hold different `off`s; a 4-way if would serialize the simdgroup): */    \
-    /* ql byte at l (+32 for the odd 32-groups), low/high nibble by off>=64, qh bits at off/16 */ \
+    /* uint32-lane unpack (the reference dequantize_q6_K shape): four 32-bit combines cover the */ \
+    /* 16 codes, nibble/crumb selection folded into masks and power-of-two scale variants — all */ \
+    /* exact, so the value is bit-identical to the byte-at-a-time form this replaces            */ \
     uint qlo = (off & 32u);                                                                       \
-    uint nsh = (off >= 64u) ? 4u : 0u;                                                            \
     uint qhs = off >> 4;                                                                          \
-    for (uint k = 0; k < 16u; k++) {                                                              \
-        uint l = lb + k;                                                                          \
-        uint q = ((ql[l + qlo] >> nsh) & 0xFu) | (((qh[l] >> qhs) & 3u) << 4);                    \
-        wk[k] = scale * (float)q + mn;                                                            \
+    device const ushort* ql16 = (device const ushort*)ql + (qlo != 0u ? 16u : 0u) + 8u * is;      \
+    device const ushort* qh16 = (device const ushort*)qh + 8u * is;                               \
+    uint kmask1 = (off >= 64u) ? ((qhs > 4u) ? 0xC0C0C0C0u : 0x30303030u)                         \
+                               : ((qhs > 0u) ? 0x0C0C0C0Cu : 0x03030303u);                        \
+    uint kmask2 = (off >= 64u) ? 0xF0F0F0F0u : 0x0F0F0F0Fu;                                       \
+    float dl0 = scale;                                                                            \
+    float dl1 = dl0 * (1.0f / 256.0f);                                                            \
+    float dl2 = dl1 * (1.0f / 256.0f);                                                            \
+    float dl3 = dl2 * (1.0f / 256.0f);                                                            \
+    uint shr_h = (qhs > 4u) ? 2u : 0u;                                                            \
+    uint shl_h = (off >= 64u) ? 0u : ((qhs > 0u) ? 2u : 4u);                                      \
+    uint shr_l = (off >= 64u) ? 4u : 0u;                                                          \
+    for (uint i = 0; i < 4u; i++) {                                                               \
+        uint low  = ((uint)ql16[2u * i] | ((uint)ql16[2u * i + 1u] << 16)) & kmask2;              \
+        uint high = ((uint)qh16[2u * i] | ((uint)qh16[2u * i + 1u] << 16)) & kmask1;              \
+        uint q = ((high << shl_h) >> shr_h) | (low >> shr_l);                                     \
+        wk[4u * i]      = dl0 * (float)(q & 0xFFu)       + mn;                                    \
+        wk[4u * i + 1u] = dl1 * (float)(q & 0xFF00u)     + mn;                                    \
+        wk[4u * i + 2u] = dl2 * (float)(q & 0xFF0000u)   + mn;                                    \
+        wk[4u * i + 3u] = dl3 * (float)(q & 0xFF000000u) + mn;                                    \
     }
 
 // GEMV: one simdgroup (32 lanes) per output element; each lane decodes one 16-element block per

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -685,10 +685,18 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
                                                                                                   \
     uint nb = p.in_f >> 4;                                                                        \
     for (uint k0 = 0; k0 < p.in_f; k0 += 32u) {                                                   \
+        /* device reads + dequant FIRST, into registers — issued while the previous       */     \
+        /* iteration's MMA phase (other simdgroups) is still draining; the barrier below  */     \
+        /* orders only the threadgroup-memory stores (mul_mm does exactly this)           */     \
+        ulong bi = (ulong)(ro + lr0) * nb + (ulong)(k0 >> 4) + il0;                               \
+        float wk[16];                                                                             \
+        DEC(wk)                                                                                   \
+        device const float4* yy =                                                                 \
+            (device const float4*)(x + (ulong)(rt + lr1c) * p.in_f + k0 + iyk);                   \
+        float4 yv0 = yy[0];                                                                       \
+        float4 yv1 = yy[1];                                                                       \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
         {   /* stage A: one 16-block per thread, into pre-transposed 8x8 tiles */                 \
-            ulong bi = (ulong)(ro + lr0) * nb + (ulong)(k0 >> 4) + il0;                           \
-            float wk[16];                                                                         \
-            DEC(wk)                                                                               \
             uint sy = lr0 >> 3;                                                                   \
             uint lx = lr0 & 7u;                                                                   \
             for (uint i = 0; i < 16u; i++) {                                                      \
@@ -696,25 +704,29 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
                 sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
             }                                                                                     \
         }                                                                                         \
-        {   /* stage B: 8 activations per thread, f32 -> f16 inline */                            \
-            device const float* yy = x + (ulong)(rt + lr1c) * p.in_f + k0 + iyk;                  \
+        {   /* stage B: 8 activations per thread, two vectorized f32->f16 half4 stores */         \
             uint ib = 4u * (tid & 3u) + (lr1 >> 3);                                               \
             uint ly = lr1 & 7u;                                                                   \
-            for (uint i = 0; i < 8u; i++) sb[64u * ib + 8u * ly + i] = (half)yy[i];               \
+            threadgroup half4* sb4 = (threadgroup half4*)(sb + 64u * ib + 8u * ly);               \
+            sb4[0] = half4(yv0);                                                                  \
+            sb4[1] = half4(yv1);                                                                  \
         }                                                                                         \
         threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
         threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
         threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
         for (uint ik = 0; ik < 4u; ik++) {                                                        \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
             for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
             for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
             for (uint i = 0; i < 8u; i++)                                                         \
                 simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
             lsma += 8u * 64u;                                                                     \
             lsmb += 4u * 64u;                                                                     \
         }                                                                                         \
-        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
     }                                                                                             \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                              \
                                                                                                   \
     if (rt + 32u <= p.m) {                                                                        \
         device float* C = dst + (ro + 32u * (sgid & 1u)) +                                        \

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -593,6 +593,98 @@ RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)
 RT_KERNEL(linear_q4k_rt, DEC16_Q4K)
 RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
+// Cooperative-tile half-fragment GEMM: one 32-row x 64-output tile per 128-thread THREADGROUP
+// (the HGEMM kernels above give each simdgroup a private tile with private staging). Per 16-wide
+// K step, threads 0..63 decode one output row's block each into the shared weight tile while
+// threads 64..127 stage the 32x16 x tile — the two run concurrently — then each simdgroup
+// consumes its 16-output slice against the SHARED x tile (x device traffic /4) with 8 independent
+// f32 accumulators. This is the mul_mm shape: more resident accumulators per threadgroup to hide
+// MMA latency, one x staging for four simdgroups. Requires out_f % 64 == 0 (every dense shape in
+// practice); others fall back to the per-simdgroup HGEMM.
+#define CMM_KERNEL(NAME, DEC)                                                                     \
+kernel void NAME(device const half*   x     [[buffer(0)]],                                       \
+                 device const uchar*  codes [[buffer(1)]],                                       \
+                 device const uchar*  scm   [[buffer(2)]],                                       \
+                 device const uchar*  dd    [[buffer(3)]],                                       \
+                 device float*        dst   [[buffer(4)]],                                       \
+                 constant QLinParams& p     [[buffer(5)]],                                       \
+                 uint gid  [[thread_position_in_grid]],                                          \
+                 uint lane [[thread_index_in_simdgroup]],                                        \
+                 uint sgid [[simdgroup_index_in_threadgroup]]) {                                 \
+    uint tgix = gid / 128u;                                                                       \
+    uint ntm = (p.m + 31u) / 32u;                                                                 \
+    uint nto = p.out_f / 64u;                                                                     \
+    if (tgix >= ntm * nto) return;                                                                \
+    uint tm = tgix / nto;                                                                         \
+    uint to = tgix % nto;                                                                         \
+    uint r0 = tm * 32u;                                                                           \
+    uint o0 = to * 64u;                                                                           \
+    uint os = o0 + sgid * 16u;      /* this simdgroup's 16-output slice */                        \
+    uint nb = p.in_f >> 4;                                                                        \
+    uint tid = sgid * 32u + lane;                                                                 \
+    threadgroup half tgX[32 * 16];                                                                \
+    threadgroup half tgW[64 * 16];                                                                \
+    if (r0 + 32u <= p.m) {                                                                        \
+        simdgroup_float8x8 acc[4][2];                                                             \
+        for (uint i = 0; i < 4u; i++)                                                             \
+            for (uint jx = 0; jx < 2u; jx++) acc[i][jx] = simdgroup_float8x8(0.0f);               \
+        for (uint kb = 0; kb < nb; kb++) {                                                        \
+            if (tid < 64u) {                                                                      \
+                ulong bi = (ulong)(o0 + tid) * nb + kb;                                           \
+                float wk[16];                                                                     \
+                DEC(wk)                                                                           \
+                for (uint k2 = 0; k2 < 16u; k2++) tgW[tid * 16u + k2] = (half)wk[k2];             \
+            } else {                                                                              \
+                uint t2 = tid - 64u;    /* 8 contiguous halfs each: 64 threads x 8 = 32x16 */     \
+                uint idx = t2 * 8u;                                                               \
+                uint rr = idx >> 4;                                                               \
+                uint e = idx & 15u;                                                               \
+                device const half* xs = x + (ulong)(r0 + rr) * p.in_f + ((ulong)kb << 4) + e;     \
+                for (uint i = 0; i < 8u; i++) tgX[idx + i] = xs[i];                               \
+            }                                                                                     \
+            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
+            for (uint kh = 0; kh < 2u; kh++) {                                                    \
+                simdgroup_half8x8 wb0, wb1;                                                       \
+                simdgroup_load(wb0, &tgW[(sgid * 16u) * 16u + kh * 8u], 16, ulong2(0, 0), true);  \
+                simdgroup_load(wb1, &tgW[(sgid * 16u + 8u) * 16u + kh * 8u], 16, ulong2(0, 0), true); \
+                for (uint rh = 0; rh < 4u; rh++) {                                                \
+                    simdgroup_half8x8 xa;                                                         \
+                    simdgroup_load(xa, &tgX[(rh * 8u) * 16u + kh * 8u], 16);                      \
+                    simdgroup_multiply_accumulate(acc[rh][0], xa, wb0, acc[rh][0]);               \
+                    simdgroup_multiply_accumulate(acc[rh][1], xa, wb1, acc[rh][1]);               \
+                }                                                                                 \
+            }                                                                                     \
+            threadgroup_barrier(mem_flags::mem_threadgroup);                                      \
+        }                                                                                         \
+        for (uint rh = 0; rh < 4u; rh++)                                                          \
+            for (uint oh = 0; oh < 2u; oh++)                                                      \
+                simdgroup_store(acc[rh][oh],                                                      \
+                                dst + (ulong)(r0 + rh * 8u) * p.out_f + os + oh * 8u, p.out_f);   \
+    } else {                                                                                      \
+        /* partial row tile: scalar dot per (row, output) element on this simdgroup's slice */    \
+        for (uint e = lane; e < 512u; e += 32u) {                                                 \
+            uint rr = r0 + e / 16u;                                                               \
+            uint o = os + (e % 16u);                                                              \
+            if (rr >= p.m) continue;                                                              \
+            float a2 = 0.0f;                                                                      \
+            for (uint kb = 0; kb < nb; kb++) {                                                    \
+                ulong bi = (ulong)o * nb + kb;                                                    \
+                float wk[16];                                                                     \
+                DEC(wk)                                                                           \
+                device const half* xb = x + (ulong)rr * p.in_f + ((ulong)kb << 4);                \
+                for (uint k2 = 0; k2 < 16u; k2++) a2 += (float)xb[k2] * (float)((half)wk[k2]);    \
+            }                                                                                     \
+            dst[(ulong)rr * p.out_f + o] = a2;                                                    \
+        }                                                                                         \
+    }                                                                                             \
+}
+
+CMM_KERNEL(linear_quik4_cmm, DEC16_K4)
+CMM_KERNEL(linear_quik6_cmm, DEC16_K6)
+CMM_KERNEL(linear_quik8_cmm, DEC16_K8)
+CMM_KERNEL(linear_q4k_cmm, DEC16_Q4K)
+CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
+
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
 HGEMM_KERNEL(linear_quik6_hmm, DEC16_K6)
 HGEMM_KERNEL(linear_quik8_hmm, DEC16_K8)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1278,6 +1278,149 @@ typedef decltype(attnflash2_f16kv_t<64, 4>) attnflash2_t;
 template [[host_name("attnflash2_f16kv_hd64")]]  kernel attnflash2_t attnflash2_f16kv_t<64, 4>;
 template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_f16kv_t<128, 4>;
 
+// ---- Vector flash attention for decode (f16 KV cache, hd 64 or 128, one query row per
+// threadgroup): the llama.cpp `kernel_flash_attn_ext_vec` structure. NSG simdgroups each own
+// interleaved C=32-position KV blocks with a PRIVATE online softmax, merged once at the end by a
+// log2 tree — same split-KV idea as attnsplit32 above, but each simdgroup step handles 32
+// positions instead of 1: lanes fold as (ty, tx) = 4 KV rows x 8-lane dots, a shuffle tree
+// reduces the 8 partials per row, and ONE simd_max/simd_sum softmax pass covers the whole block.
+// That cuts the serial chain per simdgroup from kv_len/NSG simd reductions to kv_len/(NSG*32)
+// block passes — the attnsplit kernels are latency-bound on exactly that chain at long context.
+// Q stays f32 in shared (no rounding: f32 dots over exactly-widened f16 K/V, same numeric class
+// as attnsplit32, only reassociated). Tail positions clamp their row pointer to kv_len-1 and are
+// masked in the softmax, so reads never leave the cache. O accumulates in shared per simdgroup
+// (ty==0 lanes own hd/32 float4 columns each after the fold).
+template<uint hd, uint NSG>
+kernel void attnvec_f16kv_t(device const float* q   [[buffer(0)]],
+                            device const half*  k   [[buffer(1)]],
+                            device const half*  v   [[buffer(2)]],
+                            device float*       dst [[buffer(3)]],
+                            constant AttnParams& p  [[buffer(4)]],
+                            uint3  tgpig [[threadgroup_position_in_grid]],
+                            ushort sgitg [[simdgroup_index_in_threadgroup]],
+                            ushort tiisg [[thread_index_in_simdgroup]]) {
+    constexpr uint C = 32, NE = 4, NL = 32u / NE;  // 4 KV rows x 8-lane dots per simdgroup pass
+    constexpr uint hd4 = hd / 4u;
+    constexpr uint NI = hd4 / NL;                  // float4s per lane per row (2 or 4)
+    threadgroup float sq[hd];
+    threadgroup float ssc[NSG * C];                // per-simdgroup scores, then P; (S, M) at merge
+    threadgroup float so[NSG * hd];                // per-simdgroup O partials
+
+    uint tg = tgpig.x;
+    uint ti = tg / p.n_head;
+    uint h  = tg % p.n_head;
+    uint kvh = h / (p.n_head / p.n_kv);
+    uint abs = p.pos + ti;
+    uint lo = (p.window > 0u && abs + 1u > p.window) ? (abs + 1u - p.window) : 0u;
+    uint tx = tiisg % NL, ty = tiisg / NL;
+
+    {
+        device const float4* q4 = (device const float4*)(q + ((ulong)ti * p.n_head + h) * hd);
+        threadgroup float4* sq4 = (threadgroup float4*)sq;
+        for (uint i = sgitg * 32u + tiisg; i < hd4; i += NSG * 32u) sq4[i] = q4[i];
+    }
+    threadgroup float* ss = ssc + sgitg * C;
+    threadgroup float4* so4 = (threadgroup float4*)so + sgitg * hd4;
+    if (ty == 0) {
+        for (uint ii = 0; ii < NI; ii++) so4[ii * NL + tx] = float4(0.0f);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float S = 0.0f, M = -MAXFLOAT / 2;
+    device const half4* k4 = (device const half4*)k;
+    device const half4* v4 = (device const half4*)v;
+    threadgroup const float4* sq4 = (threadgroup const float4*)sq;
+
+    for (uint ic = sgitg * C; ic <= abs; ic += NSG * C) {
+        if (ic + C <= lo) continue;   // whole block below the window (uniform per simdgroup)
+
+        // Q*K^T — each (ty, tx) fold: row ic + NE*cc + ty, 8-lane split of the hd dot
+        {
+            float mqk[C / NE];
+            for (uint cc = 0; cc < C / NE; cc++) {
+                // clamp tail rows into the cache; their scores are masked below
+                uint rc = min(ic + NE * cc + ty, p.kv_len - 1u);
+                device const half4* pk = k4 + ((ulong)rc * p.n_kv + kvh) * hd4;
+                float acc = 0.0f;
+                for (uint ii = 0; ii < NI; ii++)
+                    acc += dot(float4(pk[ii * NL + tx]), sq4[ii * NL + tx]);
+                // fold the 8 tx-lane partials of each row
+                acc += simd_shuffle_down(acc, 4);
+                acc += simd_shuffle_down(acc, 2);
+                acc += simd_shuffle_down(acc, 1);
+                mqk[cc] = simd_shuffle(acc, NL * ty);  // broadcast row sum within the ty group
+            }
+            ss[NE * tx + ty] = mqk[tx];  // lane (tx, ty) stores score of row ic + NE*tx + ty
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+
+        // online softmax — one pass over the whole 32-score block
+        {
+            float s = ss[tiisg] * p.scale;
+            uint jkv = ic + tiisg;
+            bool valid = (jkv >= lo) && (jkv <= abs);
+            float m = M;
+            M = simd_max(max(M, valid ? s : -MAXFLOAT / 2));
+            float ms = exp(m - M);
+            float vs = valid ? exp(s - M) : 0.0f;
+            S = S * ms + simd_sum(vs);
+            ss[tiisg] = vs;
+            if (ty == 0) {
+                for (uint ii = 0; ii < NI; ii++) so4[ii * NL + tx] *= ms;
+            }
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+
+        // O += P*V — same (ty, tx) fold as Q*K^T, accumulated into the ty==0 lanes' columns
+        {
+            float4 lov[NI];
+            for (uint ii = 0; ii < NI; ii++) lov[ii] = float4(0.0f);
+            for (uint cc = 0; cc < C / NE; cc++) {
+                uint rc = min(ic + NE * cc + ty, p.kv_len - 1u);
+                device const half4* pv = v4 + ((ulong)rc * p.n_kv + kvh) * hd4;
+                float pw = ss[NE * cc + ty];
+                for (uint ii = 0; ii < NI; ii++)
+                    lov[ii] += float4(pv[ii * NL + tx]) * pw;
+            }
+            for (uint ii = 0; ii < NI; ii++) {
+                lov[ii] += simd_shuffle_down(lov[ii], 16);
+                lov[ii] += simd_shuffle_down(lov[ii], 8);
+            }
+            if (ty == 0) {
+                for (uint ii = 0; ii < NI; ii++) so4[ii * NL + tx] += lov[ii];
+            }
+        }
+    }
+
+    // publish (S, M) for the merge (scores are dead)
+    if (tiisg == 0) { ss[0] = S; ss[1] = M; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // log2 merge of the per-simdgroup partials
+    for (uint rr = NSG / 2u; rr > 0u; rr >>= 1u) {
+        if (sgitg < rr) {
+            float s0 = ss[0], s1 = ssc[(sgitg + rr) * C + 0];
+            float m0 = ss[1], m1 = ssc[(sgitg + rr) * C + 1];
+            float mm = max(m0, m1);
+            float ms0 = exp(m0 - mm), ms1 = exp(m1 - mm);
+            if (tiisg == 0) { ss[0] = s0 * ms0 + s1 * ms1; ss[1] = mm; }
+            threadgroup float4* sob = (threadgroup float4*)so + (sgitg + rr) * hd4;
+            for (uint i = tiisg; i < hd4; i += 32u) so4[i] = so4[i] * ms0 + sob[i] * ms1;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (sgitg == 0) {
+        float sinv = ssc[0] == 0.0f ? 0.0f : 1.0f / ssc[0];
+        device float4* out = (device float4*)(dst + ((ulong)ti * p.n_head + h) * hd);
+        for (uint i = tiisg; i < hd4; i += 32u) out[i] = so4[i] * sinv;
+    }
+}
+
+typedef decltype(attnvec_f16kv_t<64, 32>) attnvec_t;
+template [[host_name("attnvec_f16kv_hd64")]]  kernel attnvec_t attnvec_f16kv_t<64, 32>;
+template [[host_name("attnvec_f16kv_hd128")]] kernel attnvec_t attnvec_f16kv_t<128, 32>;
+
 // ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
 // GPU so it stays in the batch (no host round-trip that would force a per-layer flush). The (half)
 // cast is IEEE round-to-nearest-even — byte-identical to the host `f16::from_f32` reference.

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -978,8 +978,11 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
     uint sg = gid / 32u;
     uint ntq = (p.rows + 7u) / 8u;
     if (sg >= ntq * p.n_head) return;
-    uint qt = sg / p.n_head;
-    uint h = sg % p.n_head;
+    /* same-head query tiles are ADJACENT simdgroups: concurrent tiles then stream the SAME
+       head's KV region and hit the SLC, instead of 16 heads' regions at once (measured: the
+       head-fastest order collapsed pp8k to ~1/3 of llama.cpp) */
+    uint qt = sg % ntq;
+    uint h = sg / ntq;
     uint group = p.n_head / p.n_kv;
     uint kvh = h / group;
     uint hd = p.head_dim;

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1016,7 +1016,8 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
         return;
     }
 
-    threadgroup half tgP[64];
+    threadgroup half tgP[128];
+    threadgroup float tgS16[128];
     threadgroup float tgD[64];
     threadgroup float tgM[8], tgL[8];
     uint abs0 = p.pos + r0;                 // row i sees positions <= abs0 + i
@@ -1032,16 +1033,23 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
     uint nfrag = hd / 8u;
     for (uint i = 0; i < nfrag; i++) oa[i] = simdgroup_float8x8(0.0f);
 
-    for (uint j0 = lo_min & ~7u; j0 <= abs_max; j0 += 8u) {
+    for (uint j0 = lo_min & ~15u; j0 <= abs_max; j0 += 16u) {
+        /* two 8-position score fragments per iteration: one scalar softmax phase and one
+           rescale per 16 KV positions instead of per 8 — the scalar phase and its barriers,
+           not KV bandwidth, are what this kernel waits on */
         device const half* kb = k + ((ulong)j0 * p.n_kv + kvh) * hd;
-        simdgroup_float8x8 sf = simdgroup_float8x8(0.0f);
+        simdgroup_float8x8 sf0 = simdgroup_float8x8(0.0f);
+        simdgroup_float8x8 sf1 = simdgroup_float8x8(0.0f);
         for (uint e0 = 0; e0 < hd; e0 += 8u) {
             simdgroup_half8x8 qa, kt;
             simdgroup_load(qa, qbase + e0, qstride);
             simdgroup_load(kt, kb + e0, kvstride, ulong2(0, 0), true);
-            simdgroup_multiply_accumulate(sf, qa, kt, sf);
+            simdgroup_multiply_accumulate(sf0, qa, kt, sf0);
+            simdgroup_load(kt, kb + 8u * kvstride + e0, kvstride, ulong2(0, 0), true);
+            simdgroup_multiply_accumulate(sf1, qa, kt, sf1);
         }
-        simdgroup_store(sf, tgD, 8);        // reuse tgD as the f32 score scratch
+        simdgroup_store(sf0, tgS16, 16);      // f32 score scratch, 8 rows x 16 cols
+        simdgroup_store(sf1, tgS16 + 8u, 16);
         simdgroup_barrier(mem_flags::mem_threadgroup);
         if (lane < 8u) {
             uint r = lane;
@@ -1049,18 +1057,18 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
             uint lor = (p.window > 0u && absr + 1u > p.window) ? (absr + 1u - p.window) : 0u;
             float mr = tgM[r];
             float mnew = mr;
-            float s[8];
-            for (uint c = 0; c < 8u; c++) {
+            float s[16];
+            for (uint c = 0; c < 16u; c++) {
                 uint j = j0 + c;
                 bool valid = (j >= lor) && (j <= absr);
-                s[c] = valid ? tgD[r * 8u + c] * p.scale : -INFINITY;
+                s[c] = valid ? tgS16[r * 16u + c] * p.scale : -INFINITY;
                 mnew = max(mnew, s[c]);
             }
             float corr = (mr == mnew) ? 1.0f : exp(mr - mnew);
             float lsum = 0.0f;
-            for (uint c = 0; c < 8u; c++) {
+            for (uint c = 0; c < 16u; c++) {
                 float pw = (s[c] == -INFINITY) ? 0.0f : exp(s[c] - mnew);
-                tgP[r * 8u + c] = (half)pw;
+                tgP[r * 16u + c] = (half)pw;
                 lsum += pw;
             }
             tgL[r] = tgL[r] * corr + lsum;
@@ -1069,16 +1077,19 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
         }
         simdgroup_barrier(mem_flags::mem_threadgroup);
         simdgroup_float8x8 df;
-        simdgroup_half8x8 pf;
+        simdgroup_half8x8 pf0, pf1;
         simdgroup_load(df, tgD, 8);
-        simdgroup_load(pf, tgP, 8);
+        simdgroup_load(pf0, tgP, 16);
+        simdgroup_load(pf1, tgP + 8u, 16);
         device const half* vb = v + ((ulong)j0 * p.n_kv + kvh) * hd;
         for (uint i = 0; i < nfrag; i++) {
             simdgroup_float8x8 tmp;
             simdgroup_multiply(tmp, df, oa[i]);
             simdgroup_half8x8 vf;
             simdgroup_load(vf, vb + i * 8u, kvstride);
-            simdgroup_multiply_accumulate(oa[i], pf, vf, tmp);
+            simdgroup_multiply_accumulate(tmp, pf0, vf, tmp);
+            simdgroup_load(vf, vb + 8u * kvstride + i * 8u, kvstride);
+            simdgroup_multiply_accumulate(oa[i], pf1, vf, tmp);
         }
         simdgroup_barrier(mem_flags::mem_threadgroup);
     }

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -329,7 +329,11 @@ fn check_linear_add_fusion(dtype: DType, wbytes: Vec<u8>, in_f: usize, out_f: us
         dst,
         n: out_f as u32,
     });
-    let bound = vec![(x, f32_bytes(&xs)), (w, wbytes.clone()), (rt, f32_bytes(&res))];
+    let bound = vec![
+        (x, f32_bytes(&xs)),
+        (w, wbytes.clone()),
+        (rt, f32_bytes(&res)),
+    ];
     // Reference: dequant the SAME bytes + f32 matmul + add (the CPU backend Q8-quantizes the
     // activation for quant Linear, so it is not the oracle here — same as the other quant tests).
     let wref = infr_gguf::dequant::dequant_block(dtype, &wbytes).unwrap();
@@ -1053,8 +1057,9 @@ fn attention_long_context_split32_hd96_parity() {
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn attention_vec_sliding_window_parity() {
-    let (rows, kv_len, nh, nkv, hd, pos, win) =
-        (1usize, 300usize, 8usize, 2usize, 64usize, 299usize, 100usize);
+    let (rows, kv_len, nh, nkv, hd, pos, win) = (
+        1usize, 300usize, 8usize, 2usize, 64usize, 299usize, 100usize,
+    );
     let mut g = Graph::new();
     let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
     let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -303,6 +303,64 @@ fn synth_q6k(n_elem: usize, seed: u32) -> Vec<u8> {
     out
 }
 
+// Linear (m=1, K-quant) immediately followed by a residual Add: the backend's peephole fuses the
+// pair into `linear_*_add` (one dispatch, Add's dst written directly). Compare against the CPU
+// reference running the UNFUSED pair — the fusion must be invisible.
+fn check_linear_add_fusion(dtype: DType, wbytes: Vec<u8>, in_f: usize, out_f: usize) {
+    let xs = rand_f32(in_f, 91);
+    let res = rand_f32(out_f, 92);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![1, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], dtype));
+    let rt = g.input(TensorDesc::new(vec![out_f], DType::F32));
+    let mid = g.internal(TensorDesc::new(vec![1, out_f], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst: mid,
+        m: 1,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+    });
+    g.push(Op::Add {
+        a: mid,
+        b: rt,
+        dst,
+        n: out_f as u32,
+    });
+    let bound = vec![(x, f32_bytes(&xs)), (w, wbytes.clone()), (rt, f32_bytes(&res))];
+    // Reference: dequant the SAME bytes + f32 matmul + add (the CPU backend Q8-quantizes the
+    // activation for quant Linear, so it is not the oracle here — same as the other quant tests).
+    let wref = infr_gguf::dequant::dequant_block(dtype, &wbytes).unwrap();
+    let mut reference = ref_linear(&xs, &wref, 1, in_f, out_f);
+    for (o, r) in reference.iter_mut().zip(res.iter()) {
+        *o += r;
+    }
+    let mtl = run(
+        &MetalBackend::new().expect("metal backend"),
+        &g,
+        &bound,
+        dst,
+        out_f,
+    );
+    assert_close(&reference, &mtl, 1e-3, "linear+add fusion");
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_add_fusion_q4k_parity() {
+    let (in_f, out_f) = (512usize, 384usize);
+    check_linear_add_fusion(DType::Q4K, synth_q4k(out_f * in_f, 93), in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_add_fusion_q6k_parity() {
+    let (in_f, out_f) = (512usize, 384usize);
+    check_linear_add_fusion(DType::Q6K, synth_q6k(out_f * in_f, 94), in_f, out_f);
+}
+
 // Shared quant-Linear parity check: Metal dequants `wbytes` (via infr_gguf) and matmuls; compare to
 // a reference that dequants the SAME bytes and matmuls — isolates Metal's quant-weight path.
 fn check_quant_linear_parity(dtype: DType, wbytes: Vec<u8>, m: usize, in_f: usize, out_f: usize) {

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -821,6 +821,108 @@ fn attention_flash_matches_reference() {
     assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
 }
 
+// Same flash shape at hd = 72 (% 8 but not % 32): routes to the single-simdgroup flash kernel
+// (`attnflash_f16kv`), which the hd % 32 == 0 tests above no longer reach (those take the
+// cooperative `attnflash2_f16kv`).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_flash_hd72_matches_reference() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (17usize, 136usize, 8usize, 2usize, 72usize, 119usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::Causal,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 171))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 172))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 173))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
+// The cooperative flash kernel (`attnflash2_f16kv`) at the real model head size (hd = 128), with
+// a partial final query tile (rows = 17) and a KV length that lands mid-block (the kernel's
+// causal-skip keeps tail reads within 7 rows of the limit).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_flash2_hd128_matches_reference() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (17usize, 136usize, 8usize, 2usize, 128usize, 119usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::Causal,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 181))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 182))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 183))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
+// Sliding-window masking through the cooperative flash kernel: the analytic per-row window
+// lower bound must match the CPU reference (whole leading KV blocks fall below some rows'
+// windows but not others').
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_flash2_sliding_window_parity() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (17usize, 136usize, 8usize, 2usize, 128usize, 119usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::SlidingWindow(64),
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 191))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 192))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 193))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
 // Long-context decode shape (rows=1, kv_len >= 128, hd <= 128): routes to the 32-way split-KV
 // kernel (`attnsplit32_*`), which the short-kv tests above never reach.
 #[test]

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -923,8 +923,9 @@ fn attention_flash2_sliding_window_parity() {
     assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
 }
 
-// Long-context decode shape (rows=1, kv_len >= 128, hd <= 128): routes to the 32-way split-KV
-// kernel (`attnsplit32_*`), which the short-kv tests above never reach.
+// Long-context decode shape (rows=1, kv_len >= 128, hd=128): routes to the VECTOR flash kernel
+// (`attnvec_f16kv_hd128`) — 32 simdgroups, 32 KV positions per simdgroup step, log2 merge. The
+// kv_len=200 tail lands mid-block, exercising the clamped+masked tail rows.
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn attention_long_context_split32_parity() {
@@ -952,6 +953,73 @@ fn attention_long_context_split32_parity() {
         (q, f32_bytes(&rand_f32(rows * nh * hd, 51))),
         (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 52))),
         (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 53))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+// The 32-way split-KV kernel (`attnsplit32_*`) retained for head sizes without a vec-kernel
+// instantiation (hd=96 here): same long-context decode shape as above.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_long_context_split32_hd96_parity() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (1usize, 200usize, 8usize, 2usize, 96usize, 199usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::Causal,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 201))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 202))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 203))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+// Sliding-window decode at depth through the vector flash kernel: whole leading KV blocks fall
+// below the window (the kernel's block-skip), and the window edge lands mid-block.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_vec_sliding_window_parity() {
+    let (rows, kv_len, nh, nkv, hd, pos, win) =
+        (1usize, 300usize, 8usize, 2usize, 64usize, 299usize, 100usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::SlidingWindow(win),
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 211))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 212))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 213))),
     ];
     assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
 }

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -506,6 +506,38 @@ fn linear_q4k_gemm_matches_dequant_reference() {
     );
 }
 
+// out_f % 64 == 0 routes to the cooperative-tile GEMM (`linear_*_cmm`); m=40 covers one full
+// 32-row tile plus a partial one. Same f16-operand reference as the other GEMM tests.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4k_coop_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    check_quant_linear_parity_impl(
+        DType::Q4K,
+        synth_q4k(out_f * in_f, 32),
+        m,
+        in_f,
+        out_f,
+        1e-3,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q6k_coop_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    check_quant_linear_parity_impl(
+        DType::Q6K,
+        synth_q6k(out_f * in_f, 33),
+        m,
+        in_f,
+        out_f,
+        1e-3,
+        true,
+    );
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn linear_q6k_gemm_matches_dequant_reference() {

--- a/docs/METAL.md
+++ b/docs/METAL.md
@@ -11,16 +11,20 @@ that emerged and the measured reasoning behind it.
 
 | model | metric | infr-metal | llama.cpp | gap |
 | --- | --- | --- | --- | --- |
-| 0.6B | tg128 | 147 tok/s | 191 | 1.30× |
+| 0.6B | tg128 | 159 tok/s | 191 | 1.20× |
 | 0.6B | tg128 @ d16384 | 48.3 tok/s | 42.9 | **infr ahead** |
 | 0.6B | pp2048 | 3346 tok/s | 3748 | 1.12× |
 | 0.6B | pp8192 | 2167 tok/s | 2336 | 1.08× |
-| 4B | tg128 | 39.9 tok/s | 46.7 | 1.17× |
+| 4B | tg128 | 40.9 tok/s | 46.7 | 1.14× |
 | 4B | tg128 @ d16384 | 21.4 tok/s | 24.5 | 1.14× |
 | 4B | pp8192 | 422 tok/s | 488 | 1.16× |
 
-The remaining decode gap at short/moderate depth is per-token host cost (graph
-rebuild + encode per token), not kernel time — the decode-replay lever.
+Decode is weight-stream bound: the GEMV kernels run ~107 GB/s of a measured
+~133 GB/s read roofline, and the per-token host cost is ~0.2 ms (the recorded
+decode-replay tape re-encodes the whole forward with no graph walk). The
+remaining gap vs llama.cpp is effective-bandwidth tail (dispatch ramp on
+36-66 MB matrices + the serial small-op chain), not kernel structure — the
+mul_mv port matches their N_R0/N_SG configuration exactly.
 
 From the naive reference implementation: decode ~44×, prefill ~250×+. Model
 load is ~10× faster than the repack era and resident weight memory is the raw
@@ -151,7 +155,7 @@ GPU wall per op — costs the batching (analysis mode, not the fast path).
 
 ## Tests
 
-`tests/parity.rs` — 37 GPU parity tests vs the CPU reference: every op, and
+`tests/parity.rs` — 39 GPU parity tests vs the CPU reference: every op, and
 for quantized Linear every (format × kernel shape) pair including partial
 tiles; attention covers unsplit/split8/split32/flash/flash2/vec, sliding
 windows at both tile and block granularity, partial query tiles, and the
@@ -162,7 +166,9 @@ kept so the floors above stay reproducible.
 ## Negative results (measured — don't re-try without new evidence)
 
 - Op fusion / dispatch-count reduction: per-kernel overhead is ~1.2 µs; a fused
-  Add+RmsNorm measured nothing.
+  Add+RmsNorm measured nothing at prefill. (The decode Linear→Add residual
+  peephole — mirroring the Vulkan adapter — is the exception: +2.5% on 4B
+  decode, from removing a dependency stage per sublayer, not dispatch count.)
 - Row-tiled GEMV for prefill weight reuse: zero change — the SLC already
   absorbed the re-reads; the scalar pipeline's ~1:1 load:FMA ratio was the
   limit (hence MMA).

--- a/docs/METAL.md
+++ b/docs/METAL.md
@@ -1,19 +1,26 @@
 # infr-metal — Apple GPU backend architecture
 
-State as of 2026-07-02 (PRs #4/#5/#6). `crates/infr-metal` implements the same
+State as of 2026-07-02 (PRs #4/#5/#6 merged, #10 = the flash_attn_ext arc).
+`crates/infr-metal` implements the same
 `Backend` seam as `infr-cpu` and `infr-vulkan` on Apple's Metal API. It started
 as a correctness-first reference (per-op command buffers, dequant-to-f32
 everything) and was rebuilt profiling-first; this doc records the architecture
 that emerged and the measured reasoning behind it.
 
-## Numbers (M3 Pro 18-core, Qwen3 Q4_K_M, greedy, 889-token prompt)
+## Numbers (M3 Pro 18-core, Qwen3 Q4_K_M, `infr bench` vs `llama-bench`, same GGUF)
 
-| model | metric | infr-metal | llama.cpp (same GGUF/machine) | gap |
+| model | metric | infr-metal | llama.cpp | gap |
 | --- | --- | --- | --- | --- |
-| 0.6B | decode 360 tok | ~132 tok/s | 191 | 1.45× |
-| 0.6B | prefill 889 | ~2840 tok/s | 4191 | 1.48× |
-| 4B | decode 430 tok | 37.5 tok/s | 46.7 | 1.25× |
-| 4B | prefill 889 | ~498 tok/s | 630 | 1.27× |
+| 0.6B | tg128 | 147 tok/s | 191 | 1.30× |
+| 0.6B | tg128 @ d16384 | 48.3 tok/s | 42.9 | **infr ahead** |
+| 0.6B | pp2048 | 3346 tok/s | 3748 | 1.12× |
+| 0.6B | pp8192 | 2167 tok/s | 2336 | 1.08× |
+| 4B | tg128 | 39.9 tok/s | 46.7 | 1.17× |
+| 4B | tg128 @ d16384 | 21.4 tok/s | 24.5 | 1.14× |
+| 4B | pp8192 | 422 tok/s | 488 | 1.16× |
+
+The remaining decode gap at short/moderate depth is per-token host cost (graph
+rebuild + encode per token), not kernel time — the decode-replay lever.
 
 From the naive reference implementation: decode ~44×, prefill ~250×+. Model
 load is ~10× faster than the repack era and resident weight memory is the raw
@@ -82,11 +89,13 @@ owns a 32×16 quadrant as 8 f32 accumulators; partial token tiles stage through
 threadgroup memory with a row-guarded copy-out so every tile takes the MMA
 path.
 
-Precision policy: **decode is bit-exact** against `dequant_block` (same f32
-multiply sequence). Prefill GEMM rounds operands to f16 (~5e-4 relative, well
-under quantization error — the llama.cpp trade); its parity tests compare
-against a reference that rounds operands identically, keeping the tolerance at
-1e-3 instead of testing nothing with a loosened bound.
+Precision policy: **decode is algebraically identical to `dequant_block`, FP
+reassociation only** (the mul_mv-shape GEMV reconstructs the exact dequant
+values but reorders the f32 dot's summation; parity holds at 1e-4). Prefill
+GEMM rounds operands to f16 (~5e-4 relative, well under quantization error —
+the llama.cpp trade); its parity tests compare against a reference that rounds
+operands identically, keeping the tolerance at 1e-3 instead of testing nothing
+with a loosened bound.
 
 ## Attention routing
 
@@ -94,20 +103,36 @@ All scalar variants share `AttnParams` and an online-softmax core; routing is
 by launch shape because the scalar kernels are latency-bound on their serial
 O(kv_len) chain:
 
-- **`attnflash_f16kv`** — wide launches on an f16 cache (rows·n_head ≥ 128,
-  kv_len ≥ 64, hd ≤ 128, hd % 8 == 0): one simdgroup per (8-query tile, head).
-  K^T/V 8×8 fragments load DIRECTLY from the f16 cache (strided, transposed for
-  K), Q is cast once per op to f16, scores + output accumulate f32, the masked
-  online softmax runs scalar f32 on an 8×8 tile per 8-position KV block with
-  the row rescale as a diagonal f32 MMA. An earlier all-f32 flash kernel lost
-  to the scalar split (it staged K/V through 8 KB threadgroup tiles); zero
-  staging is what makes this one win. Tail blocks may read up to 7 rows past
-  the causal limit — always inside the bound cache buffer — and are masked.
-- **`attnsplit32_*` / `attnsplit_*`** — narrow launches (decode) and long
-  contexts: NSG (32 or 8) simdgroups per (query, head), each owning a strided
-  KV slice with a private online softmax, merged in threadgroup memory. The
-  32-way split fires when kv_len ≥ 128 and hd ≤ 128 (its accumulator needs
-  16 KB of threadgroup memory).
+- **`attnflash2_f16kv` (hd 64/128)** — the llama.cpp `kernel_flash_attn_ext`
+  structure for wide launches: NSG=4 simdgroups cooperate on ONE (8-query
+  tile, head) threadgroup over C=64 KV positions per iteration, each phase
+  split along a different axis (QK^T by KV columns with K^T direct from the
+  f16 cache; softmax by query rows, all 32 lanes on float2 scores, M/S stats
+  pinned in the owning simdgroup's registers; P·V by output columns with O
+  fragments held in registers). Analytic causal/window masking, zero-padded
+  partial query tiles. Templated over compile-time head_dim (hd=64/128
+  instantiations — the fully-unrolled loops were worth +38% alone); NSG=8
+  benched slower.
+- **`attnflash_f16kv`** — the single-simdgroup flash kernel, kept for
+  hd % 8 == 0 shapes outside the hd 64/128 instantiations: one simdgroup per
+  (8-query tile, head), K^T/V 8×8 fragments direct from the f16 cache, scalar
+  masked online softmax per 16-position KV block, diagonal-MMA row rescale.
+  An earlier all-f32 flash kernel lost to the scalar split (it staged K/V
+  through 8 KB threadgroup tiles); zero staging is what makes these win. Tail
+  blocks may read up to 7 rows past the causal limit — always inside the
+  bound cache buffer — and are masked.
+- **`attnvec_f16kv` (hd 64/128)** — the llama.cpp `kernel_flash_attn_ext_vec`
+  structure for long-context decode (kv_len ≥ 128): 32 simdgroups per
+  (query, head), each owning interleaved 32-position KV blocks with a private
+  online softmax — 4 KV rows × 8-lane dots per pass, shuffle-tree reduce, ONE
+  simd_max/simd_sum per block (the split kernels below run that chain once
+  per position and are latency-bound on it) — merged once at the end by a
+  log2 tree. Q stays f32 (parity 1e-4); tail rows clamp into the cache and
+  mask in the softmax.
+- **`attnsplit32_*` / `attnsplit_*`** — narrow launches and long contexts on
+  head sizes without a vec instantiation: NSG (32 or 8) simdgroups per
+  (query, head), each owning a strided KV slice with a private online
+  softmax, merged in threadgroup memory.
 - **`attention_*`** — the lean one-simdgroup-per-(query, head) kernel for
   short-context leftovers.
 
@@ -126,9 +151,11 @@ GPU wall per op — costs the batching (analysis mode, not the fast path).
 
 ## Tests
 
-`tests/parity.rs` — 30+ GPU parity tests vs the CPU reference: every op, and
+`tests/parity.rs` — 37 GPU parity tests vs the CPU reference: every op, and
 for quantized Linear every (format × kernel shape) pair including partial
-tiles; attention covers unsplit/split8/split32/flash and sliding window.
+tiles; attention covers unsplit/split8/split32/flash/flash2/vec, sliding
+windows at both tile and block granularity, partial query tiles, and the
+retained hd=72/96 routes.
 `tests/dispatch_overhead.rs`, `tests/gemv_bw.rs` — evidence probes (ignored),
 kept so the floors above stay reproducible.
 

--- a/docs/METAL.md
+++ b/docs/METAL.md
@@ -13,11 +13,12 @@ that emerged and the measured reasoning behind it.
 | --- | --- | --- | --- | --- |
 | 0.6B | tg128 | 159 tok/s | 191 | 1.20× |
 | 0.6B | tg128 @ d16384 | 48.3 tok/s | 42.9 | **infr ahead** |
-| 0.6B | pp2048 | 3346 tok/s | 3748 | 1.12× |
-| 0.6B | pp8192 | 2167 tok/s | 2336 | 1.08× |
+| 0.6B | pp2048 | 3543 tok/s | 3748 | 1.06× |
+| 0.6B | pp8192 | 2258 tok/s | 2336 | 1.03× |
 | 4B | tg128 | 40.9 tok/s | 46.7 | 1.14× |
 | 4B | tg128 @ d16384 | 21.4 tok/s | 24.5 | 1.14× |
-| 4B | pp8192 | 422 tok/s | 488 | 1.16× |
+| 4B | pp2048 | 576 tok/s | 608 | 1.06× |
+| 4B | pp8192 | 434 tok/s | 488 | 1.12× |
 
 Decode is weight-stream bound: the GEMV kernels run ~107 GB/s of a measured
 ~133 GB/s read roofline, and the per-token host cost is ~0.2 ms (the recorded
@@ -87,7 +88,12 @@ NK=32. The load-bearing piece is the **threadgroup-memory layout**: staged
 operands are contiguous 8×8 half tiles (weights written pre-transposed), so
 every `simdgroup_load` is stride-8 and conflict-free — tile size, barrier
 count, and decode width were each probed separately and none of them was the
-gap. Each thread dequantizes exactly one 16-block per K-step (128 threads = the
+gap. Two more mul_mm details each measured real wins later: the device reads +
+dequant issue BEFORE the barrier that drains the previous iteration's MMA
+(latency-hides behind compute, +5% 4B pp2048), and the DEC16 decoders use the
+reference dequantize shapes — in-place high nibble with the /16 folded into
+the scale (Q4_K), uint32-lane ql/qh combines (Q6_K) — bit-identical values,
+~+4% more. Each thread dequantizes exactly one 16-block per K-step (128 threads = the
 whole weight tile) and x is cast f32→f16 inline during staging. Each simdgroup
 owns a 32×16 quadrant as 8 f32 accumulators; partial token tiles stage through
 threadgroup memory with a row-guarded copy-out so every tile takes the MMA

--- a/docs/METAL.md
+++ b/docs/METAL.md
@@ -9,16 +9,18 @@ that emerged and the measured reasoning behind it.
 
 ## Numbers (M3 Pro 18-core, Qwen3 Q4_K_M, `infr bench` vs `llama-bench`, same GGUF)
 
+(One idle-machine run, both engines back-to-back, 2-3 reps each.)
+
 | model | metric | infr-metal | llama.cpp | gap |
 | --- | --- | --- | --- | --- |
-| 0.6B | tg128 | 159 tok/s | 191 | 1.20× |
-| 0.6B | tg128 @ d16384 | 48.3 tok/s | 42.9 | **infr ahead** |
-| 0.6B | pp2048 | 3543 tok/s | 3748 | 1.06× |
-| 0.6B | pp8192 | 2258 tok/s | 2336 | 1.03× |
-| 4B | tg128 | 40.9 tok/s | 46.7 | 1.14× |
-| 4B | tg128 @ d16384 | 21.4 tok/s | 24.5 | 1.14× |
-| 4B | pp2048 | 576 tok/s | 608 | 1.06× |
-| 4B | pp8192 | 434 tok/s | 488 | 1.12× |
+| 0.6B | tg128 | 158 tok/s | 193 | 1.23× |
+| 0.6B | tg128 @ d16384 | 49.7 tok/s | 46.6 | **infr ahead** |
+| 0.6B | pp2048 | 3508 tok/s | 3751 | 1.07× |
+| 0.6B | pp8192 | 2233 tok/s | 2342 | 1.05× |
+| 4B | tg128 | 40.5 tok/s | 46.6 | 1.15× |
+| 4B | tg128 @ d16384 | 21.8 tok/s | 24.4 | 1.12× |
+| 4B | pp2048 | 569 tok/s | 603 | 1.06× |
+| 4B | pp8192 | 455 tok/s | 489 | 1.07× |
 
 Decode is weight-stream bound: the GEMV kernels run ~107 GB/s of a measured
 ~133 GB/s read roofline, and the per-token host cost is ~0.2 ms (the recorded


### PR DESCRIPTION
Ports the two llama.cpp flash-attention kernel structures that dominate long-context cost. **Stacked on #9** (contains #8 + #9's commits; the last four commits are new — merge those first, or merge this one to take the whole stack). The depth sweep in #9 identified attention as 80% of pp8192 GPU time.

## Cooperative flash attention (prefill): `attnflash2_f16kv`

The `kernel_flash_attn_ext` structure — NSG=4 simdgroups cooperate on ONE (8-query tile, head) threadgroup over C=64 KV positions per iteration, with each phase split along a different axis so every lane stays busy (the previous single-simdgroup kernel stalled in its scalar softmax, 8 of 32 lanes active, one phase per 16 KV):

- **QK^T** — the 8 score fragments split across simdgroups; K^T fragments load directly from the f16 cache (transposed, no staging).
- **softmax** — split by query rows, one float2 per lane over the 64 scores, all 32 lanes active; each row's online max/sum stats stay pinned in the owning simdgroup's registers for the whole KV loop.
- **P·V** — split by output columns, O fragments held in registers; paired KV blocks keep 2 P + 2·no V loads in flight.

Masking is analytic (causal + sliding window per row) — no mask buffer. Partial query tiles zero-pad Q in shared memory (drops the serial fallback path). Templated over compile-time head_dim, instantiated hd=64/128 (fully unrolled loops); NSG=8 was benched and lost. Pipeline-cap gated at 128 threads; other head sizes keep the old flash kernel.

## Vector flash attention (decode): `attnvec_f16kv`

The `kernel_flash_attn_ext_vec` structure for long-context decode — same split-KV idea as `attnsplit32`, but each simdgroup step covers **32 KV positions instead of 1**: lanes fold as 4 KV rows × 8-lane dots with a shuffle-tree reduce, one simd_max/simd_sum softmax pass per block, log2 merge of per-simdgroup partials at the end. The split kernels were latency-bound on their per-position serial chain. Q stays f32 in shared — same numeric class as attnsplit32 (parity tol 1e-4, no rounding). Tail rows clamp their pointer into the cache and mask in the softmax. attnsplit32 retained for other head sizes and cap degradation.

## Numbers (M3 Pro, Q4_K_M, vs llama.cpp Metal on the same GGUF)

| metric | before | after | llama.cpp | gap |
|---|---|---|---|---|
| 0.6B pp8192 | 864 | **2167** | 2336 | 1.08x |
| 0.6B pp2048 | 1327 | **3346** | 3748 | 1.12x |
| 4B pp8192 | 278 | **422** | 488 | 1.16x |
| 0.6B tg128@d16384 | 25.5 | **48.3** | 42.9 | **infr wins** |
| 0.6B tg128@d4096 | 66.9 | **86.3** | 114.5 | 1.33x* |
| 4B tg128@d16384 | 14.9 | **21.4** | 24.5 | 1.14x |

\* remaining tg gap at moderate depth is per-token engine overhead (graph recompile per token — the parked decode-replay work), not the attention kernel.

Short-context decode and prefill unchanged. Parity suite grown to 37 GPU tests: flash2 at hd=64/128 + sliding window + partial tile, vec at depth + mid-block window edge + tail clamp, hd=72/96 shapes keep the old flash/split32 paths covered. E2E chat verified coherent on metal.
