### PR TITLE
feat(metal): device DeltaNet + Conv1dSilu — qwen3-next linear attention on GPU

### DIFF
--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1585,6 +1585,34 @@ impl MetalBackend {
                 kernel,
             } => {
                 let (rr, cc, kk) = (rows as usize, channels as usize, kernel as usize);
+                // Device path: each thread owns one channel and its state column — no cross-
+                // thread deps, rows loop in-kernel, state updated in the BOUND buffer (the
+                // write-back self-copy guard keeps it authoritative). kk > 8 exceeds the
+                // kernel's register window; no real conv ships that (qwen3-next uses 4).
+                if kk <= 8 && std::env::var("INFR_METAL_NODELTA").is_err() {
+                    if let Some(sb) = bindings.get(state) {
+                        let bx = self.ensure_device(r, x);
+                        let bw = self.weight_buf(weight, g, bindings);
+                        let bd = self.dev_dst(r, dst, rr * cc);
+                        let sbuf = metal_buf(sb);
+                        let i = state.0 as usize;
+                        r.dev[i] = Some(Arc::new(sbuf.raw.clone()));
+                        r.loc[i] = Loc::Device;
+                        let pso = self.pipelines.get("conv1d_silu_f32")?;
+                        let mut p = (rr as u32).to_ne_bytes().to_vec();
+                        p.extend_from_slice(&(cc as u32).to_ne_bytes());
+                        p.extend_from_slice(&(kk as u32).to_ne_bytes());
+                        self.encode(
+                            r,
+                            &pso,
+                            &[bx.as_ref(), bw.as_ref(), &sbuf.raw, bd.as_ref()],
+                            &p,
+                            cc,
+                        );
+                        r.loc[dst.0 as usize] = Loc::Device;
+                        return Ok(());
+                    }
+                }
                 self.ensure_host(r, g, x);
                 self.ensure_host(r, g, state);
                 let xs = r.vals[x.0 as usize].clone(); // [rows, channels]
@@ -1639,6 +1667,64 @@ impl MetalBackend {
                     head_k as usize,
                     head_v as usize,
                 );
+                // Device path: one threadgroup per value head, one lane per value dim — each
+                // lane owns state column S[:, d] (the delta-rule update touches only that
+                // column, so the row scan needs no state synchronization). State updates the
+                // BOUND buffer in place. Gates match the kernel's shared/thread budgets.
+                if kd <= 256
+                    && vd.is_multiple_of(32)
+                    && vd <= 1024
+                    && std::env::var("INFR_METAL_NODELTA").is_err()
+                {
+                    if let Some(sb) = bindings.get(state) {
+                        let fits = self
+                            .pipelines
+                            .get("deltanet_f32")
+                            .map(|pl| pl.max_total_threads_per_threadgroup() >= vd as u64)
+                            .unwrap_or(false);
+                        if fits {
+                            let bq = self.ensure_device(r, q);
+                            let bk = self.ensure_device(r, k);
+                            let bv = self.ensure_device(r, v);
+                            let bb = self.ensure_device(r, b);
+                            let ba = self.ensure_device(r, a);
+                            let bac = self.weight_buf(a_coef, g, bindings);
+                            let bdt = self.weight_buf(dt_bias, g, bindings);
+                            let bd = self.dev_dst(r, dst, rr * nv * vd);
+                            let sbuf = metal_buf(sb);
+                            let i = state.0 as usize;
+                            r.dev[i] = Some(Arc::new(sbuf.raw.clone()));
+                            r.loc[i] = Loc::Device;
+                            let pso = self.pipelines.get("deltanet_f32")?;
+                            let mut p = (rr as u32).to_ne_bytes().to_vec();
+                            p.extend_from_slice(&(nv as u32).to_ne_bytes());
+                            p.extend_from_slice(&(nk as u32).to_ne_bytes());
+                            p.extend_from_slice(&(kd as u32).to_ne_bytes());
+                            p.extend_from_slice(&(vd as u32).to_ne_bytes());
+                            p.extend_from_slice(&eps.to_ne_bytes());
+                            self.encode_tg(
+                                r,
+                                &pso,
+                                &[
+                                    bq.as_ref(),
+                                    bk.as_ref(),
+                                    bv.as_ref(),
+                                    bb.as_ref(),
+                                    ba.as_ref(),
+                                    bac.as_ref(),
+                                    bdt.as_ref(),
+                                    &sbuf.raw,
+                                    bd.as_ref(),
+                                ],
+                                &p,
+                                nv * vd,
+                                vd,
+                            );
+                            r.loc[dst.0 as usize] = Loc::Device;
+                            return Ok(());
+                        }
+                    }
+                }
                 for id in [q, k, v, b, a, state] {
                     self.ensure_host(r, g, id);
                 }

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1535,7 +1535,121 @@ typedef decltype(attnvec_dyn_f16kv_t<64, 32>) attnvec_dyn_t;
 template [[host_name("attnvec_dyn_f16kv_hd64")]]  kernel attnvec_dyn_t attnvec_dyn_f16kv_t<64, 32>;
 template [[host_name("attnvec_dyn_f16kv_hd128")]] kernel attnvec_dyn_t attnvec_dyn_f16kv_t<128, 32>;
 
-// ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
+// ---- Gated DeltaNet (Qwen3-Next linear attention) + its depthwise conv, ON DEVICE. Both are
+// sequential-over-rows recurrences; the parallelism is across CHANNELS (conv: each thread owns a
+// channel and its state column, no cross-thread deps) and across (head, value-dim) (deltanet:
+// one threadgroup per value head, each lane owns state COLUMN S[:, d] — the delta-rule update
+// touches only that column, so rows need no state barrier, just the shared-q/k staging one).
+// State lives in the BOUND buffer and is updated in place (no host round-trip per layer).
+struct ConvSiluParams { uint rows; uint channels; uint kwidth; };
+kernel void conv1d_silu_f32(device const float* x     [[buffer(0)]],
+                            device const float* w     [[buffer(1)]],
+                            device float*       state [[buffer(2)]],
+                            device float*       dst   [[buffer(3)]],
+                            constant ConvSiluParams& p [[buffer(4)]],
+                            uint gid [[thread_position_in_grid]]) {
+    uint ch = gid;
+    if (ch >= p.channels) return;
+    uint kk = p.kwidth;             // host gates kwidth <= 8
+    float st[7];
+    float wv[8];
+    for (uint j = 0; j + 1 < kk; j++) st[j] = state[j * p.channels + ch];
+    for (uint j = 0; j < kk; j++) wv[j] = w[ch * kk + j];
+    for (uint t = 0; t < p.rows; t++) {
+        float xt = x[t * p.channels + ch];
+        float acc = xt * wv[kk - 1u];
+        for (uint j = 0; j + 1 < kk; j++) acc += st[j] * wv[j];
+        dst[t * p.channels + ch] = acc / (1.0f + exp(-acc));
+        for (uint j = 0; j + 2 < kk; j++) st[j] = st[j + 1];
+        if (kk >= 2u) st[kk - 2u] = xt;
+    }
+    for (uint j = 0; j + 1 < kk; j++) state[j * p.channels + ch] = st[j];
+}
+
+struct DeltaNetParams { uint rows; uint nv; uint nk; uint kd; uint vd; float eps; };
+kernel void deltanet_f32(device const float* q       [[buffer(0)]],
+                         device const float* k       [[buffer(1)]],
+                         device const float* v       [[buffer(2)]],
+                         device const float* b       [[buffer(3)]],
+                         device const float* a       [[buffer(4)]],
+                         device const float* a_coef  [[buffer(5)]],
+                         device const float* dt_bias [[buffer(6)]],
+                         device float*       state   [[buffer(7)]],
+                         device float*       dst     [[buffer(8)]],
+                         constant DeltaNetParams& p  [[buffer(9)]],
+                         uint   tgpig [[threadgroup_position_in_grid]],
+                         uint   tid   [[thread_position_in_threadgroup]],
+                         uint   lane  [[thread_index_in_simdgroup]],
+                         uint   sgid  [[simdgroup_index_in_threadgroup]]) {
+    threadgroup float qh[256];       // kd <= 256 (host-gated)
+    threadgroup float kh[256];
+    threadgroup float red[16];       // cross-simdgroup reductions + (beta, decay) broadcast
+    uint h = tgpig;
+    uint kh_idx = h % p.nk;
+    uint nsg = p.vd / 32u;           // threads == vd (host-gated: vd % 32 == 0, vd <= 1024)
+    device float* S = state + (ulong)h * p.kd * p.vd;
+    uint d = tid;
+
+    for (uint t = 0; t < p.rows; t++) {
+        // stage this row's q/k head and L2-normalize (q also x 1/sqrt(kd))
+        ulong qb = (ulong)t * p.nk * p.kd + (ulong)kh_idx * p.kd;
+        float sq = 0.0f, sk = 0.0f;
+        for (uint i = tid; i < p.kd; i += p.vd) {
+            float qv = q[qb + i];
+            float kv = k[qb + i];
+            qh[i] = qv;
+            kh[i] = kv;
+            sq += qv * qv;
+            sk += kv * kv;
+        }
+        sq = simd_sum(sq);
+        sk = simd_sum(sk);
+        if (lane == 0u) {
+            red[sgid] = sq;
+            red[8u + sgid] = sk;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tid == 0u) {
+            float tq = 0.0f, tk = 0.0f;
+            for (uint i = 0; i < nsg; i++) {
+                tq += red[i];
+                tk += red[8u + i];
+            }
+            red[0] = sqrt(tq + p.eps);
+            red[1] = sqrt(tk + p.eps);
+            // beta = sigmoid(b); decay = exp(a_coef * softplus(a + dt_bias))
+            float bv = b[t * p.nv + h];
+            red[2] = 1.0f / (1.0f + exp(-bv));
+            float z = a[t * p.nv + h] + dt_bias[h];
+            float sp = max(z, 0.0f) + log(1.0f + exp(-fabs(z)));
+            red[3] = exp(a_coef[h] * sp);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        float qn = red[0], kn = red[1], beta = red[2], decay = red[3];
+        float qscale = rsqrt((float)p.kd);
+        for (uint i = tid; i < p.kd; i += p.vd) {
+            qh[i] = qh[i] / qn * qscale;
+            kh[i] = kh[i] / kn;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // lane d owns state column S[:, d]: kv_d over the decayed state, then the delta-rule
+        // update fused with the output accumulation (one read + one write of the column)
+        float kvd = 0.0f;
+        for (uint kk = 0; kk < p.kd; kk++) kvd += kh[kk] * S[(ulong)kk * p.vd + d];
+        kvd *= decay;
+        float delta = (v[(ulong)t * p.nv * p.vd + (ulong)h * p.vd + d] - kvd) * beta;
+        float od = 0.0f;
+        for (uint kk = 0; kk < p.kd; kk++) {
+            float sv = S[(ulong)kk * p.vd + d] * decay + kh[kk] * delta;
+            S[(ulong)kk * p.vd + d] = sv;
+            od += qh[kk] * sv;
+        }
+        dst[(ulong)t * p.nv * p.vd + (ulong)h * p.vd + d] = od;
+        threadgroup_barrier(mem_flags::mem_threadgroup); // qh/kh restaged next row
+    }
+}
+
+// ---- WriteKv:// ---- WriteKv: cast-copy `n` f32 source elems into the bound KV cache at row offset `base`, on the
 // GPU so it stays in the batch (no host round-trip that would force a per-layer flush). The (half)
 // cast is IEEE round-to-nearest-even — byte-identical to the host `f16::from_f32` reference.
 struct WriteKvParams { uint n; uint base; };

--- a/crates/infr-metal/tests/deltanet_bw.rs
+++ b/crates/infr-metal/tests/deltanet_bw.rs
@@ -1,0 +1,103 @@
+//! Probe: device vs host DeltaNet + Conv1dSilu at Qwen3-Next layer shapes (one linear-attention
+//! sublayer). `INFR_METAL_NODELTA=1` forces the host path for the comparison:
+//! `cargo test -p infr-metal --release --test deltanet_bw -- --ignored --nocapture`.
+#![cfg(target_os = "macos")]
+
+use infr_core::backend::{Backend, Bindings, Buffer, BufferUsage};
+use infr_core::graph::{Graph, Op};
+use infr_core::tensor::{DType, TensorDesc};
+use infr_metal::MetalBackend;
+
+fn randv(n: usize, mut seed: u64) -> Vec<f32> {
+    (0..n)
+        .map(|_| {
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((seed >> 40) as f32 / (1u64 << 24) as f32) - 0.5
+        })
+        .collect()
+}
+
+#[test]
+#[ignore = "requires a Metal GPU (evidence probe)"]
+fn deltanet_layer_wall() {
+    // Qwen3-Next linear-attention shape: 32 value heads, 16 key heads, 128/128 dims.
+    let (nv, nk, kd, vd) = (32usize, 16usize, 128usize, 128usize);
+    for rows in [1usize, 64] {
+        let be = MetalBackend::new().unwrap();
+        let mut g = Graph::new();
+        let q = g.input(TensorDesc::new(vec![rows, nk * kd], DType::F32));
+        let k = g.input(TensorDesc::new(vec![rows, nk * kd], DType::F32));
+        let v = g.input(TensorDesc::new(vec![rows, nv * vd], DType::F32));
+        let b = g.input(TensorDesc::new(vec![rows, nv], DType::F32));
+        let a = g.input(TensorDesc::new(vec![rows, nv], DType::F32));
+        let a_coef = g.weight(TensorDesc::new(vec![nv], DType::F32));
+        let dt_bias = g.weight(TensorDesc::new(vec![nv], DType::F32));
+        let state = g.input(TensorDesc::new(vec![nv * kd * vd], DType::F32));
+        let dst = g.output(TensorDesc::new(vec![rows, nv * vd], DType::F32));
+        g.push(Op::DeltaNet {
+            q,
+            k,
+            v,
+            b,
+            a,
+            a_coef,
+            dt_bias,
+            state,
+            dst,
+            rows: rows as u32,
+            n_vhead: nv as u32,
+            n_khead: nk as u32,
+            head_k: kd as u32,
+            head_v: vd as u32,
+            eps: 1e-6,
+        });
+        let bound = vec![
+            (q, randv(rows * nk * kd, 1)),
+            (k, randv(rows * nk * kd, 2)),
+            (v, randv(rows * nv * vd, 3)),
+            (b, randv(rows * nv, 4)),
+            (a, randv(rows * nv, 5)),
+            (a_coef, randv(nv, 6)),
+            (dt_bias, randv(nv, 7)),
+            (state, randv(nv * kd * vd, 8)),
+        ];
+        let mut bufs: Vec<(infr_core::tensor::TensorId, Box<dyn Buffer>)> = Vec::new();
+        for (id, vals) in &bound {
+            let bytes: &[u8] = bytemuck::cast_slice(vals);
+            let bb = be
+                .alloc(bytes.len().max(4), BufferUsage::Activations)
+                .unwrap();
+            be.upload(bb.as_ref(), bytes).unwrap();
+            bufs.push((*id, bb));
+        }
+        bufs.push((
+            dst,
+            be.alloc(rows * nv * vd * 4, BufferUsage::Activations)
+                .unwrap(),
+        ));
+        let mut binds = Bindings::new();
+        for (id, bb) in &bufs {
+            binds.bind(*id, bb.as_ref());
+        }
+        let plan = be.compile(&g).unwrap();
+        for _ in 0..3 {
+            be.execute(plan.as_ref(), &binds).unwrap();
+        }
+        be.sync().unwrap();
+        let reps = 30;
+        let t0 = std::time::Instant::now();
+        for _ in 0..reps {
+            be.execute(plan.as_ref(), &binds).unwrap();
+        }
+        be.sync().unwrap();
+        let per = t0.elapsed().as_secs_f64() / reps as f64;
+        let path = if std::env::var("INFR_METAL_NODELTA").is_ok() {
+            "host"
+        } else {
+            "device"
+        };
+        println!("deltanet rows={rows} ({path}): {:.3} ms/op", per * 1e3);
+    }
+}

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1273,6 +1273,87 @@ fn deltanet_parity() {
     assert_close(&cpu[1], &mtl[1], 1e-4, "deltanet state");
 }
 
+// Multi-row scan at the qwen3-next head shape: the state must carry across rows exactly (the
+// device kernel loops rows with each lane owning its state column).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn deltanet_multirow_parity() {
+    let (rows, nv, nk, kd, vd) = (5usize, 4usize, 2usize, 128usize, 128usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nk * kd], DType::F32));
+    let k = g.input(TensorDesc::new(vec![rows, nk * kd], DType::F32));
+    let v = g.input(TensorDesc::new(vec![rows, nv * vd], DType::F32));
+    let b = g.input(TensorDesc::new(vec![rows, nv], DType::F32));
+    let a = g.input(TensorDesc::new(vec![rows, nv], DType::F32));
+    let a_coef = g.weight(TensorDesc::new(vec![nv], DType::F32));
+    let dt_bias = g.weight(TensorDesc::new(vec![nv], DType::F32));
+    let state = g.input(TensorDesc::new(vec![nv * kd * vd], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, nv * vd], DType::F32));
+    g.push(Op::DeltaNet {
+        q,
+        k,
+        v,
+        b,
+        a,
+        a_coef,
+        dt_bias,
+        state,
+        dst,
+        rows: rows as u32,
+        n_vhead: nv as u32,
+        n_khead: nk as u32,
+        head_k: kd as u32,
+        head_v: vd as u32,
+        eps: 1e-6,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nk * kd, 300))),
+        (k, f32_bytes(&rand_f32(rows * nk * kd, 301))),
+        (v, f32_bytes(&rand_f32(rows * nv * vd, 302))),
+        (b, f32_bytes(&rand_f32(rows * nv, 303))),
+        (a, f32_bytes(&rand_f32(rows * nv, 304))),
+        (a_coef, f32_bytes(&rand_f32(nv, 305))),
+        (dt_bias, f32_bytes(&rand_f32(nv, 306))),
+        (state, f32_bytes(&rand_f32(nv * kd * vd, 307))),
+    ];
+    let reads = [(dst, rows * nv * vd), (state, nv * kd * vd)];
+    let cpu = run_multi(&CpuBackend::new(), &g, &bound, &reads);
+    let mtl = run_multi(&MetalBackend::new().expect("metal"), &g, &bound, &reads);
+    assert_close(&cpu[0], &mtl[0], 1e-4, "deltanet multirow dst");
+    assert_close(&cpu[1], &mtl[1], 1e-4, "deltanet multirow state");
+}
+
+// Multi-row conv: the rolling state shifts once per row and survives to the next.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn conv1d_silu_multirow_parity() {
+    let (rows, cc, kk) = (5usize, 256usize, 4usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, cc], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![cc, kk], DType::F32));
+    let state = g.input(TensorDesc::new(vec![kk - 1, cc], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![rows, cc], DType::F32));
+    g.push(Op::Conv1dSilu {
+        x,
+        weight: w,
+        state,
+        dst,
+        rows: rows as u32,
+        channels: cc as u32,
+        kernel: kk as u32,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * cc, 310))),
+        (w, f32_bytes(&rand_f32(cc * kk, 311))),
+        (state, f32_bytes(&rand_f32((kk - 1) * cc, 312))),
+    ];
+    let reads = [(dst, rows * cc), (state, (kk - 1) * cc)];
+    let cpu = run_multi(&CpuBackend::new(), &g, &bound, &reads);
+    let mtl = run_multi(&MetalBackend::new().expect("metal"), &g, &bound, &reads);
+    assert_close(&cpu[0], &mtl[0], 1e-4, "conv multirow dst");
+    assert_close(&cpu[1], &mtl[1], 0.0, "conv multirow state");
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn copy_parity() {


### PR DESCRIPTION
Based on main (independent of #11). The Qwen3-Next hybrid's recurrences ran on the host: every linear-attention sublayer flushed the batch, downloaded q/k/v/b/a, scanned rows on the CPU, and re-uploaded — breaking the one-command-buffer-per-forward model per layer. Both ops now run on device, with the recurrent state updated in the bound buffer.

## Kernels

- **`conv1d_silu_f32`** — one thread per channel owns its rolling-state column in registers (kernel width ≤ 8); the row loop runs in-kernel with no cross-thread deps and no barriers.
- **`deltanet_f32`** — one threadgroup per value head, one lane per value dim. The key observation: the delta-rule update touches only state column S[:, d], so lane d owns it exclusively and the sequential row scan needs **no state synchronization** — only the shared q/k staging barrier. L2 norms via simd + cross-simdgroup reduction; the kv pass, delta update, and output accumulation fuse into one read + one write of the state column per row.
- Host fallback retained for out-of-gate shapes (kd > 256, vd % 32 ≠ 0, conv width > 8) and as the `INFR_METAL_NODELTA` escape hatch.

## Evidence

`tests/deltanet_bw.rs` (Qwen3-Next sublayer shape — 32 value heads × 16 key heads × 128/128, M3 Pro):

| rows | host | device |
|---|---|---|
| 1 (decode) | 0.56 ms | 0.60 ms |
| 64 (prefill chunk) | 21.8 ms | **4.4 ms** |

The single-op probe understates the real win: in a live forward the host path breaks the command buffer and round-trips the activations through the CPU **every layer**, which doesn't show in an isolated measurement. Decode should gain from batch continuity even at the ~tie kernel time.

## Caveats / draft status

- Op-level parity only (multi-row state-carry tests for both ops, 41 GPU tests on this branch) — no e2e run: the only qwen3-next checkpoint is 80B, which doesn't fit this machine. If someone with more RAM can A/B `INFR_METAL=1` with/without `INFR_METAL_NODELTA` on the real model, that would complete the validation.
- Touches only the two op arms + new kernels; no seam or op changes, so it should compose with #11 without conflicts.