### PR TITLE
feat(metal): device MoE path — expert-batched GEMVs off a GPU expert table

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -340,11 +340,20 @@ fn cmd_run(model: &str, message: Option<&str>) -> anyhow::Result<()> {
             Box::new(infr_llama::model::Qwen35Chat::new_metal(gguf.clone()))
         } else {
             eprintln!(
-                "[metal backend — dense/MoE forward on Apple GPU via the agnostic compute graph (reference)]"
+                "[metal backend — dense/MoE forward on Apple GPU via the agnostic compute graph, persistent KV session]"
             );
-            Box::new(infr_llama::model::CpuDenseChat::new_metal(
-                infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
-            ))
+            #[cfg(target_os = "macos")]
+            {
+                Box::new(infr_llama::model::MetalSeamChat::new(
+                    infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
+                ))
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                Box::new(infr_llama::model::CpuDenseChat::new_metal(
+                    infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
+                ))
+            }
         }
     } else if std::env::var("INFR_CPU").is_ok() {
         if is_q35 {
@@ -1418,9 +1427,18 @@ fn cmd_serve(model: &str, addr: &str) -> anyhow::Result<()> {
         };
         Some(Box::new(m))
     } else if std::env::var("INFR_METAL").is_ok() {
-        Some(Box::new(infr_llama::model::CpuDenseChat::new_metal(
-            infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
-        )))
+        #[cfg(target_os = "macos")]
+        {
+            Some(Box::new(infr_llama::model::MetalSeamChat::new(
+                infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
+            )))
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Some(Box::new(infr_llama::model::CpuDenseChat::new_metal(
+                infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
+            )))
+        }
     } else if std::env::var("INFR_CPU").is_ok() {
         Some(Box::new(infr_llama::model::CpuDenseChat::new(
             infr_llama::CpuModel::load(&gguf, tok.as_deref())?,

--- a/crates/infr-cpu/src/lib.rs
+++ b/crates/infr-cpu/src/lib.rs
@@ -2237,6 +2237,22 @@ fn cpu_buf(b: &dyn Buffer) -> &CpuBuffer {
         .expect("cpu backend: buffer is not a CpuBuffer (mixed backends?)")
 }
 
+/// Dequantize the first `need` elements of a Q8_0-block buffer (34 B / 32 elems, y = d*q).
+pub(crate) fn dequant_prefix_q8_0(bytes: &[u8], need: usize) -> Vec<f32> {
+    let mut out = Vec::with_capacity(need);
+    for b in 0..need.div_ceil(32) {
+        let off = b * 34;
+        let d = half::f16::from_le_bytes([bytes[off], bytes[off + 1]]).to_f32();
+        for i in 0..32 {
+            if out.len() == need {
+                break;
+            }
+            out.push(d * (bytes[off + 2 + i] as i8) as f32);
+        }
+    }
+    out
+}
+
 impl Backend for CpuBackend {
     fn name(&self) -> &str {
         "cpu"
@@ -2706,6 +2722,26 @@ impl Backend for CpuBackend {
                                 df[base + i] = half::f16::from_f32(s[i]).to_bits();
                             }
                         }
+                        DType::Q8_0 => {
+                            // Q8_0 blocks (34 B / 32 elems): d = amax/127 (stored f16), q =
+                            // round(x/d) — the llama.cpp quantize_row_q8_0 reference formula.
+                            // `base`/`n` are element counts and rows are 32-aligned (the runner
+                            // gates on it), so blocks never straddle a write.
+                            debug_assert!(base % 32 == 0 && n % 32 == 0);
+                            for b in 0..n / 32 {
+                                let src32 = &s[b * 32..b * 32 + 32];
+                                let amax = src32.iter().fold(0f32, |m, &v| m.max(v.abs()));
+                                let dq = amax / 127.0;
+                                let id = if dq != 0.0 { 1.0 / dq } else { 0.0 };
+                                let off = (base / 32 + b) * 34;
+                                let dh = half::f16::from_f32(dq).to_bits().to_le_bytes();
+                                d[off] = dh[0];
+                                d[off + 1] = dh[1];
+                                for (i, &v) in src32.iter().enumerate() {
+                                    d[off + 2 + i] = (v * id).round_ties_even() as i32 as i8 as u8;
+                                }
+                            }
+                        }
                         _ => {
                             let df: &mut [f32] = bytemuck::cast_slice_mut(&mut d);
                             df[base..base + n].copy_from_slice(&s[..n]);
@@ -2751,6 +2787,11 @@ impl Backend for CpuBackend {
                                     .map(|&x| half::f16::from_bits(x).to_f32())
                                     .collect()
                             };
+                            (f(&kguard), f(&vguard))
+                        }
+                        DType::Q8_0 => {
+                            // Dequant the valid prefix's Q8_0 blocks (y = d * q).
+                            let f = |b: &[u8]| -> Vec<f32> { crate::dequant_prefix_q8_0(b, need) };
                             (f(&kguard), f(&vguard))
                         }
                         _ => (

--- a/crates/infr-llama/src/cpu_backend.rs
+++ b/crates/infr-llama/src/cpu_backend.rs
@@ -476,6 +476,14 @@ pub(crate) fn generate_dense_backend(
             dt("ffn_gate.weight").is_some() && dt("ffn_gate.weight") == dt("ffn_up.weight")
         });
 
+    // INFR_KV_Q8=1 stores the KV cache as Q8_0 blocks (34 bytes / 32 elems — half the f16
+    // footprint and bandwidth); the CPU reference and the Metal backend read/write it, other
+    // backends keep f16. The graph decl carries the dtype either way, and the env is stable for
+    // the process, so a warm session and its rebuilt graphs always agree.
+    let kv_q8 = std::env::var("INFR_KV_Q8").is_ok()
+        && matches!(be.name(), "metal" | "cpu-reference")
+        && (0..c.n_layer).all(|l| (c.layer_n_kv(l) * c.layer_head_dim(l)) % 32 == 0);
+
     // ── one-time session init: weights, KV cache, per-step IO (skipped when `state` is warm) ──
     if state.is_none() {
         // ── upload weights in their NATIVE GGUF dtype (no host pre-dequant — the backend dequants
@@ -584,18 +592,24 @@ pub(crate) fn generate_dense_backend(
             wspecs.push((DType::F32, max_hd));
         }
 
-        // ── persistent KV cache buffers (f32), sized per-layer (gemma4 SWA layers are narrower) ───────
+        // ── persistent KV cache buffers, sized per-layer (gemma4 SWA layers are narrower) ───────
+        let kv_bytes = |elems: usize| {
+            if kv_q8 {
+                elems / 32 * 34
+            } else {
+                elems * 2
+            }
+        };
         let mut kbufs: Vec<Box<dyn Buffer>> = Vec::new();
         let mut vbufs: Vec<Box<dyn Buffer>> = Vec::new();
         for l in 0..c.n_layer {
             let kvrow_l = c.layer_n_kv(l) * c.layer_head_dim(l);
-            // f16 KV cache (2 bytes/elem) — matches the graph's f16 k_cache/v_cache decls.
             kbufs.push(
-                be.alloc(want_ctx * kvrow_l * 2, BufferUsage::Activations)
+                be.alloc(kv_bytes(want_ctx * kvrow_l), BufferUsage::Activations)
                     .map_err(|e| anyhow!("{e}"))?,
             );
             vbufs.push(
-                be.alloc(want_ctx * kvrow_l * 2, BufferUsage::Activations)
+                be.alloc(kv_bytes(want_ctx * kvrow_l), BufferUsage::Activations)
                     .map_err(|e| anyhow!("{e}"))?,
             );
         }
@@ -678,8 +692,10 @@ pub(crate) fn generate_dense_backend(
     let build = |batch: usize, start_pos: usize| -> (Graph, DecodeHandles) {
         let mut g = Graph::new();
         let f32d = |n: usize| TensorDesc::new(vec![n], DType::F32);
-        // KV cache is f16 — matches the GPU's f16 cache (halves memory, tightens CPU↔GPU parity).
-        let f16d = |n: usize| TensorDesc::new(vec![n], DType::F16);
+        // KV cache dtype: f16 by default (halves memory vs f32, tightens CPU↔GPU parity);
+        // Q8_0 when the runner enabled it (see `kv_q8` at the cache alloc).
+        let kvd = |n: usize| TensorDesc::new(vec![n], if kv_q8 { DType::Q8_0 } else { DType::F16 });
+        let f16d = kvd;
         let hidden = g.input(f32d(batch * ne));
         let positions = g.input(TensorDesc::new(vec![batch], DType::I32));
         let rope_freqs = rf_buf.as_ref().map(|(_, n)| g.input(f32d(*n)));

--- a/crates/infr-llama/src/cpu_backend.rs
+++ b/crates/infr-llama/src/cpu_backend.rs
@@ -482,7 +482,7 @@ pub(crate) fn generate_dense_backend(
     // the process, so a warm session and its rebuilt graphs always agree.
     let kv_q8 = std::env::var("INFR_KV_Q8").is_ok()
         && matches!(be.name(), "metal" | "cpu-reference")
-        && (0..c.n_layer).all(|l| (c.layer_n_kv(l) * c.layer_head_dim(l)) % 32 == 0);
+        && (0..c.n_layer).all(|l| (c.layer_n_kv(l) * c.layer_head_dim(l)).is_multiple_of(32));
 
     // ── one-time session init: weights, KV cache, per-step IO (skipped when `state` is warm) ──
     if state.is_none() {

--- a/crates/infr-llama/src/cpu_backend.rs
+++ b/crates/infr-llama/src/cpu_backend.rs
@@ -223,6 +223,39 @@ pub(crate) fn generate_dense_metal(
     max_new: usize,
     on_token: impl FnMut(u32),
 ) -> AResult<(Vec<u32>, GenStats)> {
+    generate_dense_metal_session(
+        mtl,
+        g,
+        cfg,
+        token_embd,
+        ple,
+        prompt,
+        max_new,
+        on_token,
+        &mut None,
+        prompt.len() + max_new + 1,
+        None,
+    )
+}
+
+/// Persistent-session Metal seam runner — the Metal twin of [`generate_dense_gpu_session`]:
+/// weights upload once into `state`, the KV cache is sized to `want_ctx`, and each call prefills
+/// only the suffix that differs from the tokens already materialized in the cache.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn generate_dense_metal_session(
+    mtl: &infr_metal::MetalBackend,
+    g: &Gguf,
+    cfg: &Config,
+    token_embd: &[f32],
+    ple: Option<&PerLayerEmbd>,
+    prompt: &[u32],
+    max_new: usize,
+    on_token: impl FnMut(u32),
+    state: &mut Option<SeamKv>,
+    want_ctx: usize,
+    constraint: Option<&mut crate::grammar::Constraint>,
+) -> AResult<(Vec<u32>, GenStats)> {
     generate_dense_backend(
         mtl,
         &|tb, dt, _n| {
@@ -239,9 +272,9 @@ pub(crate) fn generate_dense_metal(
         prompt,
         max_new,
         on_token,
-        &mut None,
-        prompt.len() + max_new + 1,
-        None,
+        state,
+        want_ctx,
+        constraint,
     )
 }
 

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -29,6 +29,17 @@ pub struct DenseVulkanSession {
     max_ctx: usize,
 }
 
+/// A persistent Metal seam session — the Apple-GPU twin of [`DenseVulkanSession`]: owns the
+/// backend, the uploaded weights + KV cache, and the token ids materialized in it, so every later
+/// [`CpuModel::generate_metal_session`] call prefills only the suffix that differs from the
+/// previous turn.
+#[cfg(target_os = "macos")]
+pub struct DenseMetalSession {
+    mtl: infr_metal::MetalBackend,
+    state: Option<crate::cpu_backend::SeamKv>,
+    max_ctx: usize,
+}
+
 impl CpuModel {
     /// Load a model for CPU inference without touching the GPU. `tokenizer_path` overrides the
     /// GGUF's embedded vocab when given.
@@ -175,6 +186,67 @@ impl CpuModel {
             &prompt,
             n_gen,
             |_| {},
+        )?;
+        Ok(stats)
+    }
+
+    /// Open a persistent Metal seam session (the Apple-GPU twin of
+    /// [`vulkan_session`](Self::vulkan_session)): weights uploaded ONCE, KV sized to `max_ctx`,
+    /// later calls prefill only the un-cached suffix.
+    #[cfg(target_os = "macos")]
+    pub fn metal_session(&self, max_ctx: usize) -> Result<DenseMetalSession> {
+        let mtl = infr_metal::MetalBackend::new().map_err(|e| anyhow!("metal init: {e}"))?;
+        Ok(DenseMetalSession {
+            mtl,
+            state: None,
+            max_ctx,
+        })
+    }
+
+    /// Greedy generation on the Metal seam through a persistent session (see
+    /// [`metal_session`](Self::metal_session)). `stats.n_prompt` reports the tokens actually
+    /// PREFILLED (the un-cached suffix) — the TTFT-honest count.
+    #[cfg(target_os = "macos")]
+    pub fn generate_metal_session(
+        &self,
+        session: &mut DenseMetalSession,
+        prompt: &str,
+        max_new: usize,
+        on_piece: impl FnMut(&str),
+    ) -> Result<crate::GenStats> {
+        self.generate_metal_session_constrained(session, prompt, max_new, None, on_piece)
+    }
+
+    /// [`generate_metal_session`](Self::generate_metal_session) with an optional llguidance
+    /// grammar constraint (serve's forced tool_choice) applied to the decode.
+    #[cfg(target_os = "macos")]
+    pub fn generate_metal_session_constrained(
+        &self,
+        session: &mut DenseMetalSession,
+        prompt: &str,
+        max_new: usize,
+        constraint: Option<&mut crate::grammar::Constraint>,
+        mut on_piece: impl FnMut(&str),
+    ) -> Result<crate::GenStats> {
+        let enc = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| anyhow!("encode: {e}"))?;
+        let prompt_tokens: Vec<u32> = enc.get_ids().to_vec();
+        let mut acc: Vec<u32> = Vec::new();
+        let mut printed = 0usize;
+        let (_generated, stats) = crate::cpu_backend::generate_dense_metal_session(
+            &session.mtl,
+            &self.gguf,
+            &self.cfg,
+            &self.token_embd,
+            self.per_layer_embd.as_ref(),
+            &prompt_tokens,
+            max_new,
+            |id| stream_token(&self.tokenizer, &mut acc, &mut printed, id, &mut on_piece),
+            &mut session.state,
+            session.max_ctx,
+            constraint,
         )?;
         Ok(stats)
     }

--- a/crates/infr-llama/src/model.rs
+++ b/crates/infr-llama/src/model.rs
@@ -467,6 +467,73 @@ impl ChatModel for DenseSeamChat {
     }
 }
 
+/// Metal seam backend for dense/MoE with a persistent session — the Apple-GPU twin of
+/// [`DenseSeamChat`]: weights upload once, the KV cache persists across turns, and each turn
+/// prefills only the suffix that differs from the previous rendered history.
+#[cfg(target_os = "macos")]
+pub struct MetalSeamChat {
+    model: CpuModel,
+    session: Option<crate::cpu_model::DenseMetalSession>,
+}
+
+#[cfg(target_os = "macos")]
+impl MetalSeamChat {
+    pub fn new(model: CpuModel) -> Self {
+        Self {
+            model,
+            session: None,
+        }
+    }
+
+    fn ensure_session(&mut self) -> Result<()> {
+        if self.session.is_none() {
+            let max_ctx = std::env::var("INFR_MAX_CTX")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(self.model.config().n_ctx_train);
+            self.session = Some(self.model.metal_session(max_ctx)?);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl ChatModel for MetalSeamChat {
+    fn render(&self, messages: &[(&str, &str)]) -> Result<String> {
+        self.model.render_chat_messages(messages)
+    }
+
+    fn generate(
+        &mut self,
+        prompt: &str,
+        max_new: usize,
+        on_piece: &mut dyn FnMut(&str),
+    ) -> Result<GenStats> {
+        self.ensure_session()?;
+        self.model
+            .generate_metal_session(self.session.as_mut().unwrap(), prompt, max_new, |p| {
+                on_piece(p)
+            })
+    }
+
+    fn generate_constrained(
+        &mut self,
+        prompt: &str,
+        max_new: usize,
+        constraint: &mut crate::grammar::Constraint,
+        on_piece: &mut dyn FnMut(&str),
+    ) -> Result<GenStats> {
+        self.ensure_session()?;
+        self.model.generate_metal_session_constrained(
+            self.session.as_mut().unwrap(),
+            prompt,
+            max_new,
+            Some(constraint),
+            |p| on_piece(p),
+        )
+    }
+}
+
 /// CPU reference backend (`INFR_CPU=1`) for dense/MoE: the agnostic compute-graph forward, no GPU.
 /// Stateless full-prefill each turn (no cross-turn KV yet), but the shared `Chat` now feeds the FULL
 /// rendered history in every turn, so multi-turn context works.

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1259,22 +1259,30 @@ impl MetalBackend {
                 );
                 let base = pos * rs;
                 let n = rows * rs;
+                let q8 = g.desc(cache).dtype == DType::Q8_0;
                 if let Some(posbuf) = r.posbuf.clone() {
                     // Recording a replay tape: the row offset must come from the positions buffer
-                    // (the baked `pos` is this token's only) — f16 cache guaranteed by the gate.
-                    let pso = self.pipelines.get("writekv_dyn_f16")?;
+                    // (the baked `pos` is this token's only) — f16/q8 cache guaranteed by the gate.
+                    let pso = self.pipelines.get(if q8 {
+                        "writekv_dyn_q8"
+                    } else {
+                        "writekv_dyn_f16"
+                    })?;
                     let mut p = (n as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(rs as u32).to_ne_bytes());
-                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw, &posbuf], &p, n);
+                    let threads = if q8 { n / 32 } else { n };
+                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw, &posbuf], &p, threads);
                 } else {
                     let kern = match g.desc(cache).dtype {
+                        DType::Q8_0 => "writekv_q8",
                         DType::F16 => "writekv_f16",
                         _ => "writekv_f32",
                     };
                     let pso = self.pipelines.get(kern)?;
                     let mut p = (n as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(base as u32).to_ne_bytes());
-                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw], &p, n);
+                    let threads = if q8 { n / 32 } else { n };
+                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw], &p, threads);
                 }
             }
             Op::Attention {
@@ -1347,6 +1355,54 @@ impl MetalBackend {
                         &p,
                         rows * nh * 32 * 32,
                         32 * 32,
+                    );
+                    r.loc[dst.0 as usize] = Loc::Device;
+                    return Ok(());
+                }
+                // Q8_0 cache: rows==1 decode takes the q8 vector kernel (hd 64/128); every
+                // other shape the scalar dequant-on-read fallback (prefill lives here until a
+                // q8 flash port). Both dequantize exactly — reassociation-only vs the f16 math.
+                if g.desc(k_cache).dtype == DType::Q8_0 {
+                    // Any row count: the vector kernel runs one threadgroup per (row, head),
+                    // so prefill rides it too (no q8 flash port yet — this is the split-KV
+                    // class, ~3-5x slower than flash2 at depth but 100x the scalar fallback).
+                    let vq8 = matches!(hd, 64 | 128) && kv_len >= 128 && {
+                        let kn = if hd == 64 {
+                            "attnvec_q8kv_hd64"
+                        } else {
+                            "attnvec_q8kv_hd128"
+                        };
+                        self.pipelines
+                            .get(kn)
+                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 1024)
+                            .unwrap_or(false)
+                    };
+                    let kern = if vq8 {
+                        if hd == 64 {
+                            "attnvec_q8kv_hd64"
+                        } else {
+                            "attnvec_q8kv_hd128"
+                        }
+                    } else {
+                        "attention_q8kv"
+                    };
+                    let pso = self.pipelines.get(kern)?;
+                    let mut p = (rows as u32).to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(kv_len as u32).to_ne_bytes());
+                    p.extend_from_slice(&(nh as u32).to_ne_bytes());
+                    p.extend_from_slice(&(nkv as u32).to_ne_bytes());
+                    p.extend_from_slice(&(hd as u32).to_ne_bytes());
+                    p.extend_from_slice(&scale.to_ne_bytes());
+                    p.extend_from_slice(&window.to_ne_bytes());
+                    p.extend_from_slice(&pos.to_ne_bytes());
+                    let nsg = if vq8 { 32 } else { 1 };
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[bq.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref()],
+                        &p,
+                        rows * nh * nsg * 32,
+                        nsg * 32,
                     );
                     r.loc[dst.0 as usize] = Loc::Device;
                     return Ok(());

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -169,7 +169,7 @@ fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
             Op::RmsNorm { .. } | Op::Linear { .. } | Op::GatedAct { .. } | Op::Add { .. } => {}
             Op::QkNormRope { .. } => has_rope = true,
             Op::WriteKv { cache, .. } => {
-                if g.desc(*cache).dtype != DType::F16 {
+                if !matches!(g.desc(*cache).dtype, DType::F16 | DType::Q8_0) {
                     return false;
                 }
             }
@@ -182,7 +182,7 @@ fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
                 has_attn = true;
                 if *rows != 1
                     || !matches!(*head_dim, 64 | 128)
-                    || g.desc(*k_cache).dtype != DType::F16
+                    || !matches!(g.desc(*k_cache).dtype, DType::F16 | DType::Q8_0)
                 {
                     return false;
                 }
@@ -491,8 +491,16 @@ impl MetalBackend {
         // gated on its pipeline cap — a capped device (CI paravirtual) keeps the per-token path.
         let dyn_cap_ok = || -> bool {
             let kern = g.ops.iter().find_map(|op| match op {
-                Op::Attention { head_dim: 64, .. } => Some("attnvec_dyn_f16kv_hd64"),
-                Op::Attention { head_dim: 128, .. } => Some("attnvec_dyn_f16kv_hd128"),
+                Op::Attention {
+                    head_dim: hd @ (64 | 128),
+                    k_cache,
+                    ..
+                } => Some(match (g.desc(*k_cache).dtype == DType::Q8_0, hd) {
+                    (false, 64) => "attnvec_dyn_f16kv_hd64",
+                    (false, _) => "attnvec_dyn_f16kv_hd128",
+                    (true, 64) => "attnvec_dyn_q8kv_hd64",
+                    (true, _) => "attnvec_dyn_q8kv_hd128",
+                }),
                 _ => None,
             });
             kern.is_some_and(|kn| {
@@ -1329,15 +1337,16 @@ impl MetalBackend {
                     infr_core::graph::AttnMask::SlidingWindow(w) => w as u32,
                 };
                 if let Some(posbuf) = r.posbuf.clone() {
-                    // Recording a replay tape (rows==1, f16 cache, hd 64/128 — checked by the
+                    // Recording a replay tape (rows==1, f16/q8 cache, hd 64/128 — checked by the
                     // gate): route straight to the dynamic-pos vector flash kernel, which reads
                     // pos from the positions buffer and covers every kv_len from 1 up. The usual
                     // shape routing below would bake this token's kv_len into the kernel CHOICE,
                     // which is exactly what a replayed tape can't have.
-                    let kern = if hd == 64 {
-                        "attnvec_dyn_f16kv_hd64"
-                    } else {
-                        "attnvec_dyn_f16kv_hd128"
+                    let kern = match (g.desc(k_cache).dtype == DType::Q8_0, hd) {
+                        (false, 64) => "attnvec_dyn_f16kv_hd64",
+                        (false, _) => "attnvec_dyn_f16kv_hd128",
+                        (true, 64) => "attnvec_dyn_q8kv_hd64",
+                        (true, _) => "attnvec_dyn_q8kv_hd128",
                     };
                     let pso = self.pipelines.get(kern)?;
                     let mut p = (rows as u32).to_ne_bytes().to_vec();

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -166,7 +166,11 @@ fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
     let mut has_attn = false;
     for op in &g.ops {
         match op {
-            Op::RmsNorm { .. } | Op::Linear { .. } | Op::GatedAct { .. } | Op::Add { .. } => {}
+            Op::RmsNorm { .. }
+            | Op::Linear { .. }
+            | Op::GatedAct { .. }
+            | Op::GatedActFused { .. }
+            | Op::Add { .. } => {}
             Op::QkNormRope { .. } => has_rope = true,
             Op::WriteKv { cache, .. } => {
                 if !matches!(g.desc(*cache).dtype, DType::F16 | DType::Q8_0) {
@@ -1240,10 +1244,28 @@ impl MetalBackend {
             }
             // Only produced when `Capabilities::combined_gu` is set — Metal leaves it false (the
             // reference backend keeps the separate gate/up form), so this arm is unreachable.
-            Op::GatedActFused { .. } => {
-                return Err(Error::Unsupported(
-                    "metal: GatedActFused unsupported (combined_gu is false)".into(),
-                ))
+            Op::GatedActFused {
+                gu,
+                dst,
+                rows,
+                nff,
+                act,
+            } => {
+                let (rows, nff) = (rows as usize, nff as usize);
+                let bg = self.ensure_device(r, gu);
+                let bd = self.dev_dst(r, dst, rows * nff);
+                let pso = self.pipelines.get("gatedactfused_f32")?;
+                let act_code: u32 = match act {
+                    infr_core::graph::Activation::Silu => 0,
+                    infr_core::graph::Activation::Gelu => 1,
+                    infr_core::graph::Activation::Sigmoid => 2,
+                };
+                let mut p = (rows as u32).to_ne_bytes().to_vec();
+                p.extend_from_slice(&(nff as u32).to_ne_bytes());
+                p.extend_from_slice(&act_code.to_ne_bytes());
+                p.extend_from_slice(&0u32.to_ne_bytes()); // pad to GatedParams
+                self.encode(r, &pso, &[bg.as_ref(), bd.as_ref()], &p, rows * nff);
+                r.loc[dst.0 as usize] = Loc::Device;
             }
             Op::WriteKv {
                 src,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1521,6 +1521,9 @@ impl MetalBackend {
                     n_used as usize,
                     n_ff_exp as usize,
                 );
+                // Rows inferred from the bound activation shape (the seam's batched prefill
+                // passes [rows, ne]); each row routes independently.
+                let rows = g.desc(x).numel() / ne;
                 // Device path for K-quant experts (the shapes real MoE checkpoints ship): router
                 // GEMV -> on-device top-k -> expert-BATCHED GEMV stages picking their weight
                 // slices from the device expert table, weighted sum via a final reduce. Seven
@@ -1547,12 +1550,14 @@ impl MetalBackend {
                     && moe_kern(ddt2).is_some();
                 if device_ok {
                     let bx = self.ensure_device(r, x);
-                    let bd = self.dev_dst(r, dst, ne);
-                    // Router logits: small f32 GEMV over the dequant-cached router weight.
+                    let bd = self.dev_dst(r, dst, rows * ne);
+                    // Router logits for ALL rows (one GEMV-per-(row, expert) dispatch over the
+                    // dequant-cached router weight), then per-row top-k into the [rows, 32]
+                    // expert table (idx in slots 0..16, f32 weights in 16..32).
                     let rw = self.weight_buf(router, g, bindings);
-                    let logits = self.scratch_buf(n_expert, 0);
+                    let logits = self.scratch_buf(rows * n_expert, 0);
                     let pso = self.pipelines.get("linear_f32")?;
-                    let mut p = 1u32.to_ne_bytes().to_vec();
+                    let mut p = (rows as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(ne as u32).to_ne_bytes());
                     p.extend_from_slice(&(n_expert as u32).to_ne_bytes());
                     self.encode_tg(
@@ -1560,102 +1565,243 @@ impl MetalBackend {
                         &pso,
                         &[bx.as_ref(), rw.as_ref(), logits.as_ref()],
                         &p,
-                        n_expert * 32,
+                        rows * n_expert * 32,
                         32,
                     );
-                    // Top-k + weights into the fixed 32-slot expert table.
-                    let tbl = self.scratch_buf(32, 1);
+                    let tbl = self.scratch_buf(rows * 32, 1);
                     let pso = self.pipelines.get("moe_topk")?;
                     let mut p = (n_expert as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(n_used as u32).to_ne_bytes());
                     p.extend_from_slice(&scale.to_ne_bytes());
-                    self.encode_tg(r, &pso, &[logits.as_ref(), tbl.as_ref()], &p, 32, 32);
-                    // Expert FFN, batched over the selected experts — one dispatch per stage
-                    // (gate, up, act, down, reduce), slots resolved from the table in-kernel.
+                    self.encode_tg(r, &pso, &[logits.as_ref(), tbl.as_ref()], &p, rows * 32, 32);
+                    // Expert FFN, batched over (chunk rows x selected experts) — one dispatch per
+                    // stage per chunk; chunking bounds the expert scratch (a full 8k-row prefill
+                    // would need ~0.5 GB of it).
                     let gq = self.weight_qui(gate_exps, g, bindings);
                     let uq = self.weight_qui(up_exps, g, bindings);
                     let dq = self.weight_qui(down_exps, g, bindings);
-                    let gate_t = self.scratch_buf(n_used * nffx, 2);
-                    let up_t = self.scratch_buf(n_used * nffx, 3);
-                    let act_t = self.scratch_buf(n_used * nffx, 4);
-                    let ydown = self.scratch_buf(n_used * ne, 5);
+                    const CHUNK: usize = 256;
+                    let chunk = rows.min(CHUNK);
+                    let gate_t = self.scratch_buf(chunk * n_used * nffx, 2);
+                    let up_t = self.scratch_buf(chunk * n_used * nffx, 3);
+                    let act_t = self.scratch_buf(chunk * n_used * nffx, 4);
+                    let ydown = self.scratch_buf(chunk * n_used * ne, 5);
                     let act_code: u32 = match act {
                         infr_core::graph::Activation::Silu => 0,
                         infr_core::graph::Activation::Gelu => 1,
                         infr_core::graph::Activation::Sigmoid => 2,
                     };
-                    let pack = |in_f: usize, out_f: usize| -> Vec<u8> {
+                    let pack = |in_f: usize, out_f: usize, row0: usize| -> Vec<u8> {
                         let mut p = 1u32.to_ne_bytes().to_vec();
                         p.extend_from_slice(&(in_f as u32).to_ne_bytes());
                         p.extend_from_slice(&(out_f as u32).to_ne_bytes());
                         p.extend_from_slice(&0u32.to_ne_bytes()); // dshift (native kernels)
                         p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                        p.extend_from_slice(&(row0 as u32).to_ne_bytes());
                         p
                     };
-                    let pso = self.pipelines.get(moe_kern(gdt2).unwrap().0)?;
-                    self.encode_tg(
-                        r,
-                        &pso,
-                        &[
-                            bx.as_ref(),
-                            &gq.codes,
-                            &gq.scm,
-                            &gq.dd,
-                            gate_t.as_ref(),
-                            tbl.as_ref(),
-                        ],
-                        &pack(ne, nffx),
-                        n_used * (nffx / 2) * 32,
-                        32,
-                    );
-                    let pso = self.pipelines.get(moe_kern(udt2).unwrap().0)?;
-                    self.encode_tg(
-                        r,
-                        &pso,
-                        &[
-                            bx.as_ref(),
-                            &uq.codes,
-                            &uq.scm,
-                            &uq.dd,
-                            up_t.as_ref(),
-                            tbl.as_ref(),
-                        ],
-                        &pack(ne, nffx),
-                        n_used * (nffx / 2) * 32,
-                        32,
-                    );
-                    let pso = self.pipelines.get("gatedact_f32")?;
-                    let mut p = (n_used as u32).to_ne_bytes().to_vec();
-                    p.extend_from_slice(&(nffx as u32).to_ne_bytes());
-                    p.extend_from_slice(&act_code.to_ne_bytes());
-                    p.extend_from_slice(&0u32.to_ne_bytes()); // up_off
-                    self.encode(
-                        r,
-                        &pso,
-                        &[gate_t.as_ref(), up_t.as_ref(), act_t.as_ref()],
-                        &p,
-                        n_used * nffx,
-                    );
-                    let pso = self.pipelines.get(moe_kern(ddt2).unwrap().1)?;
-                    self.encode_tg(
-                        r,
-                        &pso,
-                        &[
-                            act_t.as_ref(),
-                            &dq.codes,
-                            &dq.scm,
-                            &dq.dd,
-                            ydown.as_ref(),
-                            tbl.as_ref(),
-                        ],
-                        &pack(nffx, ne),
-                        n_used * (ne / 2) * 32,
-                        32,
-                    );
-                    let pso = self.pipelines.get("moe_reduce")?;
-                    let mut p = (ne as u32).to_ne_bytes().to_vec();
-                    p.extend_from_slice(&(n_used as u32).to_ne_bytes());
-                    self.encode(r, &pso, &[ydown.as_ref(), bd.as_ref()], &p, ne);
+                    // Expert-grouped GEMM for prefill-width rows (the llama.cpp mul_mm_id
+                    // shape): group the chunk's (token, slot) pairs by expert on-device, then
+                    // run the cooperative-GEMM tile per expert over its token group — MMA
+                    // compute instead of one GEMV per pair. Small row counts (decode) keep the
+                    // GEMV stages below.
+                    let grouped =
+                        rows >= 16 && ne % 64 == 0 && nffx % 64 == 0 && n_expert <= 1024 && {
+                            let kn = if gdt2 == DType::Q4K {
+                                "linear_q4k_cmm_id"
+                            } else {
+                                "linear_q6k_cmm_id"
+                            };
+                            self.pipelines
+                                .get(kn)
+                                .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                                .unwrap_or(false)
+                        };
+                    let ids = self.scratch_buf(n_expert * rows.min(CHUNK), 6);
+                    let tpe = self.scratch_buf(n_expert, 7);
+                    let cmm_id = |dt: DType, scale: bool| -> &'static str {
+                        match (dt, scale) {
+                            (DType::Q4K, false) => "linear_q4k_cmm_id",
+                            (DType::Q4K, true) => "linear_q4k_cmm_id_w",
+                            (DType::Q6K, false) => "linear_q6k_cmm_id",
+                            _ => "linear_q6k_cmm_id_w",
+                        }
+                    };
+                    for row0 in (0..rows).step_by(CHUNK) {
+                        let cr = (rows - row0).min(CHUNK);
+                        if grouped {
+                            let cap = rows.min(CHUNK);
+                            // map: one thread per expert scans the chunk's routing table
+                            let pso = self.pipelines.get("moe_map")?;
+                            let mut p = (n_expert as u32).to_ne_bytes().to_vec();
+                            p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                            p.extend_from_slice(&(cr as u32).to_ne_bytes());
+                            p.extend_from_slice(&(row0 as u32).to_ne_bytes());
+                            p.extend_from_slice(&(cap as u32).to_ne_bytes());
+                            self.encode_tg(
+                                r,
+                                &pso,
+                                &[tbl.as_ref(), ids.as_ref(), tpe.as_ref()],
+                                &p,
+                                n_expert,
+                                n_expert,
+                            );
+                            let ntt = cr.div_ceil(32);
+                            let idpack = |in_f: usize, out_f: usize| -> Vec<u8> {
+                                let mut p = (in_f as u32).to_ne_bytes().to_vec();
+                                p.extend_from_slice(&(out_f as u32).to_ne_bytes());
+                                p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                                p.extend_from_slice(&(cap as u32).to_ne_bytes());
+                                p.extend_from_slice(&(row0 as u32).to_ne_bytes());
+                                p.extend_from_slice(&(ntt as u32).to_ne_bytes());
+                                p
+                            };
+                            let gemm = |me: &Self,
+                                        r: &mut Resident,
+                                        kern: &'static str,
+                                        xb: &MtlBuffer,
+                                        q: &QuiWeight,
+                                        db: &MtlBuffer,
+                                        in_f: usize,
+                                        out_f: usize|
+                             -> Result<()> {
+                                let pso = me.pipelines.get(kern)?;
+                                me.encode_tg(
+                                    r,
+                                    &pso,
+                                    &[
+                                        xb,
+                                        &q.codes,
+                                        &q.scm,
+                                        &q.dd,
+                                        db,
+                                        ids.as_ref(),
+                                        tpe.as_ref(),
+                                        tbl.as_ref(),
+                                    ],
+                                    &idpack(in_f, out_f),
+                                    n_expert * ntt * (out_f / 64) * 128,
+                                    128,
+                                );
+                                Ok(())
+                            };
+                            gemm(
+                                self,
+                                r,
+                                cmm_id(gdt2, false),
+                                bx.as_ref(),
+                                &gq,
+                                gate_t.as_ref(),
+                                ne,
+                                nffx,
+                            )?;
+                            gemm(
+                                self,
+                                r,
+                                cmm_id(udt2, false),
+                                bx.as_ref(),
+                                &uq,
+                                up_t.as_ref(),
+                                ne,
+                                nffx,
+                            )?;
+                            let pso = self.pipelines.get("gatedact_f32")?;
+                            let mut p = ((cr * n_used) as u32).to_ne_bytes().to_vec();
+                            p.extend_from_slice(&(nffx as u32).to_ne_bytes());
+                            p.extend_from_slice(&act_code.to_ne_bytes());
+                            p.extend_from_slice(&0u32.to_ne_bytes());
+                            self.encode(
+                                r,
+                                &pso,
+                                &[gate_t.as_ref(), up_t.as_ref(), act_t.as_ref()],
+                                &p,
+                                cr * n_used * nffx,
+                            );
+                            gemm(
+                                self,
+                                r,
+                                cmm_id(ddt2, true),
+                                act_t.as_ref(),
+                                &dq,
+                                ydown.as_ref(),
+                                nffx,
+                                ne,
+                            )?;
+                            let pso = self.pipelines.get("moe_reduce")?;
+                            let mut p = (ne as u32).to_ne_bytes().to_vec();
+                            p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                            p.extend_from_slice(&(cr as u32).to_ne_bytes());
+                            p.extend_from_slice(&(row0 as u32).to_ne_bytes());
+                            self.encode(r, &pso, &[ydown.as_ref(), bd.as_ref()], &p, cr * ne);
+                            continue;
+                        }
+                        let pso = self.pipelines.get(moe_kern(gdt2).unwrap().0)?;
+                        self.encode_tg(
+                            r,
+                            &pso,
+                            &[
+                                bx.as_ref(),
+                                &gq.codes,
+                                &gq.scm,
+                                &gq.dd,
+                                gate_t.as_ref(),
+                                tbl.as_ref(),
+                            ],
+                            &pack(ne, nffx, row0),
+                            cr * n_used * (nffx / 2) * 32,
+                            32,
+                        );
+                        let pso = self.pipelines.get(moe_kern(udt2).unwrap().0)?;
+                        self.encode_tg(
+                            r,
+                            &pso,
+                            &[
+                                bx.as_ref(),
+                                &uq.codes,
+                                &uq.scm,
+                                &uq.dd,
+                                up_t.as_ref(),
+                                tbl.as_ref(),
+                            ],
+                            &pack(ne, nffx, row0),
+                            cr * n_used * (nffx / 2) * 32,
+                            32,
+                        );
+                        let pso = self.pipelines.get("gatedact_f32")?;
+                        let mut p = ((cr * n_used) as u32).to_ne_bytes().to_vec();
+                        p.extend_from_slice(&(nffx as u32).to_ne_bytes());
+                        p.extend_from_slice(&act_code.to_ne_bytes());
+                        p.extend_from_slice(&0u32.to_ne_bytes()); // up_off
+                        self.encode(
+                            r,
+                            &pso,
+                            &[gate_t.as_ref(), up_t.as_ref(), act_t.as_ref()],
+                            &p,
+                            cr * n_used * nffx,
+                        );
+                        let pso = self.pipelines.get(moe_kern(ddt2).unwrap().1)?;
+                        self.encode_tg(
+                            r,
+                            &pso,
+                            &[
+                                act_t.as_ref(),
+                                &dq.codes,
+                                &dq.scm,
+                                &dq.dd,
+                                ydown.as_ref(),
+                                tbl.as_ref(),
+                            ],
+                            &pack(nffx, ne, row0),
+                            cr * n_used * (ne / 2) * 32,
+                            32,
+                        );
+                        let pso = self.pipelines.get("moe_reduce")?;
+                        let mut p = (ne as u32).to_ne_bytes().to_vec();
+                        p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                        p.extend_from_slice(&(cr as u32).to_ne_bytes());
+                        p.extend_from_slice(&(row0 as u32).to_ne_bytes());
+                        self.encode(r, &pso, &[ydown.as_ref(), bd.as_ref()], &p, cr * ne);
+                    }
                     r.loc[dst.0 as usize] = Loc::Device;
                     return Ok(());
                 }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1372,9 +1372,54 @@ impl MetalBackend {
                 // other shape the scalar dequant-on-read fallback (prefill lives here until a
                 // q8 flash port). Both dequantize exactly — reassociation-only vs the f16 math.
                 if g.desc(k_cache).dtype == DType::Q8_0 {
-                    // Any row count: the vector kernel runs one threadgroup per (row, head),
-                    // so prefill rides it too (no q8 flash port yet — this is the split-KV
-                    // class, ~3-5x slower than flash2 at depth but 100x the scalar fallback).
+                    // Prefill-wide launches take the q8 cooperative flash (dequant-staged KV
+                    // tiles) — the same gate shape as the f16 flash.
+                    let fq8 = rows * nh >= 128 && kv_len >= 64 && matches!(hd, 64 | 128) && {
+                        let kn = if hd == 64 {
+                            "attnflash2_q8kv_hd64"
+                        } else {
+                            "attnflash2_q8kv_hd128"
+                        };
+                        self.pipelines
+                            .get(kn)
+                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                            .unwrap_or(false)
+                    };
+                    if fq8 {
+                        let kern = if hd == 64 {
+                            "attnflash2_q8kv_hd64"
+                        } else {
+                            "attnflash2_q8kv_hd128"
+                        };
+                        let pso = self.pipelines.get(kern)?;
+                        let mut p = (rows as u32).to_ne_bytes().to_vec();
+                        p.extend_from_slice(&(kv_len as u32).to_ne_bytes());
+                        p.extend_from_slice(&(nh as u32).to_ne_bytes());
+                        p.extend_from_slice(&(nkv as u32).to_ne_bytes());
+                        p.extend_from_slice(&(hd as u32).to_ne_bytes());
+                        p.extend_from_slice(&scale.to_ne_bytes());
+                        p.extend_from_slice(&window.to_ne_bytes());
+                        p.extend_from_slice(&pos.to_ne_bytes());
+                        let n = rows * nh * hd;
+                        let qh = Arc::new(self.device.new_buffer(
+                            (n * 2).max(4) as u64,
+                            MTLResourceOptions::StorageModeShared,
+                        ));
+                        let cast = self.pipelines.get("cast_f32_f16")?;
+                        self.encode(r, &cast, &[bq.as_ref(), &qh], &(n as u32).to_ne_bytes(), n);
+                        self.encode_tg(
+                            r,
+                            &pso,
+                            &[qh.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref()],
+                            &p,
+                            rows.div_ceil(8) * nh * 128,
+                            128,
+                        );
+                        r.loc[dst.0 as usize] = Loc::Device;
+                        return Ok(());
+                    }
+                    // The vector kernel runs one threadgroup per (row, head), covering decode
+                    // and any prefill shape the flash gate declined.
                     let vq8 = matches!(hd, 64 | 128) && kv_len >= 128 && {
                         let kn = if hd == 64 {
                             "attnvec_q8kv_hd64"

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -271,6 +271,17 @@ impl MetalBackend {
             .new_buffer((n.max(1) * 4) as u64, MTLResourceOptions::StorageModeShared)
     }
 
+    /// A reusable op-scratch buffer (see `MetalBackend::scratch`): get-or-create by
+    /// (f32 count, tag).
+    fn scratch_buf(&self, n: usize, tag: u8) -> Arc<MtlBuffer> {
+        self.scratch
+            .lock()
+            .unwrap()
+            .entry((n, tag))
+            .or_insert_with(|| Arc::new(self.zeros_buf(n)))
+            .clone()
+    }
+
     /// Read `n` f32s out of a device buffer.
     fn read_f32(buf: &MtlBuffer, n: usize) -> Vec<f32> {
         let mut out = vec![0f32; n];
@@ -1510,6 +1521,144 @@ impl MetalBackend {
                     n_used as usize,
                     n_ff_exp as usize,
                 );
+                // Device path for K-quant experts (the shapes real MoE checkpoints ship): router
+                // GEMV -> on-device top-k -> expert-BATCHED GEMV stages picking their weight
+                // slices from the device expert table, weighted sum via a final reduce. Seven
+                // dispatches, no expert bytes or activations on the host. Falls back to the host
+                // path below for other dtypes (INFR_METAL_NOMOE forces it).
+                let moe_kern = |dt: DType| -> Option<(&'static str, &'static str)> {
+                    match dt {
+                        DType::Q4K => Some(("linear_q4k_moe", "linear_q4k_moe_acc")),
+                        DType::Q6K => Some(("linear_q6k_moe", "linear_q6k_moe_acc")),
+                        _ => None,
+                    }
+                };
+                let (gdt2, udt2, ddt2) = (
+                    g.desc(gate_exps).dtype,
+                    g.desc(up_exps).dtype,
+                    g.desc(down_exps).dtype,
+                );
+                let device_ok = n_used <= 16
+                    && ne % 256 == 0
+                    && nffx % 256 == 0
+                    && std::env::var("INFR_METAL_NOMOE").is_err()
+                    && moe_kern(gdt2).is_some()
+                    && moe_kern(udt2).is_some()
+                    && moe_kern(ddt2).is_some();
+                if device_ok {
+                    let bx = self.ensure_device(r, x);
+                    let bd = self.dev_dst(r, dst, ne);
+                    // Router logits: small f32 GEMV over the dequant-cached router weight.
+                    let rw = self.weight_buf(router, g, bindings);
+                    let logits = self.scratch_buf(n_expert, 0);
+                    let pso = self.pipelines.get("linear_f32")?;
+                    let mut p = 1u32.to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(ne as u32).to_ne_bytes());
+                    p.extend_from_slice(&(n_expert as u32).to_ne_bytes());
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[bx.as_ref(), rw.as_ref(), logits.as_ref()],
+                        &p,
+                        n_expert * 32,
+                        32,
+                    );
+                    // Top-k + weights into the fixed 32-slot expert table.
+                    let tbl = self.scratch_buf(32, 1);
+                    let pso = self.pipelines.get("moe_topk")?;
+                    let mut p = (n_expert as u32).to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                    p.extend_from_slice(&scale.to_ne_bytes());
+                    self.encode_tg(r, &pso, &[logits.as_ref(), tbl.as_ref()], &p, 32, 32);
+                    // Expert FFN, batched over the selected experts — one dispatch per stage
+                    // (gate, up, act, down, reduce), slots resolved from the table in-kernel.
+                    let gq = self.weight_qui(gate_exps, g, bindings);
+                    let uq = self.weight_qui(up_exps, g, bindings);
+                    let dq = self.weight_qui(down_exps, g, bindings);
+                    let gate_t = self.scratch_buf(n_used * nffx, 2);
+                    let up_t = self.scratch_buf(n_used * nffx, 3);
+                    let act_t = self.scratch_buf(n_used * nffx, 4);
+                    let ydown = self.scratch_buf(n_used * ne, 5);
+                    let act_code: u32 = match act {
+                        infr_core::graph::Activation::Silu => 0,
+                        infr_core::graph::Activation::Gelu => 1,
+                        infr_core::graph::Activation::Sigmoid => 2,
+                    };
+                    let pack = |in_f: usize, out_f: usize| -> Vec<u8> {
+                        let mut p = 1u32.to_ne_bytes().to_vec();
+                        p.extend_from_slice(&(in_f as u32).to_ne_bytes());
+                        p.extend_from_slice(&(out_f as u32).to_ne_bytes());
+                        p.extend_from_slice(&0u32.to_ne_bytes()); // dshift (native kernels)
+                        p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                        p
+                    };
+                    let pso = self.pipelines.get(moe_kern(gdt2).unwrap().0)?;
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[
+                            bx.as_ref(),
+                            &gq.codes,
+                            &gq.scm,
+                            &gq.dd,
+                            gate_t.as_ref(),
+                            tbl.as_ref(),
+                        ],
+                        &pack(ne, nffx),
+                        n_used * (nffx / 2) * 32,
+                        32,
+                    );
+                    let pso = self.pipelines.get(moe_kern(udt2).unwrap().0)?;
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[
+                            bx.as_ref(),
+                            &uq.codes,
+                            &uq.scm,
+                            &uq.dd,
+                            up_t.as_ref(),
+                            tbl.as_ref(),
+                        ],
+                        &pack(ne, nffx),
+                        n_used * (nffx / 2) * 32,
+                        32,
+                    );
+                    let pso = self.pipelines.get("gatedact_f32")?;
+                    let mut p = (n_used as u32).to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(nffx as u32).to_ne_bytes());
+                    p.extend_from_slice(&act_code.to_ne_bytes());
+                    p.extend_from_slice(&0u32.to_ne_bytes()); // up_off
+                    self.encode(
+                        r,
+                        &pso,
+                        &[gate_t.as_ref(), up_t.as_ref(), act_t.as_ref()],
+                        &p,
+                        n_used * nffx,
+                    );
+                    let pso = self.pipelines.get(moe_kern(ddt2).unwrap().1)?;
+                    self.encode_tg(
+                        r,
+                        &pso,
+                        &[
+                            act_t.as_ref(),
+                            &dq.codes,
+                            &dq.scm,
+                            &dq.dd,
+                            ydown.as_ref(),
+                            tbl.as_ref(),
+                        ],
+                        &pack(nffx, ne),
+                        n_used * (ne / 2) * 32,
+                        32,
+                    );
+                    let pso = self.pipelines.get("moe_reduce")?;
+                    let mut p = (ne as u32).to_ne_bytes().to_vec();
+                    p.extend_from_slice(&(n_used as u32).to_ne_bytes());
+                    self.encode(r, &pso, &[ydown.as_ref(), bd.as_ref()], &p, ne);
+                    r.loc[dst.0 as usize] = Loc::Device;
+                    return Ok(());
+                }
                 self.ensure_host(r, g, x);
                 let xs = r.vals[x.0 as usize].clone();
                 // `x` may hold several rows (the seam's batched prefill) — route + run per row,

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -147,7 +147,9 @@ impl Backend for MetalBackend {
             decode_replay: true,
             // The reference backend keeps the separate gate/up FFN form (no GatedActFused
             // lowering); the runner's combined-gu upload stays Vulkan-only.
-            combined_gu: false,
+            // One fused [2*nff, ne] gate+up Linear + GatedActFused per FFN — one dispatch and
+            // one contiguous weight stream instead of two.
+            combined_gu: true,
         }
     }
 

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -85,6 +85,10 @@ pub struct MetalBackend {
     /// single slot, same single-generation lifetime as the weight caches (one backend per
     /// generation, bindings stable across the decode loop).
     pub(crate) replay: std::sync::Mutex<Option<exec::Tape>>,
+    /// Op-scratch buffers reused across ops/executes (keyed by (f32 count, tag) — distinct tags
+    /// for same-size buffers alive in one op). Reuse across layers is safe: the batch's hazard
+    /// tracking orders each layer's writes after the previous layer's reads.
+    pub(crate) scratch: std::sync::Mutex<std::collections::HashMap<(usize, u8), std::sync::Arc<metal::Buffer>>>,
 }
 
 // MTLDevice / MTLCommandQueue are documented thread-safe; the pipeline states are immutable after
@@ -107,6 +111,7 @@ impl MetalBackend {
             prof_ops: std::env::var("INFR_METAL_PROFILE").as_deref() == Ok("2"),
             prof: std::sync::Mutex::new(profile::Profile::default()),
             replay: std::sync::Mutex::new(None),
+            scratch: std::sync::Mutex::new(std::collections::HashMap::new()),
         })
     }
 }

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -88,7 +88,8 @@ pub struct MetalBackend {
     /// Op-scratch buffers reused across ops/executes (keyed by (f32 count, tag) — distinct tags
     /// for same-size buffers alive in one op). Reuse across layers is safe: the batch's hazard
     /// tracking orders each layer's writes after the previous layer's reads.
-    pub(crate) scratch: std::sync::Mutex<std::collections::HashMap<(usize, u8), std::sync::Arc<metal::Buffer>>>,
+    pub(crate) scratch:
+        std::sync::Mutex<std::collections::HashMap<(usize, u8), std::sync::Arc<metal::Buffer>>>,
 }
 
 // MTLDevice / MTLCommandQueue are documented thread-safe; the pipeline states are immutable after

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1835,8 +1835,12 @@ inline float q8_at(device const uchar* c, ulong e) {
 inline float4 q8_float4(device const uchar* c, ulong e) { /* e % 4 == 0: never straddles */
     device const uchar* blk = c + (e >> 5) * 34ul;
     float d = (float)*(device const half*)blk;
-    device const uchar* q = blk + 2u + (e & 31u);
-    return d * float4((float)(char)q[0], (float)(char)q[1], (float)(char)q[2], (float)(char)q[3]);
+    /* codes start at blk+2 (2-byte aligned): two ushort loads cover the 4 codes */
+    device const ushort* q2 = (device const ushort*)(blk + 2u + (e & 31u));
+    uint lo = q2[0];
+    uint hi = q2[1];
+    return d * float4((float)(char)(lo & 0xFFu), (float)(char)(lo >> 8),
+                      (float)(char)(hi & 0xFFu), (float)(char)(hi >> 8));
 }
 kernel void writekv_q8(device const float* src   [[buffer(0)]],
                        device uchar*       cache [[buffer(1)]],

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1822,4 +1822,250 @@ kernel void writekv_dyn_f16(device const float* src   [[buffer(0)]],
     if (gid >= p.n) return;
     cache[(uint)posb[0] * p.row_stride + gid] = (half)src[gid];
 }
+
+// ---- Q8_0 KV cache (INFR_KV_Q8): 34-byte blocks of 32 codes — half the f16 footprint and
+// bandwidth. Quantization matches the CPU reference bit-for-bit: d = amax/127 stored as f16,
+// q = rint(x/d) (ties to even, matching Rust's round_ties_even). Rows are 32-aligned (the
+// runner gates on it), so a written row never straddles a block.
+inline float q8_at(device const uchar* c, ulong e) {
+    device const uchar* blk = c + (e >> 5) * 34ul;
+    float d = (float)*(device const half*)blk; /* 34*b is even — the f16 d is always aligned */
+    return d * (float)(char)blk[2u + (e & 31u)];
+}
+inline float4 q8_float4(device const uchar* c, ulong e) { /* e % 4 == 0: never straddles */
+    device const uchar* blk = c + (e >> 5) * 34ul;
+    float d = (float)*(device const half*)blk;
+    device const uchar* q = blk + 2u + (e & 31u);
+    return d * float4((float)(char)q[0], (float)(char)q[1], (float)(char)q[2], (float)(char)q[3]);
+}
+kernel void writekv_q8(device const float* src   [[buffer(0)]],
+                       device uchar*       cache [[buffer(1)]],
+                       constant WriteKvParams& p [[buffer(2)]],
+                       uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.n / 32u) return;   // one thread per 32-elem block; p.base is in elements
+    device const float* s = src + gid * 32u;
+    float amax = 0.0f;
+    for (uint i = 0; i < 32u; i++) amax = max(amax, fabs(s[i]));
+    float d = amax / 127.0f;
+    float id = d != 0.0f ? 1.0f / d : 0.0f;
+    device uchar* blk = cache + ((ulong)(p.base >> 5) + gid) * 34ul;
+    *(device half*)blk = (half)d;
+    for (uint i = 0; i < 32u; i++) blk[2u + i] = (uchar)(char)(int)rint(s[i] * id);
+}
+kernel void writekv_dyn_q8(device const float* src   [[buffer(0)]],
+                           device uchar*       cache [[buffer(1)]],
+                           device const int*   posb  [[buffer(2)]],
+                           constant WriteKvDynParams& p [[buffer(3)]],
+                           uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.n / 32u) return;
+    device const float* s = src + gid * 32u;
+    float amax = 0.0f;
+    for (uint i = 0; i < 32u; i++) amax = max(amax, fabs(s[i]));
+    float d = amax / 127.0f;
+    float id = d != 0.0f ? 1.0f / d : 0.0f;
+    ulong base_blk = (ulong)(uint)posb[0] * (p.row_stride >> 5);
+    device uchar* blk = cache + (base_blk + gid) * 34ul;
+    *(device half*)blk = (half)d;
+    for (uint i = 0; i < 32u; i++) blk[2u + i] = (uchar)(char)(int)rint(s[i] * id);
+}
+
+// Scalar attention over a Q8_0 cache — the attention_f16kv shape with dequant-on-read. The
+// catch-all q8 route (prefill + odd shapes); the vector kernel below covers rows==1 decode.
+kernel void attention_q8kv(device const float* q   [[buffer(0)]],
+                           device const uchar* k   [[buffer(1)]],
+                           device const uchar* v   [[buffer(2)]],
+                           device float*       dst [[buffer(3)]],
+                           constant AttnParams& p  [[buffer(4)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    uint sg = gid / 32u;
+    if (sg >= p.rows * p.n_head) return;
+    uint ti = sg / p.n_head;
+    uint h = sg % p.n_head;
+    uint group = p.n_head / p.n_kv;
+    uint kvh = h / group;
+    uint qb = sg * p.head_dim;
+    uint abs = p.pos + ti;
+    uint lo = (p.window > 0u && abs + 1u > p.window) ? (abs + 1u - p.window) : 0u;
+
+    float acc[MAX_DPL];
+    for (uint t = 0; t < MAX_DPL; t++) acc[t] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint j = lo; j <= abs; j++) {
+        ulong kb = ((ulong)j * p.n_kv + kvh) * p.head_dim;
+        float part = 0.0f;
+        for (uint d = lane; d < p.head_dim; d += 32u) part += q[qb + d] * q8_at(k, kb + d);
+        float sc = simd_sum(part) * p.scale;
+        float mnew = max(m, sc);
+        float corr = exp(m - mnew);
+        float pw = exp(sc - mnew);
+        l = l * corr + pw;
+        uint t = 0;
+        for (uint d = lane; d < p.head_dim; d += 32u) {
+            acc[t] = acc[t] * corr + pw * q8_at(v, kb + d);
+            t++;
+        }
+        m = mnew;
+    }
+    uint t = 0;
+    for (uint d = lane; d < p.head_dim; d += 32u) { dst[qb + d] = acc[t] / l; t++; }
+}
+
+// Vector flash attention over a Q8_0 cache — the attnvec structure with dequant-on-read
+// (see attnvec_body; kept as a sibling body because the KV accessor type differs). Same
+// numeric class: f32 dots over exactly-dequantized q8 values, reassociation only.
+template<uint hd, uint NSG>
+inline void attnvec_q8_body(device const float* q,
+                            device const uchar* k,
+                            device const uchar* v,
+                            device float*       dst,
+                            constant AttnParams& p,
+                            uint abs, uint kvl,
+                            threadgroup float* sq,
+                            threadgroup float* ssc,
+                            threadgroup float* so,
+                            uint3  tgpig,
+                            ushort sgitg,
+                            ushort tiisg) {
+    constexpr uint C = 32, NE = 4, NL = 32u / NE;
+    constexpr uint hd4 = hd / 4u;
+    constexpr uint NI = hd4 / NL;
+
+    uint tg = tgpig.x;
+    uint ti = tg / p.n_head;
+    uint h  = tg % p.n_head;
+    uint kvh = h / (p.n_head / p.n_kv);
+    uint lo = (p.window > 0u && abs + 1u > p.window) ? (abs + 1u - p.window) : 0u;
+    uint tx = tiisg % NL, ty = tiisg / NL;
+
+    {
+        device const float4* q4 = (device const float4*)(q + ((ulong)ti * p.n_head + h) * hd);
+        threadgroup float4* sq4 = (threadgroup float4*)sq;
+        for (uint i = sgitg * 32u + tiisg; i < hd4; i += NSG * 32u) sq4[i] = q4[i];
+    }
+    threadgroup float* ss = ssc + sgitg * C;
+    threadgroup float4* so4 = (threadgroup float4*)so + sgitg * hd4;
+    if (ty == 0) {
+        for (uint ii = 0; ii < NI; ii++) so4[ii * NL + tx] = float4(0.0f);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float S = 0.0f, M = -MAXFLOAT / 2;
+    threadgroup const float4* sq4 = (threadgroup const float4*)sq;
+
+    for (uint ic = sgitg * C; ic <= abs; ic += NSG * C) {
+        if (ic + C <= lo) continue;
+        {
+            float mqk[C / NE];
+            for (uint cc = 0; cc < C / NE; cc++) {
+                uint rc = min(ic + NE * cc + ty, kvl - 1u);
+                ulong eb = ((ulong)rc * p.n_kv + kvh) * hd;
+                float acc = 0.0f;
+                for (uint ii = 0; ii < NI; ii++)
+                    acc += dot(q8_float4(k, eb + (ii * NL + tx) * 4u), sq4[ii * NL + tx]);
+                acc += simd_shuffle_down(acc, 4);
+                acc += simd_shuffle_down(acc, 2);
+                acc += simd_shuffle_down(acc, 1);
+                mqk[cc] = simd_shuffle(acc, NL * ty);
+            }
+            ss[NE * tx + ty] = mqk[tx];
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            float sv = ss[tiisg] * p.scale;
+            uint jkv = ic + tiisg;
+            bool valid = (jkv >= lo) && (jkv <= abs);
+            float m = M;
+            M = simd_max(max(M, valid ? sv : -MAXFLOAT / 2));
+            float ms = exp(m - M);
+            float vs = valid ? exp(sv - M) : 0.0f;
+            S = S * ms + simd_sum(vs);
+            ss[tiisg] = vs;
+            if (ty == 0) {
+                for (uint ii = 0; ii < NI; ii++) so4[ii * NL + tx] *= ms;
+            }
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            float4 lov[NI];
+            for (uint ii = 0; ii < NI; ii++) lov[ii] = float4(0.0f);
+            for (uint cc = 0; cc < C / NE; cc++) {
+                uint rc = min(ic + NE * cc + ty, kvl - 1u);
+                ulong eb = ((ulong)rc * p.n_kv + kvh) * hd;
+                float pw = ss[NE * cc + ty];
+                for (uint ii = 0; ii < NI; ii++)
+                    lov[ii] += q8_float4(v, eb + (ii * NL + tx) * 4u) * pw;
+            }
+            for (uint ii = 0; ii < NI; ii++) {
+                lov[ii] += simd_shuffle_down(lov[ii], 16);
+                lov[ii] += simd_shuffle_down(lov[ii], 8);
+            }
+            if (ty == 0) {
+                for (uint ii = 0; ii < NI; ii++) so4[ii * NL + tx] += lov[ii];
+            }
+        }
+    }
+
+    if (tiisg == 0) { ss[0] = S; ss[1] = M; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint rr = NSG / 2u; rr > 0u; rr >>= 1u) {
+        if (sgitg < rr) {
+            float s0 = ss[0], s1 = ssc[(sgitg + rr) * C + 0];
+            float m0 = ss[1], m1 = ssc[(sgitg + rr) * C + 1];
+            float mm = max(m0, m1);
+            float ms0 = exp(m0 - mm), ms1 = exp(m1 - mm);
+            if (tiisg == 0) { ss[0] = s0 * ms0 + s1 * ms1; ss[1] = mm; }
+            threadgroup float4* sob = (threadgroup float4*)so + (sgitg + rr) * hd4;
+            for (uint i = tiisg; i < hd4; i += 32u) so4[i] = so4[i] * ms0 + sob[i] * ms1;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (sgitg == 0) {
+        float sinv = ssc[0] == 0.0f ? 0.0f : 1.0f / ssc[0];
+        device float4* out = (device float4*)(dst + ((ulong)ti * p.n_head + h) * hd);
+        for (uint i = tiisg; i < hd4; i += 32u) out[i] = so4[i] * sinv;
+    }
+}
+
+template<uint hd, uint NSG>
+kernel void attnvec_q8kv_t(device const float* q   [[buffer(0)]],
+                           device const uchar* k   [[buffer(1)]],
+                           device const uchar* v   [[buffer(2)]],
+                           device float*       dst [[buffer(3)]],
+                           constant AttnParams& p  [[buffer(4)]],
+                           uint3  tgpig [[threadgroup_position_in_grid]],
+                           ushort sgitg [[simdgroup_index_in_threadgroup]],
+                           ushort tiisg [[thread_index_in_simdgroup]]) {
+    threadgroup float sq[hd];
+    threadgroup float ssc[NSG * 32];
+    threadgroup float so[NSG * hd];
+    uint abs = p.pos + tgpig.x / p.n_head;
+    attnvec_q8_body<hd, NSG>(q, k, v, dst, p, abs, p.kv_len, sq, ssc, so, tgpig, sgitg, tiisg);
+}
+
+template<uint hd, uint NSG>
+kernel void attnvec_dyn_q8kv_t(device const float* q    [[buffer(0)]],
+                               device const uchar* k    [[buffer(1)]],
+                               device const uchar* v    [[buffer(2)]],
+                               device float*       dst  [[buffer(3)]],
+                               device const int*   posb [[buffer(4)]],
+                               constant AttnParams& p   [[buffer(5)]],
+                               uint3  tgpig [[threadgroup_position_in_grid]],
+                               ushort sgitg [[simdgroup_index_in_threadgroup]],
+                               ushort tiisg [[thread_index_in_simdgroup]]) {
+    threadgroup float sq[hd];
+    threadgroup float ssc[NSG * 32];
+    threadgroup float so[NSG * hd];
+    uint abs = (uint)posb[0];
+    attnvec_q8_body<hd, NSG>(q, k, v, dst, p, abs, abs + 1u, sq, ssc, so, tgpig, sgitg, tiisg);
+}
+
+typedef decltype(attnvec_q8kv_t<64, 32>) attnvec_q8_t;
+template [[host_name("attnvec_q8kv_hd64")]]  kernel attnvec_q8_t attnvec_q8kv_t<64, 32>;
+template [[host_name("attnvec_q8kv_hd128")]] kernel attnvec_q8_t attnvec_q8kv_t<128, 32>;
+typedef decltype(attnvec_dyn_q8kv_t<64, 32>) attnvec_dyn_q8_t;
+template [[host_name("attnvec_dyn_q8kv_hd64")]]  kernel attnvec_dyn_q8_t attnvec_dyn_q8kv_t<64, 32>;
+template [[host_name("attnvec_dyn_q8kv_hd128")]] kernel attnvec_dyn_q8_t attnvec_dyn_q8kv_t<128, 32>;
 "#;

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1105,6 +1105,18 @@ inline float gated_act(uint act, float g) {
     return 0.5f * g * (1.0f + tanh(0.7978845608f * (g + 0.044715f * g * g * g)));
 }
 struct GatedParams { uint rows; uint nff; uint act; uint up_off; };
+// Fused-projection form (`combined_gu`): gate|up live in ONE [rows, 2*nff] buffer (gate half
+// first), produced by a single Linear over the concatenated weights.
+kernel void gatedactfused_f32(device const float* gu  [[buffer(0)]],
+                              device float*       dst [[buffer(1)]],
+                              constant GatedParams& p [[buffer(2)]],
+                              uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.nff) return;
+    uint r = gid / p.nff;
+    uint i = gid % p.nff;
+    ulong gb = (ulong)r * 2u * p.nff;
+    dst[gid] = gated_act(p.act, gu[gb + i]) * gu[gb + p.nff + i];
+}
 kernel void gatedact_f32(device const float* gate [[buffer(0)]],
                          device const float* up   [[buffer(1)]],
                          device float*       dst  [[buffer(2)]],

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -710,33 +710,45 @@ kernel void moe_topk(device const float* logits [[buffer(0)]],
                      device uint*        tbl    [[buffer(1)]],
                      constant MoeTopkParams& p  [[buffer(2)]],
                      uint gid [[thread_position_in_grid]]) {
-    if (gid != 0u) return;
-    float maxl = -MAXFLOAT;
-    for (uint e = 0; e < p.n_expert; e++) maxl = max(maxl, logits[e]);
+    uint lane = gid;   // one simdgroup (32 threads); each lane owns experts e = lane + 32j
+    float lmax = -MAXFLOAT;
+    for (uint e = lane; e < p.n_expert; e += 32u) lmax = max(lmax, logits[e]);
+    float maxl = simd_max(lmax);
+    // psum in the reference's ascending order (exact bit-match), broadcast from lane 0
     float psum = 0.0f;
-    for (uint e = 0; e < p.n_expert; e++) psum += exp(logits[e] - maxl);
+    if (lane == 0u) {
+        for (uint e = 0; e < p.n_expert; e++) psum += exp(logits[e] - maxl);
+    }
+    psum = simd_broadcast_first(psum);
+    // top-k selection, lane-parallel: each round every lane offers its best untaken expert
+    // (ascending scan + strict > == lowest index per lane), simd_max picks the winning logit
+    // and simd_min the lowest tied index — exactly the reference's stable-sort order
+    uint taken = 0u;   // bitmask over this lane's stride slots j
     uint sel[16];
-    // exp is monotonic: top-k by logit == top-k by prob, same first-index tie rule
     for (uint u = 0; u < p.n_used; u++) {
-        float best = -MAXFLOAT;
-        uint bi = 0u;
-        for (uint e = 0; e < p.n_expert; e++) {
-            bool taken = false;
-            for (uint t = 0; t < u; t++) taken = taken || (sel[t] == e);
-            if (!taken && logits[e] > best) { best = logits[e]; bi = e; }
+        float bv = -MAXFLOAT;
+        uint be = 0xFFFFFFFFu;
+        uint j = 0u;
+        for (uint e = lane; e < p.n_expert; e += 32u, j++) {
+            if ((taken & (1u << j)) == 0u && logits[e] > bv) { bv = logits[e]; be = e; }
         }
-        sel[u] = bi;
+        float m = simd_max(bv);
+        uint pick = simd_min(bv == m ? be : 0xFFFFFFFFu);
+        sel[u] = pick;
+        if ((pick & 31u) == lane) taken |= 1u << (pick >> 5);
     }
-    float wsum = 0.0f;
-    float ws[16];
-    for (uint u = 0; u < p.n_used; u++) {
-        ws[u] = exp(logits[sel[u]] - maxl) / psum;
-        wsum += ws[u];
-    }
-    wsum = max(wsum, 1e-20f);
-    for (uint u = 0; u < p.n_used; u++) {
-        tbl[u] = sel[u];
-        tbl[16u + u] = as_type<uint>(ws[u] / wsum * p.scale);
+    if (lane == 0u) {
+        float wsum = 0.0f;
+        float ws[16];
+        for (uint u = 0; u < p.n_used; u++) {
+            ws[u] = exp(logits[sel[u]] - maxl) / psum;
+            wsum += ws[u];
+        }
+        wsum = max(wsum, 1e-20f);
+        for (uint u = 0; u < p.n_used; u++) {
+            tbl[u] = sel[u];
+            tbl[16u + u] = as_type<uint>(ws[u] / wsum * p.scale);
+        }
     }
 }
 

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -664,7 +664,7 @@ kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
 // scratch; the down variant (EPI 2) reads its slot's activation row and writes w[slot]*y to its
 // slot's output row — `moe_reduce` then folds the weighted expert sum (slot-ascending, the CPU
 // reference's accumulation order).
-struct MoeLinParams { uint m; uint in_f; uint out_f; uint dshift; uint n_used; };
+struct MoeLinParams { uint m; uint in_f; uint out_f; uint dshift; uint n_used; uint row0; };
 #define MOE_WRAP(NAME, BODY, EPI, ROWB)                                                           \
 kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
                  device const uchar*  codes [[buffer(1)]],                                       \
@@ -676,15 +676,20 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
                  uint gid  [[thread_position_in_grid]],                                          \
                  uint lane [[thread_index_in_simdgroup]]) {                                      \
     uint sg = gid / 32u;                                                                          \
-    uint per_out = p.out_f >> 1;         /* simdgroups per expert (2 rows each) */               \
-    uint slot = sg / per_out;                                                                     \
-    uint e = tbl[slot];                                                                           \
-    float w = as_type<float>(tbl[16u + slot]); /* weights after the 16-slot index block */        \
+    uint per_out = p.out_f >> 1;         /* simdgroups per expert (2 weight rows each) */        \
+    uint row = sg / (p.n_used * per_out);          /* token row within this chunk */             \
+    uint rem = sg % (p.n_used * per_out);                                                         \
+    uint slot = rem / per_out;                                                                    \
+    uint e = tbl[(p.row0 + row) * 32u + slot];                                                    \
+    float w = as_type<float>(tbl[(p.row0 + row) * 32u + 16u + slot]);                             \
     ulong row_b = (ulong)(p.in_f >> 8) * ROWB;                                                    \
     device const uchar* ec = codes + (ulong)e * p.out_f * row_b;                                  \
-    device const float* xs = (EPI == 2) ? x + slot * p.in_f : x;                                  \
-    uint g2 = (sg % per_out) * 32u + lane;   /* body sees a per-expert grid */                    \
-    BODY<EPI>(xs, ec, dst + slot * p.out_f, xs, p, w, true, g2, lane);                            \
+    /* gate/up read the token's row of x [rows, ne]; down reads its (row, slot) activation */     \
+    device const float* xs = (EPI == 2) ? x + (ulong)(row * p.n_used + slot) * p.in_f             \
+                                        : x + (ulong)(p.row0 + row) * p.in_f;                     \
+    device float* ds = dst + (ulong)(row * p.n_used + slot) * p.out_f;                            \
+    uint g2 = (rem % per_out) * 32u + lane;  /* body sees a per-(row, expert) grid */             \
+    BODY<EPI>(xs, ec, ds, xs, p, w, true, g2, lane);                                              \
 }
 MOE_WRAP(linear_q4k_moe,     linear_q4k_body, 0, 144ul)
 MOE_WRAP(linear_q4k_moe_acc, linear_q4k_body, 2, 144ul)
@@ -692,25 +697,170 @@ MOE_WRAP(linear_q6k_moe,     linear_q6k_body, 0, 210ul)
 MOE_WRAP(linear_q6k_moe_acc, linear_q6k_body, 2, 210ul)
 #undef MOE_WRAP
 
+// ---- Expert-grouped GEMM for batched MoE prefill (the llama.cpp mul_mm_id shape). Rather than
+// one GEMV per (token, slot) — no MMA, compute-bound at prefill widths — `moe_map` groups the
+// chunk's (token, slot) pairs by EXPERT (one thread per expert scans the routing table, so each
+// expert's list is token-ascending and deterministic), and the `*_cmm_id` kernels run the shared
+// cooperative-GEMM tile over each expert's token group: grid = expert x token-tile x out-tile,
+// tiles past an expert's count return before any barrier, activations stage through the same
+// pre-transposed 8x8 layout with the token row resolved through the id list, and the output
+// SCATTERS through threadgroup staging to each token's (row, slot) scratch row. The down variant
+// folds the routing weight during the scatter. Ids are chunk-relative (`row0` rebases).
+struct MoeMapParams { uint n_expert; uint n_used; uint rows; uint row0; uint cap; };
+kernel void moe_map(device const uint* tbl [[buffer(0)]],
+                    device uint*       ids [[buffer(1)]],
+                    device uint*       tpe [[buffer(2)]],
+                    constant MoeMapParams& p [[buffer(3)]],
+                    uint tid [[thread_position_in_grid]]) {
+    if (tid >= p.n_expert) return;
+    uint n = 0;
+    for (uint r = 0; r < p.rows; r++) {
+        device const uint* rt = tbl + (ulong)(p.row0 + r) * 32u;
+        for (uint u = 0; u < p.n_used; u++) {
+            if (rt[u] == tid) {
+                ids[tid * p.cap + n] = r * p.n_used + u;
+                n++;
+            }
+        }
+    }
+    tpe[tid] = n;
+}
+
+struct MoeCmmParams { uint in_f; uint out_f; uint n_used; uint cap; uint row0; uint ntt; };
+// DIVROW: gate/up read x[row0 + t/n_used]; down (DIVROW=0) reads its (row, slot) activation row.
+// WSCALE: fold the routing weight tbl[(row0 + t/n_used)*32 + 16 + t%n_used] during the scatter.
+#define MOE_CMM_KERNEL(NAME, DEC, DIVROW, WSCALE)                                                 \
+kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
+                 device const uchar*  codes [[buffer(1)]],                                       \
+                 device const uchar*  scm   [[buffer(2)]],                                       \
+                 device const uchar*  dd    [[buffer(3)]],                                       \
+                 device float*        dst   [[buffer(4)]],                                       \
+                 device const uint*   ids   [[buffer(5)]],                                       \
+                 device const uint*   tpe   [[buffer(6)]],                                       \
+                 device const uint*   tbl   [[buffer(7)]],                                       \
+                 constant MoeCmmParams& p   [[buffer(8)]],                                       \
+                 uint gid  [[thread_position_in_grid]],                                          \
+                 uint lane [[thread_index_in_simdgroup]],                                        \
+                 uint sgid [[simdgroup_index_in_threadgroup]]) {                                 \
+    uint tgix = gid / 128u;                                                                       \
+    uint nto = p.out_f / 64u;                                                                     \
+    uint e = tgix / (p.ntt * nto);                                                                \
+    uint rem = tgix % (p.ntt * nto);                                                              \
+    uint tt0 = (rem / nto) * 32u;                                                                 \
+    uint ro = (rem % nto) * 64u;                                                                  \
+    uint cnt = tpe[e];                                                                            \
+    if (tt0 >= cnt) return;   /* uniform per threadgroup, before any barrier */                   \
+    uint nr1 = min(32u, cnt - tt0);                                                               \
+    uint tid = sgid * 32u + lane;                                                                 \
+                                                                                                  \
+    threadgroup float shraw[2048];                                                                \
+    threadgroup half* sa = (threadgroup half*)shraw;                                              \
+    threadgroup half* sb = ((threadgroup half*)shraw) + 2048u;                                    \
+                                                                                                  \
+    uint lr0 = tid >> 1;                                                                          \
+    uint il0 = tid & 1u;                                                                          \
+    uint lr1 = tid >> 2;                                                                          \
+    uint iyk = (tid & 3u) * 8u;                                                                   \
+    uint lr1c = min(lr1, nr1 - 1u);                                                               \
+    uint tident = ids[e * p.cap + tt0 + lr1c];                                                    \
+    uint xrow = DIVROW ? (p.row0 + tident / p.n_used) : tident;                                   \
+                                                                                                  \
+    simdgroup_half8x8 ma[4];                                                                      \
+    simdgroup_half8x8 mb[2];                                                                      \
+    simdgroup_float8x8 mc[8];                                                                     \
+    for (uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                               \
+                                                                                                  \
+    uint nb = p.in_f >> 4;                                                                        \
+    ulong ebase = (ulong)e * p.out_f * nb;   /* expert's first block index */                     \
+    for (uint k0 = 0; k0 < p.in_f; k0 += 32u) {                                                   \
+        ulong bi = ebase + (ulong)(ro + lr0) * nb + (ulong)(k0 >> 4) + il0;                       \
+        float wk[16];                                                                             \
+        DEC(wk)                                                                                   \
+        device const float4* yy =                                                                 \
+            (device const float4*)(x + (ulong)xrow * p.in_f + k0 + iyk);                          \
+        float4 yv0 = yy[0];                                                                       \
+        float4 yv1 = yy[1];                                                                       \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        {                                                                                         \
+            uint sy = lr0 >> 3;                                                                   \
+            uint lx = lr0 & 7u;                                                                   \
+            for (uint i = 0; i < 16u; i++) {                                                      \
+                uint sx = 2u * il0 + (i >> 3);                                                    \
+                sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
+            }                                                                                     \
+        }                                                                                         \
+        {                                                                                         \
+            uint ib = 4u * (tid & 3u) + (lr1 >> 3);                                               \
+            uint ly = lr1 & 7u;                                                                   \
+            threadgroup half4* sb4 = (threadgroup half4*)(sb + 64u * ib + 8u * ly);               \
+            sb4[0] = half4(yv0);                                                                  \
+            sb4[1] = half4(yv1);                                                                  \
+        }                                                                                         \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
+        threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
+        for (uint ik = 0; ik < 4u; ik++) {                                                        \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
+            for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
+            for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
+            for (uint i = 0; i < 8u; i++)                                                         \
+                simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
+            lsma += 8u * 64u;                                                                     \
+            lsmb += 4u * 64u;                                                                     \
+        }                                                                                         \
+    }                                                                                             \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                              \
+                                                                                                  \
+    /* scatter through threadgroup staging: token rows are non-contiguous scratch rows */         \
+    threadgroup float* tc = shraw + 32u * (sgid & 1u) + (16u * (sgid >> 1)) * 64u;                \
+    for (uint i = 0; i < 8u; i++)                                                                 \
+        simdgroup_store(mc[i], tc + 8u * (i & 3u) + 8u * 64u * (i >> 2), 64u);                    \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                              \
+    if (sgid == 0u) {                                                                             \
+        for (uint j = lane; j < nr1; j += 32u) {                                                  \
+            uint t = ids[e * p.cap + tt0 + j];                                                    \
+            float w = WSCALE                                                                      \
+                ? as_type<float>(tbl[(ulong)(p.row0 + t / p.n_used) * 32u + 16u + t % p.n_used])  \
+                : 1.0f;                                                                           \
+            device float* d2 = dst + (ulong)t * p.out_f + ro;                                     \
+            threadgroup const float* c2 = shraw + j * 64u;                                        \
+            for (uint i = 0; i < 64u; i++) d2[i] = c2[i] * w;                                     \
+        }                                                                                         \
+    }                                                                                             \
+}
+MOE_CMM_KERNEL(linear_q4k_cmm_id,   DEC16_Q4K, 1, 0)
+MOE_CMM_KERNEL(linear_q4k_cmm_id_w, DEC16_Q4K, 0, 1)
+MOE_CMM_KERNEL(linear_q6k_cmm_id,   DEC16_Q6K, 1, 0)
+MOE_CMM_KERNEL(linear_q6k_cmm_id_w, DEC16_Q6K, 0, 1)
+#undef MOE_CMM_KERNEL
+
 // Weighted expert sum: dst[i] = sum_u y[u*ne + i] (weights already folded into y by the down
 // GEMV's EPI-2 epilogue; slot-ascending order matches the CPU reference).
-struct MoeReduceParams { uint ne; uint n_used; };
+struct MoeReduceParams { uint ne; uint n_used; uint rows; uint row0; };
 kernel void moe_reduce(device const float* y   [[buffer(0)]],
                        device float*       dst [[buffer(1)]],
                        constant MoeReduceParams& p [[buffer(2)]],
                        uint gid [[thread_position_in_grid]]) {
-    if (gid >= p.ne) return;
+    if (gid >= p.rows * p.ne) return;
+    uint row = gid / p.ne;
+    uint i = gid % p.ne;
     float s = 0.0f;
-    for (uint u = 0; u < p.n_used; u++) s += y[u * p.ne + gid];
-    dst[gid] = s;
+    for (uint u = 0; u < p.n_used; u++) s += y[(row * p.n_used + u) * p.ne + i];
+    dst[(p.row0 + row) * p.ne + i] = s;
 }
 
 struct MoeTopkParams { uint n_expert; uint n_used; float scale; };
-kernel void moe_topk(device const float* logits [[buffer(0)]],
-                     device uint*        tbl    [[buffer(1)]],
+kernel void moe_topk(device const float* logits_all [[buffer(0)]],
+                     device uint*        tbl_all    [[buffer(1)]],
                      constant MoeTopkParams& p  [[buffer(2)]],
                      uint gid [[thread_position_in_grid]]) {
-    uint lane = gid;   // one simdgroup (32 threads); each lane owns experts e = lane + 32j
+    // one simdgroup (32 threads) per token row; each lane owns experts e = lane + 32j
+    uint row = gid / 32u;
+    uint lane = gid % 32u;
+    device const float* logits = logits_all + (ulong)row * p.n_expert;
+    device uint* tbl = tbl_all + row * 32u;
     float lmax = -MAXFLOAT;
     for (uint e = lane; e < p.n_expert; e += 32u) lmax = max(lmax, logits[e]);
     float maxl = simd_max(lmax);

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -2066,6 +2066,166 @@ kernel void attnvec_dyn_q8kv_t(device const float* q    [[buffer(0)]],
     attnvec_q8_body<hd, NSG>(q, k, v, dst, p, abs, abs + 1u, sq, ssc, so, tgpig, sgitg, tiisg);
 }
 
+// Cooperative flash attention over a Q8_0 cache — the attnflash2 structure with a cooperative
+// dequant-staging stage (the llama.cpp flash_attn_ext quantized-KV branch shape): K/V can't be
+// simdgroup_load'ed from q8 blocks, so per 64-position KV block all 128 threads dequantize the
+// tile into threadgroup memory — K PRE-TRANSPOSED [hd][64] so the QK fragments load
+// non-transposed and conflict-free, V row-major [64][hd] staged into the SAME tile during the
+// softmax phase (the K reads are done by then; one extra barrier per block). ~24 KB threadgroup
+// at hd=128 (vs 8 KB for the f16 kernel — the occupancy cost of in-kernel dequant).
+template<uint hd, uint NSG>
+kernel void attnflash2_q8kv_t(device const half*  q   [[buffer(0)]],
+                              device const uchar* k   [[buffer(1)]],
+                              device const uchar* v   [[buffer(2)]],
+                              device float*       dst [[buffer(3)]],
+                              constant AttnParams& p  [[buffer(4)]],
+                              uint3  tgpig [[threadgroup_position_in_grid]],
+                              ushort sgitg [[simdgroup_index_in_threadgroup]],
+                              ushort tiisg [[thread_index_in_simdgroup]]) {
+    constexpr uint QT = 8, C = 64, NQ = QT / NSG, SH = C;
+    constexpr uint NBR = hd / 32u;          // q8 blocks per KV row
+    threadgroup half  sq[QT * hd];
+    threadgroup float so[QT * hd];
+    threadgroup float ss[QT * SH];
+    threadgroup half  kvt[C * hd];          // K as [hd][C], then V as [C][hd]
+
+    uint ntq = (p.rows + QT - 1u) / QT;
+    uint qt = tgpig.x % ntq;
+    uint h  = tgpig.x / ntq;
+    constexpr uint hd4 = hd / 4u;
+    constexpr uint no = hd / (8u * NSG);
+    constexpr uint NC = (C / 8u) / NSG;
+    uint kvh = h / (p.n_head / p.n_kv);
+    uint r0 = qt * QT;
+    uint abs0 = p.pos + r0;
+    uint abs_max = p.pos + min(p.rows - 1u, r0 + QT - 1u);
+    uint lo_min = (p.window > 0u && abs0 + 1u > p.window) ? (abs0 + 1u - p.window) : 0u;
+    ulong qstride = (ulong)p.n_head * hd;
+    uint tid = (uint)sgitg * 32u + tiisg;
+
+    for (uint jj = 0; jj < NQ; jj++) {
+        uint j = jj * NSG + sgitg;
+        bool live = r0 + j < p.rows;
+        device const half4* q4 =
+            (device const half4*)(q + (ulong)min(r0 + j, p.rows - 1u) * qstride + (ulong)h * hd);
+        threadgroup half4*  sq4 = (threadgroup half4*)sq + j * hd4;
+        threadgroup float4* so4 = (threadgroup float4*)so + j * hd4;
+        for (uint i = tiisg; i < hd4; i += 32u) {
+            sq4[i] = live ? q4[i] : half4(0.0h);
+            so4[i] = float4(0.0f);
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float S[NQ];
+    float M[NQ];
+    for (uint jj = 0; jj < NQ; jj++) { S[jj] = 0.0f; M[jj] = -MAXFLOAT / 2; }
+
+    for (uint ic = lo_min & ~(C - 1u); ic <= abs_max; ic += C) {
+        // stage K [hd][C]: each thread dequantizes whole q8 blocks (clamped rows are masked
+        // in the softmax, so their junk never contributes)
+        for (uint b = tid; b < C * NBR; b += NSG * 32u) {
+            uint rr = b / NBR;
+            uint dsub = (b % NBR) * 32u;
+            uint rc = min(ic + rr, p.kv_len - 1u);
+            ulong eb = ((ulong)rc * p.n_kv + kvh) * hd + dsub;
+            device const uchar* blk = k + (eb >> 5) * 34ul;
+            float d = (float)*(device const half*)blk;
+            for (uint i = 0; i < 32u; i++)
+                kvt[(dsub + i) * C + rr] = (half)(d * (float)(char)blk[2u + i]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            threadgroup const half* pk = kvt + 8u * sgitg;
+            threadgroup float* ps = ss + 8u * sgitg;
+            for (uint cc = 0; cc < NC; cc++) {
+                simdgroup_float8x8 mqk = simdgroup_float8x8(0.0f);
+                if (ic + 8u * (sgitg + cc * NSG) <= abs_max) {
+                    for (uint i = 0; i < hd; i += 16u) {
+                        simdgroup_half8x8 mq, mk;
+                        simdgroup_load(mq, sq + i, hd);
+                        simdgroup_load(mk, pk + i * C, C);
+                        simdgroup_multiply_accumulate(mqk, mq, mk, mqk);
+                        simdgroup_load(mq, sq + i + 8u, hd);
+                        simdgroup_load(mk, pk + (i + 8u) * C, C);
+                        simdgroup_multiply_accumulate(mqk, mq, mk, mqk);
+                    }
+                }
+                simdgroup_store(mqk, ps, SH);
+                pk += 8u * NSG;
+                ps += 8u * NSG;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // softmax (rows split across simdgroups) + V staging [C][hd] in the same phase —
+        // the K reads are complete, the V reads haven't started
+        for (uint jj = 0; jj < NQ; jj++) {
+            uint j = jj * NSG + sgitg;
+            uint absr = abs0 + j;
+            uint lor = (p.window > 0u && absr + 1u > p.window) ? (absr + 1u - p.window) : 0u;
+            threadgroup float2* ss2 = (threadgroup float2*)(ss + j * SH);
+            float2 s2 = ss2[tiisg] * p.scale;
+            uint c0 = ic + 2u * tiisg;
+            bool v0 = (c0 >= lor) && (c0 <= absr);
+            bool v1 = (c0 + 1u >= lor) && (c0 + 1u <= absr);
+            float m = M[jj];
+            float mnew =
+                simd_max(max(m, max(v0 ? s2.x : -MAXFLOAT / 2, v1 ? s2.y : -MAXFLOAT / 2)));
+            float ms = exp(m - mnew);
+            float pw0 = v0 ? exp(s2.x - mnew) : 0.0f;
+            float pw1 = v1 ? exp(s2.y - mnew) : 0.0f;
+            S[jj] = S[jj] * ms + simd_sum(pw0 + pw1);
+            M[jj] = mnew;
+            ss2[tiisg] = float2(pw0, pw1);
+            threadgroup float4* so4 = (threadgroup float4*)so + j * hd4;
+            for (uint i = tiisg; i < hd4; i += 32u) so4[i] *= ms;
+        }
+        for (uint b = tid; b < C * NBR; b += NSG * 32u) {
+            uint rr = b / NBR;
+            uint dsub = (b % NBR) * 32u;
+            uint rc = min(ic + rr, p.kv_len - 1u);
+            ulong eb = ((ulong)rc * p.n_kv + kvh) * hd + dsub;
+            device const uchar* blk = v + (eb >> 5) * 34ul;
+            float d = (float)*(device const half*)blk;
+            for (uint i = 0; i < 32u; i++)
+                kvt[rr * hd + dsub + i] = (half)(d * (float)(char)blk[2u + i]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            simdgroup_float8x8 lo[4];
+            threadgroup float* sot = so + 8u * sgitg;
+            for (uint ii = 0; ii < no; ii++) simdgroup_load(lo[ii], sot + 8u * NSG * ii, hd);
+            threadgroup const half* pv = kvt + 8u * sgitg;
+            uint nblk = min(C / 8u, (abs_max - ic) / 8u + 1u);
+            for (uint cc = 0; cc < nblk; cc++) {
+                simdgroup_float8x8 vs;
+                simdgroup_load(vs, ss + 8u * cc, SH);
+                for (uint ii = 0; ii < no; ii++) {
+                    simdgroup_half8x8 mv;
+                    simdgroup_load(mv, pv + 8u * NSG * ii, hd);
+                    simdgroup_multiply_accumulate(lo[ii], vs, mv, lo[ii]);
+                }
+                pv += 8u * hd;
+            }
+            for (uint ii = 0; ii < no; ii++) simdgroup_store(lo[ii], sot + 8u * NSG * ii, hd);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    for (uint jj = 0; jj < NQ; jj++) {
+        uint j = jj * NSG + sgitg;
+        if (r0 + j >= p.rows) continue;
+        float sc = S[jj] == 0.0f ? 0.0f : 1.0f / S[jj];
+        device float4* out = (device float4*)(dst + ((ulong)(r0 + j)) * qstride + (ulong)h * hd);
+        threadgroup const float4* so4 = (threadgroup const float4*)so + j * hd4;
+        for (uint i = tiisg; i < hd4; i += 32u) out[i] = so4[i] * sc;
+    }
+}
+
+typedef decltype(attnflash2_q8kv_t<64, 4>) attnflash2_q8_t;
+template [[host_name("attnflash2_q8kv_hd64")]]  kernel attnflash2_q8_t attnflash2_q8kv_t<64, 4>;
+template [[host_name("attnflash2_q8kv_hd128")]] kernel attnflash2_q8_t attnflash2_q8kv_t<128, 4>;
+
 typedef decltype(attnvec_q8kv_t<64, 32>) attnvec_q8_t;
 template [[host_name("attnvec_q8kv_hd64")]]  kernel attnvec_q8_t attnvec_q8kv_t<64, 32>;
 template [[host_name("attnvec_q8kv_hd128")]] kernel attnvec_q8_t attnvec_q8kv_t<128, 32>;

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -461,12 +461,15 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
 // GEMV left on the table.
 // Body shared by the plain GEMV and the fused-residual variant (`FADD`: dst = W·x + res, the
 // decode o_proj/down_proj + Add peephole — one dispatch and no sublayer-output round-trip).
-template<bool FADD>
+// EPI epilogue modes: 0 = dst = s; 1 = dst = s + res (fused residual Add); 2 = MoE accumulate,
+// dst = (zeroacc ? 0 : dst) + wgt*s (the weighted expert sum, first expert zeroes).
+template<int EPI, typename PT>
 inline void linear_q4k_body(device const float*  x,
                             device const uchar*  codes,
                             device float*        dst,
                             device const float*  res,
-                            constant QLinParams& p,
+                            constant PT& p,
+                            float wgt, bool zeroacc,
                             uint gid, uint lane) {
     uint first_row = (gid / 32u) * 2u;
     if (first_row >= p.out_f) return;
@@ -532,7 +535,11 @@ inline void linear_q4k_body(device const float*  x,
     }
     for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
         float s = simd_sum(sumf[row]);
-        if (lane == 0u) dst[first_row + row] = FADD ? s + res[first_row + row] : s;
+        if (lane == 0u) {
+            if (EPI == 2)      dst[first_row + row] = (zeroacc ? 0.0f : dst[first_row + row]) + wgt * s;
+            else if (EPI == 1) dst[first_row + row] = s + res[first_row + row];
+            else               dst[first_row + row] = s;
+        }
     }
 }
 
@@ -544,7 +551,7 @@ kernel void linear_q4k(device const float*  x     [[buffer(0)]],
                        constant QLinParams& p     [[buffer(5)]],
                        uint gid  [[thread_position_in_grid]],
                        uint lane [[thread_index_in_simdgroup]]) {
-    linear_q4k_body<false>(x, codes, dst, x, p, gid, lane);
+    linear_q4k_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
 }
 kernel void linear_q4k_add(device const float*  x     [[buffer(0)]],
                            device const uchar*  codes [[buffer(1)]],
@@ -555,15 +562,16 @@ kernel void linear_q4k_add(device const float*  x     [[buffer(0)]],
                            constant QLinParams& p     [[buffer(6)]],
                            uint gid  [[thread_position_in_grid]],
                            uint lane [[thread_index_in_simdgroup]]) {
-    linear_q4k_body<true>(x, codes, dst, res, p, gid, lane);
+    linear_q4k_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
 }
 
-template<bool FADD>
+template<int EPI, typename PT>
 inline void linear_q6k_body(device const float*  x,
                             device const uchar*  codes,
                             device float*        dst,
                             device const float*  res,
-                            constant QLinParams& p,
+                            constant PT& p,
+                            float wgt, bool zeroacc,
                             uint gid, uint lane) {
     uint first_row = (gid / 32u) * 2u;
     if (first_row >= p.out_f) return;
@@ -619,7 +627,11 @@ inline void linear_q6k_body(device const float*  x,
     }
     for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
         float s = simd_sum(sumf[row]);
-        if (lane == 0u) dst[first_row + row] = FADD ? s + res[first_row + row] : s;
+        if (lane == 0u) {
+            if (EPI == 2)      dst[first_row + row] = (zeroacc ? 0.0f : dst[first_row + row]) + wgt * s;
+            else if (EPI == 1) dst[first_row + row] = s + res[first_row + row];
+            else               dst[first_row + row] = s;
+        }
     }
 }
 
@@ -631,7 +643,7 @@ kernel void linear_q6k(device const float*  x     [[buffer(0)]],
                        constant QLinParams& p     [[buffer(5)]],
                        uint gid  [[thread_position_in_grid]],
                        uint lane [[thread_index_in_simdgroup]]) {
-    linear_q6k_body<false>(x, codes, dst, x, p, gid, lane);
+    linear_q6k_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
 }
 kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
                            device const uchar*  codes [[buffer(1)]],
@@ -642,7 +654,90 @@ kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
                            constant QLinParams& p     [[buffer(6)]],
                            uint gid  [[thread_position_in_grid]],
                            uint lane [[thread_index_in_simdgroup]]) {
-    linear_q6k_body<true>(x, codes, dst, res, p, gid, lane);
+    linear_q6k_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
+}
+
+// ---- MoE expert GEMVs: the shared GEMV bodies, batched over the SELECTED experts — one
+// dispatch covers all n_used experts (slot = high grid bits), each picking its weight slice
+// from the device expert table (`moe_topk` below), so a whole MoE FFN is 7 dispatches with no
+// host round-trip. Gate/up read the shared x and write per-slot rows of the [n_used, out_f]
+// scratch; the down variant (EPI 2) reads its slot's activation row and writes w[slot]*y to its
+// slot's output row — `moe_reduce` then folds the weighted expert sum (slot-ascending, the CPU
+// reference's accumulation order).
+struct MoeLinParams { uint m; uint in_f; uint out_f; uint dshift; uint n_used; };
+#define MOE_WRAP(NAME, BODY, EPI, ROWB)                                                           \
+kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
+                 device const uchar*  codes [[buffer(1)]],                                       \
+                 device const uchar*  scm   [[buffer(2)]],                                       \
+                 device const uchar*  dd    [[buffer(3)]],                                       \
+                 device float*        dst   [[buffer(4)]],                                       \
+                 device const uint*   tbl   [[buffer(5)]],                                       \
+                 constant MoeLinParams& p   [[buffer(6)]],                                       \
+                 uint gid  [[thread_position_in_grid]],                                          \
+                 uint lane [[thread_index_in_simdgroup]]) {                                      \
+    uint sg = gid / 32u;                                                                          \
+    uint per_out = p.out_f >> 1;         /* simdgroups per expert (2 rows each) */               \
+    uint slot = sg / per_out;                                                                     \
+    uint e = tbl[slot];                                                                           \
+    float w = as_type<float>(tbl[16u + slot]); /* weights after the 16-slot index block */        \
+    ulong row_b = (ulong)(p.in_f >> 8) * ROWB;                                                    \
+    device const uchar* ec = codes + (ulong)e * p.out_f * row_b;                                  \
+    device const float* xs = (EPI == 2) ? x + slot * p.in_f : x;                                  \
+    uint g2 = (sg % per_out) * 32u + lane;   /* body sees a per-expert grid */                    \
+    BODY<EPI>(xs, ec, dst + slot * p.out_f, xs, p, w, true, g2, lane);                            \
+}
+MOE_WRAP(linear_q4k_moe,     linear_q4k_body, 0, 144ul)
+MOE_WRAP(linear_q4k_moe_acc, linear_q4k_body, 2, 144ul)
+MOE_WRAP(linear_q6k_moe,     linear_q6k_body, 0, 210ul)
+MOE_WRAP(linear_q6k_moe_acc, linear_q6k_body, 2, 210ul)
+#undef MOE_WRAP
+
+// Weighted expert sum: dst[i] = sum_u y[u*ne + i] (weights already folded into y by the down
+// GEMV's EPI-2 epilogue; slot-ascending order matches the CPU reference).
+struct MoeReduceParams { uint ne; uint n_used; };
+kernel void moe_reduce(device const float* y   [[buffer(0)]],
+                       device float*       dst [[buffer(1)]],
+                       constant MoeReduceParams& p [[buffer(2)]],
+                       uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.ne) return;
+    float s = 0.0f;
+    for (uint u = 0; u < p.n_used; u++) s += y[u * p.ne + gid];
+    dst[gid] = s;
+}
+
+struct MoeTopkParams { uint n_expert; uint n_used; float scale; };
+kernel void moe_topk(device const float* logits [[buffer(0)]],
+                     device uint*        tbl    [[buffer(1)]],
+                     constant MoeTopkParams& p  [[buffer(2)]],
+                     uint gid [[thread_position_in_grid]]) {
+    if (gid != 0u) return;
+    float maxl = -MAXFLOAT;
+    for (uint e = 0; e < p.n_expert; e++) maxl = max(maxl, logits[e]);
+    float psum = 0.0f;
+    for (uint e = 0; e < p.n_expert; e++) psum += exp(logits[e] - maxl);
+    uint sel[16];
+    // exp is monotonic: top-k by logit == top-k by prob, same first-index tie rule
+    for (uint u = 0; u < p.n_used; u++) {
+        float best = -MAXFLOAT;
+        uint bi = 0u;
+        for (uint e = 0; e < p.n_expert; e++) {
+            bool taken = false;
+            for (uint t = 0; t < u; t++) taken = taken || (sel[t] == e);
+            if (!taken && logits[e] > best) { best = logits[e]; bi = e; }
+        }
+        sel[u] = bi;
+    }
+    float wsum = 0.0f;
+    float ws[16];
+    for (uint u = 0; u < p.n_used; u++) {
+        ws[u] = exp(logits[sel[u]] - maxl) / psum;
+        wsum += ws[u];
+    }
+    wsum = max(wsum, 1e-20f);
+    for (uint u = 0; u < p.n_used; u++) {
+        tbl[u] = sel[u];
+        tbl[16u + u] = as_type<uint>(ws[u] / wsum * p.scale);
+    }
 }
 
 GEMV_KERNEL(linear_quik4, DEC16_K4)

--- a/crates/infr-metal/tests/moe_bw.rs
+++ b/crates/infr-metal/tests/moe_bw.rs
@@ -1,0 +1,122 @@
+//! Probe: device vs host MoeFfn path at Qwen3-30B-A3B decode shapes (one token, one layer).
+//! Temporary evidence for the MoE-on-device work — run with
+//! `INFR_METAL_NOMOE=1` to force the host path for the comparison:
+//! `cargo test -p infr-metal --release --test moe_bw -- --ignored --nocapture`.
+#![cfg(target_os = "macos")]
+
+use infr_core::backend::{Backend, Bindings, Buffer, BufferUsage};
+use infr_core::graph::{Graph, Op};
+use infr_core::tensor::{DType, TensorDesc};
+use infr_metal::MetalBackend;
+
+fn lcg_bytes(mut seed: u32, n: usize) -> Vec<u8> {
+    (0..n)
+        .map(|_| {
+            seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+            (seed >> 16) as u8
+        })
+        .collect()
+}
+
+fn synth_q4k(n_elem: usize, seed: u32) -> Vec<u8> {
+    let mut out = Vec::new();
+    for blk_i in 0..(n_elem / 256) {
+        let mut blk = vec![0u8; 144];
+        blk[0..2].copy_from_slice(&half::f16::from_f32(0.05).to_le_bytes());
+        blk[2..4].copy_from_slice(&half::f16::from_f32(0.10).to_le_bytes());
+        blk[4..144].copy_from_slice(&lcg_bytes(seed ^ blk_i as u32, 140));
+        out.extend_from_slice(&blk);
+    }
+    out
+}
+
+#[test]
+#[ignore = "requires a Metal GPU (evidence probe)"]
+fn moe_layer_wall() {
+    // Qwen3-30B-A3B MoE layer: ne=2048, n_ff_exp=768, 128 experts, 8 used.
+    let (ne, n_expert, n_used, nff) = (2048usize, 128usize, 8usize, 768usize);
+    let be = MetalBackend::new().unwrap();
+
+    // CHAIN of layers in one graph (dst feeds the next op's x), so the timing reports the
+    // MARGINAL per-layer cost inside a batched forward, not the fixed per-execute overhead.
+    let nlayers = 8usize;
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![ne], DType::F32));
+    let router = g.weight(TensorDesc::new(vec![n_expert, ne], DType::F32));
+    let gate = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::Q4K));
+    let up = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::Q4K));
+    let down = g.weight(TensorDesc::new(vec![n_expert, ne, nff], DType::Q4K));
+    let mut cur = x;
+    let mut dst = x;
+    for l in 0..nlayers {
+        dst = if l + 1 == nlayers {
+            g.output(TensorDesc::new(vec![ne], DType::F32))
+        } else {
+            g.internal(TensorDesc::new(vec![ne], DType::F32))
+        };
+        g.push(Op::MoeFfn {
+            x: cur,
+            router,
+            gate_exps: gate,
+            up_exps: up,
+            down_exps: down,
+            dst,
+            ne: ne as u32,
+            n_expert: n_expert as u32,
+            n_used: n_used as u32,
+            n_ff_exp: nff as u32,
+            scale: 1.0,
+            act: infr_core::graph::Activation::Silu,
+        });
+        cur = dst;
+    }
+
+    let xs: Vec<f32> = (0..ne).map(|i| (i % 13) as f32 * 0.01 - 0.06).collect();
+    let rw: Vec<f32> = (0..n_expert * ne).map(|i| (i % 17) as f32 * 0.001).collect();
+    let bound: Vec<(infr_core::tensor::TensorId, Vec<u8>)> = vec![
+        (x, bytemuck::cast_slice(&xs).to_vec()),
+        (router, bytemuck::cast_slice(&rw).to_vec()),
+        (gate, synth_q4k(n_expert * nff * ne, 1)),
+        (up, synth_q4k(n_expert * nff * ne, 2)),
+        (down, synth_q4k(n_expert * ne * nff, 3)),
+    ];
+
+    let mut bufs: Vec<(infr_core::tensor::TensorId, Box<dyn Buffer>)> = Vec::new();
+    for (id, bytes) in &bound {
+        let b = be.alloc(bytes.len().max(4), BufferUsage::Weights).unwrap();
+        be.upload(b.as_ref(), bytes).unwrap();
+        bufs.push((*id, b));
+    }
+    let ob = be.alloc(ne * 4, BufferUsage::Activations).unwrap();
+    bufs.push((dst, ob));
+    let mut binds = Bindings::new();
+    for (id, b) in &bufs {
+        binds.bind(*id, b.as_ref());
+    }
+    let plan = be.compile(&g).unwrap();
+
+    // Warmup (weight-cache build + pipeline compile), then timed reps.
+    for _ in 0..3 {
+        be.execute(plan.as_ref(), &binds).unwrap();
+    }
+    be.sync().unwrap();
+    let reps = 50;
+    let t0 = std::time::Instant::now();
+    for _ in 0..reps {
+        be.execute(plan.as_ref(), &binds).unwrap();
+    }
+    be.sync().unwrap();
+    let per = t0.elapsed().as_secs_f64() / (reps * nlayers) as f64;
+    let path = if std::env::var("INFR_METAL_NOMOE").is_ok() {
+        "host"
+    } else {
+        "device"
+    };
+    // Active bytes per token: 3 matmuls x n_used experts (q4k = 4.5 bpw -> 0.5625 B/elem).
+    let mb = (3 * n_used * nff * ne) as f64 * 0.5625 / 1e6;
+    println!(
+        "moe layer ({path}, marginal of {nlayers}-chain): {:.3} ms/op, active expert stream {mb:.1} MB -> {:.1} GB/s",
+        per * 1e3,
+        mb / 1e3 / per
+    );
+}

--- a/crates/infr-metal/tests/moe_bw.rs
+++ b/crates/infr-metal/tests/moe_bw.rs
@@ -72,7 +72,9 @@ fn moe_layer_wall() {
     }
 
     let xs: Vec<f32> = (0..ne).map(|i| (i % 13) as f32 * 0.01 - 0.06).collect();
-    let rw: Vec<f32> = (0..n_expert * ne).map(|i| (i % 17) as f32 * 0.001).collect();
+    let rw: Vec<f32> = (0..n_expert * ne)
+        .map(|i| (i % 17) as f32 * 0.001)
+        .collect();
     let bound: Vec<(infr_core::tensor::TensorId, Vec<u8>)> = vec![
         (x, bytemuck::cast_slice(&xs).to_vec()),
         (router, bytemuck::cast_slice(&rw).to_vec()),

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -784,6 +784,101 @@ fn writekv_f16_parity() {
     assert_eq!(cpu, mtl, "WriteKv f16 cache bytes must be identical");
 }
 
+// Q8_0 KV cache (INFR_KV_Q8): the quantization on write must be BYTE-identical between the CPU
+// reference and the Metal kernel (d = amax/127 as f16, q = rint(x/d)).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn writekv_q8_parity() {
+    let (rows, row_stride, max_ctx, pos) = (2usize, 256usize, 8usize, 3usize);
+    let cache_bytes = max_ctx * row_stride / 32 * 34;
+    let mut g = Graph::new();
+    let src = g.input(TensorDesc::new(vec![rows, row_stride], DType::F32));
+    let cache = g.input(TensorDesc::new(vec![max_ctx * row_stride], DType::Q8_0));
+    g.push(Op::WriteKv {
+        src,
+        cache,
+        rows: rows as u32,
+        row_stride: row_stride as u32,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (src, f32_bytes(&rand_f32(rows * row_stride, 44))),
+        (cache, vec![0u8; cache_bytes]),
+    ];
+    let cpu = run_readback(&CpuBackend::new(), &g, &bound, cache, cache_bytes);
+    let mtl = run_readback(
+        &MetalBackend::new().expect("metal backend"),
+        &g,
+        &bound,
+        cache,
+        cache_bytes,
+    );
+    assert_eq!(cpu, mtl, "WriteKv q8 cache bytes must be identical");
+}
+
+// Attention over a Q8_0 cache: WriteKv quantizes, Attention dequantizes on read. Both routes:
+// the scalar fallback (prefill shape) and the rows==1 vector kernel (decode at depth).
+fn q8_attention_test(rows: usize, kv_len: usize, hd: usize, pos: usize, tol: f32, seed: u64) {
+    let (nh, nkv) = (8usize, 2usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::Q8_0));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::Q8_0));
+    let ksrc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F32));
+    let vsrc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let row = (nkv * hd) as u32;
+    g.push(Op::WriteKv {
+        src: ksrc,
+        cache: kc,
+        rows: kv_len as u32,
+        row_stride: row,
+        pos: 0,
+    });
+    g.push(Op::WriteKv {
+        src: vsrc,
+        cache: vc,
+        rows: kv_len as u32,
+        row_stride: row,
+        pos: 0,
+    });
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::Causal,
+        pos: pos as u32,
+    });
+    let nkv_elems = kv_len * nkv * hd;
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, seed))),
+        (kc, vec![0u8; nkv_elems / 32 * 34]),
+        (vc, vec![0u8; nkv_elems / 32 * 34]),
+        (ksrc, f32_bytes(&rand_f32(nkv_elems, seed + 1))),
+        (vsrc, f32_bytes(&rand_f32(nkv_elems, seed + 2))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, tol);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_q8_scalar_parity() {
+    q8_attention_test(3, 6, 64, 3, 1e-4, 240);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_q8_vec_parity() {
+    q8_attention_test(1, 200, 128, 199, 1e-4, 250);
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn attention_gqa_causal_parity() {

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1265,6 +1265,24 @@ fn gatedact_upoff_parity() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn gatedactfused_parity() {
+    let (rows, nff) = (3usize, 256usize);
+    let mut g = Graph::new();
+    let gu = g.input(TensorDesc::new(vec![rows, 2 * nff], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, nff], DType::F32));
+    g.push(Op::GatedActFused {
+        gu,
+        dst,
+        rows: rows as u32,
+        nff: nff as u32,
+        act: infr_core::graph::Activation::Silu,
+    });
+    let bound = vec![(gu, f32_bytes(&rand_f32(rows * 2 * nff, 270)))];
+    assert_parity(&g, &bound, dst, rows * nff, 1e-5);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn moe_ffn_parity() {
     let (ne, n_expert, n_used, nff) = (64usize, 8usize, 2usize, 128usize);
     let mut g = Graph::new();

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1195,6 +1195,54 @@ fn moe_ffn_parity() {
     assert_parity(&g, &bound, dst, ne, 1e-3);
 }
 
+// Quantized experts route to the DEVICE MoE path (router GEMV + on-device top-k + expert-table
+// GEMVs); the f32 test above keeps the host fallback covered. CPU is the oracle here (its MoE
+// matvec dequants the same bytes and dots in f32 — no Q8 activation quantization).
+fn moe_quant_test(dtype: DType, synth: fn(usize, u32) -> Vec<u8>, seed: u32) {
+    let (ne, n_expert, n_used, nff) = (256usize, 8usize, 3usize, 256usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![ne], DType::F32));
+    let router = g.weight(TensorDesc::new(vec![n_expert, ne], DType::F32));
+    let gate = g.weight(TensorDesc::new(vec![n_expert, nff, ne], dtype));
+    let up = g.weight(TensorDesc::new(vec![n_expert, nff, ne], dtype));
+    let down = g.weight(TensorDesc::new(vec![n_expert, ne, nff], dtype));
+    let dst = g.output(TensorDesc::new(vec![ne], DType::F32));
+    g.push(Op::MoeFfn {
+        x,
+        router,
+        gate_exps: gate,
+        up_exps: up,
+        down_exps: down,
+        dst,
+        ne: ne as u32,
+        n_expert: n_expert as u32,
+        n_used: n_used as u32,
+        n_ff_exp: nff as u32,
+        scale: 1.0,
+        act: infr_core::graph::Activation::Silu,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(ne, seed as u64))),
+        (router, f32_bytes(&rand_f32(n_expert * ne, seed as u64 + 1))),
+        (gate, synth(n_expert * nff * ne, seed + 2)),
+        (up, synth(n_expert * nff * ne, seed + 3)),
+        (down, synth(n_expert * ne * nff, seed + 4)),
+    ];
+    assert_parity(&g, &bound, dst, ne, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn moe_ffn_q4k_device_parity() {
+    moe_quant_test(DType::Q4K, synth_q4k, 80);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn moe_ffn_q6k_device_parity() {
+    moe_quant_test(DType::Q6K, synth_q6k, 90);
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn conv1d_silu_parity() {

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -879,6 +879,14 @@ fn attention_q8_vec_parity() {
     q8_attention_test(1, 200, 128, 199, 1e-4, 250);
 }
 
+// Wide q8 launch: routes to the cooperative q8 flash (dequant-staged KV tiles). Q rounds to f16
+// on this path (the flash trade), hence the flash-class tolerance.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_q8_flash_parity() {
+    q8_attention_test(17, 136, 128, 119, 5e-3, 260);
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn attention_gqa_causal_parity() {

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1243,6 +1243,109 @@ fn moe_ffn_q6k_device_parity() {
     moe_quant_test(DType::Q6K, synth_q6k, 90);
 }
 
+// Batched rows through the device MoE path (rows spanning two 256-row chunks): every row routes
+// independently; parity vs the CPU reference's per-row loop.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn moe_ffn_batched_rows_parity() {
+    let (rows, ne, n_expert, n_used, nff) = (300usize, 256usize, 8usize, 3usize, 256usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, ne], DType::F32));
+    let router = g.weight(TensorDesc::new(vec![n_expert, ne], DType::F32));
+    let gate = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::Q4K));
+    let up = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::Q4K));
+    let down = g.weight(TensorDesc::new(vec![n_expert, ne, nff], DType::Q4K));
+    let dst = g.output(TensorDesc::new(vec![rows, ne], DType::F32));
+    g.push(Op::MoeFfn {
+        x,
+        router,
+        gate_exps: gate,
+        up_exps: up,
+        down_exps: down,
+        dst,
+        ne: ne as u32,
+        n_expert: n_expert as u32,
+        n_used: n_used as u32,
+        n_ff_exp: nff as u32,
+        scale: 1.0,
+        act: infr_core::graph::Activation::Silu,
+    });
+    // x scaled down: the ~50x-real synthetic weights would push gate/up activations past f16
+    // range (the kernels' operand precision) with unit-scale inputs — real hidden states don't.
+    let xs_small: Vec<f32> = rand_f32(rows * ne, 95).iter().map(|v| v * 0.02).collect();
+    let bound = vec![
+        (x, f32_bytes(&xs_small)),
+        (router, f32_bytes(&rand_f32(n_expert * ne, 96))),
+        (gate, synth_q4k(n_expert * nff * ne, 97)),
+        (up, synth_q4k(n_expert * nff * ne, 98)),
+        (down, synth_q4k(n_expert * ne * nff, 99)),
+    ];
+    // Reference mirrors the grouped-GEMM path's numerics (same policy as the dense GEMM parity
+    // tests): expert weights and stage inputs round to f16 (the kernels' operand precision, f32
+    // accumulate), router/top-k stay f32. Residual tolerance covers reassociation over the
+    // ~50x-real-magnitude synthetic weights' cancellation tail.
+    let r16 =
+        |v: &[f32]| -> Vec<f32> { v.iter().map(|&x| half::f16::from_f32(x).to_f32()).collect() };
+    let xs: Vec<f32> = {
+        let (_, b) = &bound[0];
+        bytemuck::cast_slice::<u8, f32>(b).to_vec()
+    };
+    let rw: Vec<f32> = {
+        let (_, b) = &bound[1];
+        bytemuck::cast_slice::<u8, f32>(b).to_vec()
+    };
+    use infr_gguf::dequant::dequant_block;
+    let gw = r16(&dequant_block(DType::Q4K, &bound[2].1).unwrap());
+    let uw = r16(&dequant_block(DType::Q4K, &bound[3].1).unwrap());
+    let dw = r16(&dequant_block(DType::Q4K, &bound[4].1).unwrap());
+    let mut reference = vec![0f32; rows * ne];
+    for row in 0..rows {
+        let x = &xs[row * ne..(row + 1) * ne];
+        let logits: Vec<f32> = (0..n_expert)
+            .map(|e| (0..ne).map(|i| rw[e * ne + i] * x[i]).sum::<f32>())
+            .collect();
+        let maxl = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let probs: Vec<f32> = logits.iter().map(|&v| (v - maxl).exp()).collect();
+        let psum: f32 = probs.iter().sum();
+        let mut idx: Vec<usize> = (0..n_expert).collect();
+        idx.sort_by(|&a, &b| probs[b].partial_cmp(&probs[a]).unwrap());
+        idx.truncate(n_used);
+        let wsum: f32 = idx.iter().map(|&e| probs[e] / psum).sum::<f32>().max(1e-20);
+        let x16 = r16(x);
+        for &e in &idx {
+            let gs = &gw[e * nff * ne..(e + 1) * nff * ne];
+            let us = &uw[e * nff * ne..(e + 1) * nff * ne];
+            let ds = &dw[e * ne * nff..(e + 1) * ne * nff];
+            let gate: Vec<f32> = (0..nff)
+                .map(|o| (0..ne).map(|i| gs[o * ne + i] * x16[i]).sum::<f32>())
+                .collect();
+            let up: Vec<f32> = (0..nff)
+                .map(|o| (0..ne).map(|i| us[o * ne + i] * x16[i]).sum::<f32>())
+                .collect();
+            let act: Vec<f32> = (0..nff)
+                .map(|i| {
+                    let g = gate[i];
+                    (g / (1.0 + (-g).exp())) * up[i]
+                })
+                .collect();
+            let a16 = r16(&act);
+            let w_e = (probs[e] / psum) / wsum;
+            for o in 0..ne {
+                let y: f32 = (0..nff).map(|i| ds[o * nff + i] * a16[i]).sum();
+                reference[row * ne + o] += w_e * y;
+            }
+        }
+    }
+    let mtl = run(
+        &MetalBackend::new().expect("metal backend"),
+        &g,
+        &bound,
+        dst,
+        rows * ne,
+    );
+    assert_close(&reference, &mtl, 5e-3, "moe batched grouped");
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn conv1d_silu_parity() {

--- a/docs/METAL.md
+++ b/docs/METAL.md
@@ -155,6 +155,19 @@ which for these kernels means skipped KV slices and garbage merges. Every
 wide-threadgroup route checks its own pipeline's cap and degrades to the
 next-narrower kernel.
 
+## Q8_0 KV cache (`INFR_KV_Q8=1`)
+
+Opt-in: both caches stored as Q8_0 blocks (34 B / 32 elems) — **half the f16
+footprint and bandwidth**, so 16k-context sessions fit machines the f16 cache
+would swap on. Write quantization is byte-identical between the CPU reference
+and `writekv_q8` (d = amax/127 as f16, q = rint(x/d)); reads dequantize
+exactly. Decode at depth rides `attnvec_q8kv` (the vector kernel with
+dequant-on-read; also serves prefill until a q8 flash port — the named
+follow-up), everything else the scalar fallback. Throughput is
+model-dependent: the q8 read path trades bandwidth for ALU (ushort-pair code
+loads), measuring +13% on 0.6B tg128@d16384 (56.2 t/s) but ~-6% on 4B at
+d4096 — enable it for footprint or for small models at depth.
+
 ## Profiling
 
 `INFR_METAL_PROFILE=1`: per-op CPU-encode + GPU commit+wait wall, printed on

--- a/docs/METAL.md
+++ b/docs/METAL.md
@@ -161,12 +161,15 @@ Opt-in: both caches stored as Q8_0 blocks (34 B / 32 elems) — **half the f16
 footprint and bandwidth**, so 16k-context sessions fit machines the f16 cache
 would swap on. Write quantization is byte-identical between the CPU reference
 and `writekv_q8` (d = amax/127 as f16, q = rint(x/d)); reads dequantize
-exactly. Decode at depth rides `attnvec_q8kv` (the vector kernel with
-dequant-on-read; also serves prefill until a q8 flash port — the named
-follow-up), everything else the scalar fallback. Throughput is
-model-dependent: the q8 read path trades bandwidth for ALU (ushort-pair code
-loads), measuring +13% on 0.6B tg128@d16384 (56.2 t/s) but ~-6% on 4B at
-d4096 — enable it for footprint or for small models at depth.
+exactly. Prefill rides `attnflash2_q8kv` — the cooperative flash structure
+with a dequant-staging stage (all 128 threads dequantize each 64-position KV
+block into a 24 KB threadgroup tile: K pre-transposed [hd][64] for
+conflict-free fragment loads, V staged into the same tile during the softmax
+phase). Decode at depth rides `attnvec_q8kv`; the q8 decode replay tape
+records like f16. Throughput is model-dependent — the q8 read path trades
+bandwidth for ALU: 0.6B tg128@d16384 62.7 t/s (+26% over the f16 cache, +35%
+over llama.cpp's), 4B ~-6% (already weight-stream-bound); pp8192 runs at ~68%
+of the f16 flash. Enable it for the footprint, and for small models at depth.
 
 ## Profiling
 


### PR DESCRIPTION
**Draft, stacked on #10** — contains all of #10's commits plus one new commit (`e9e7d6b`); the diff collapses to just the MoE work once #10 merges.

## What

`Op::MoeFfn` previously ran on the host: per token per layer it dequantized three expert weight slices to f32 on the CPU and round-tripped each matvec through its own command buffer. For K-quant experts (the shapes real MoE checkpoints ship) the whole FFN now runs on-device in **seven dispatches**:

1. **Router GEMV** (dequant-cached f32 weight) → **`moe_topk`**: softmax + top-k on device — ties go to the lowest index, matching the CPU reference's stable sort — with renormalized weights written to a 32-slot device expert table.
2. **Gate/up/down GEMVs batched over the selected experts**: one dispatch covers all n_used slots (slot = high grid bits), each resolving its expert's weight slice from the table in-kernel. The shared `linear_q4k`/`linear_q6k` bodies gained an EPI-2 epilogue (`dst = w·s`) so the down projection folds the routing weight per slot.
3. **Gated activation** over all slots at once, and a final **`moe_reduce`** doing the slot-ascending weighted sum (the CPU accumulation order).

Expert scratch lives in a reusable (size, tag)-keyed pool — no per-op allocations. The host path is retained for non-K-quant dtypes and as the `INFR_METAL_NOMOE` escape hatch.

## Evidence

`tests/moe_bw.rs` (Qwen3-30B-A3B layer shape — ne=2048, 128 experts, 8 used, n_ff_exp=768 — M3 Pro, marginal cost in an 8-layer chain):

| path | ms / MoE layer |
|---|---|
| host (previous) | 114.9 |
| device, per-slot dispatches | 0.570 |
| device, expert-batched | **0.465** |

~250× over the host path. Parity: q4k + q6k device-path tests vs the CPU oracle, plus the existing f32 test keeping the host fallback covered (41 GPU tests, clippy clean).

## Caveats / draft status

- **Not yet validated on a real checkpoint** — no qwen3moe GGUF fits this machine's 18 GB (30B-A3B Q4_K_M is 18.6 GB). The op-level parity + probe are the evidence so far; happy to keep this as draft until someone runs a real model, or land it as strictly-better-than-host.
- Known follow-ups: `moe_topk` is serial on one thread (~tens of µs/layer, parallelizable), and prefill currently hits this op per token — a token-batched expert pass is the phase-2 item.