### PR TITLE
fix(metal): Op::Linear.w_off support — fused-QKV models crashed the Metal backend

### DIFF
--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -115,6 +115,9 @@ fn linear_add_peephole(
 pub(crate) struct TapeEntry {
     pso: ComputePipelineState,
     bufs: Vec<MtlBuffer>,
+    /// Per-buffer byte offset for `set_buffer` (parallel to `bufs`; all zero except the
+    /// fused-QKV weight slices — see the Linear arm's `w_off`).
+    offs: Vec<u64>,
     params: Vec<u8>,
     threads: usize,
     tg: usize,
@@ -363,6 +366,21 @@ impl MetalBackend {
         threads: usize,
         tg: usize,
     ) {
+        let with_offs: Vec<(&MtlBuffer, u64)> = bufs.iter().map(|b| (*b, 0)).collect();
+        self.encode_tg_off(r, pso, &with_offs, params, threads, tg);
+    }
+
+    /// As `encode_tg`, but each buffer binds at a byte offset — the fused-QKV Linear slices
+    /// bind the shared concatenated weight at each projection's row offset (`Op::Linear.w_off`).
+    fn encode_tg_off(
+        &self,
+        r: &mut Resident,
+        pso: &ComputePipelineState,
+        bufs: &[(&MtlBuffer, u64)],
+        params: &[u8],
+        threads: usize,
+        tg: usize,
+    ) {
         if threads == 0 {
             return;
         }
@@ -374,8 +392,8 @@ impl MetalBackend {
         }
         let enc = r.enc.as_ref().unwrap();
         enc.set_compute_pipeline_state(pso);
-        for (i, b) in bufs.iter().enumerate() {
-            enc.set_buffer(i as u64, Some(b), 0);
+        for (i, (b, off)) in bufs.iter().enumerate() {
+            enc.set_buffer(i as u64, Some(b), *off);
         }
         if !params.is_empty() {
             enc.set_bytes(
@@ -390,7 +408,8 @@ impl MetalBackend {
         if let Some(tape) = r.tape.as_mut() {
             tape.push(TapeEntry {
                 pso: pso.clone(),
-                bufs: bufs.iter().map(|b| (*b).clone()).collect(),
+                bufs: bufs.iter().map(|(b, _)| (*b).clone()).collect(),
+                offs: bufs.iter().map(|(_, off)| *off).collect(),
                 params: params.to_vec(),
                 threads,
                 tg,
@@ -408,7 +427,7 @@ impl MetalBackend {
             for e in &tape.entries {
                 enc.set_compute_pipeline_state(&e.pso);
                 for (i, b) in e.bufs.iter().enumerate() {
-                    enc.set_buffer(i as u64, Some(b), 0);
+                    enc.set_buffer(i as u64, Some(b), e.offs[i]);
                 }
                 if !e.params.is_empty() {
                     enc.set_bytes(
@@ -931,13 +950,6 @@ impl MetalBackend {
                 out_f,
                 w_off,
             } => {
-                // Only produced by the fused-QKV runner path, which is gated on
-                // `Capabilities::combined_gu` — Metal leaves it false, so this is unreachable.
-                if w_off != 0 {
-                    return Err(Error::Unsupported(
-                        "metal: Linear w_off (fused-QKV slices) unsupported".into(),
-                    ));
-                }
                 let (m, in_f, out_f) = (m as usize, in_f as usize, out_f as usize);
                 let bx = self.ensure_device(r, x);
                 let bd = self.dev_dst(r, dst, m * out_f);
@@ -952,6 +964,32 @@ impl MetalBackend {
                     // weight block decoded once for all 8 rows, instead of the GEMV kernel
                     // re-streaming the whole weight matrix once per row.
                     let qw = self.weight_qui(weight, g, bindings);
+                    // Fused-QKV slice: `w_off` is a whole-row element offset into the shared
+                    // concatenated weight (the runner bakes it as `row0 * in_f`), so it lands on
+                    // a block boundary in every stream — bind each stream at the corresponding
+                    // byte offset and the kernels see the slice as a standalone [out_f, in_f]
+                    // weight. Native K-quant streams are raw GGUF blocks (144 B / 210 B per 256
+                    // elements); factored streams are bit-packed codes + 4 B scm per 16 elements
+                    // + 4 B (d, dmin) per 2^dshift elements.
+                    let e = w_off as u64;
+                    let dd_off = (e >> qw.dshift) * 4;
+                    let (codes_off, scm_off, dd_off) = match qw.kern {
+                        _ if w_off == 0 => (0, 0, 0),
+                        // Native kernels read raw GGUF blocks; scm/dd are dummy buffers.
+                        "linear_q4k" => (e / 256 * 144, 0, 0),
+                        "linear_q6k" => (e / 256 * 210, 0, 0),
+                        "linear_quik4" => (e / 2, e / 4, dd_off),
+                        "linear_quik6" => (e / 4 * 3, e / 4, dd_off),
+                        _ => (e, e / 4, dd_off),
+                    };
+                    // `set_buffer` offsets must stay 4-byte aligned; every real fused shape does
+                    // (in_f is a multiple of 512 or the format's stride is already 4-aligned) —
+                    // reject the pathological remainder instead of tripping API validation.
+                    if codes_off % 4 != 0 || scm_off % 4 != 0 || dd_off % 4 != 0 {
+                        return Err(Error::Unsupported(
+                            "metal: Linear w_off lands off 4-byte alignment".into(),
+                        ));
+                    }
                     // sgs = simdgroups to launch; tg = threadgroup width. GEMM tiles 8x16 per
                     // simdgroup (4 simdgroups per threadgroup for the staging tile). The GEMM
                     // kernel requires its full 128-thread threadgroup (per-simdgroup staging
@@ -992,10 +1030,16 @@ impl MetalBackend {
                     if cmm_ok {
                         // Reads f32 x directly (casts to f16 while staging) — no cast pass.
                         let pso = self.pipelines.get(cmm_kern)?;
-                        self.encode_tg(
+                        self.encode_tg_off(
                             r,
                             &pso,
-                            &[bx.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[
+                                (bx.as_ref(), 0),
+                                (&qw.codes, codes_off),
+                                (&qw.scm, scm_off),
+                                (&qw.dd, dd_off),
+                                (bd.as_ref(), 0),
+                            ],
                             &p,
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,
@@ -1011,10 +1055,16 @@ impl MetalBackend {
                         let n = (m * in_f) as u32;
                         self.encode(r, &cast, &[bx.as_ref(), &xh], &n.to_ne_bytes(), m * in_f);
                         let pso = self.pipelines.get(hmm_kern)?;
-                        self.encode_tg(
+                        self.encode_tg_off(
                             r,
                             &pso,
-                            &[xh.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[
+                                (xh.as_ref(), 0),
+                                (&qw.codes, codes_off),
+                                (&qw.scm, scm_off),
+                                (&qw.dd, dd_off),
+                                (bd.as_ref(), 0),
+                            ],
                             &p,
                             m.div_ceil(32) * (out_f / 16) * 32,
                             128,
@@ -1047,16 +1097,16 @@ impl MetalBackend {
                             let bres = self.ensure_device(r, res);
                             let bfd = self.dev_dst(r, fdst, out_f);
                             let pso = self.pipelines.get(fk)?;
-                            self.encode_tg(
+                            self.encode_tg_off(
                                 r,
                                 &pso,
                                 &[
-                                    bx.as_ref(),
-                                    &qw.codes,
-                                    &qw.scm,
-                                    &qw.dd,
-                                    bfd.as_ref(),
-                                    bres.as_ref(),
+                                    (bx.as_ref(), 0),
+                                    (&qw.codes, codes_off),
+                                    (&qw.scm, scm_off),
+                                    (&qw.dd, dd_off),
+                                    (bfd.as_ref(), 0),
+                                    (bres.as_ref(), 0),
                                 ],
                                 &p,
                                 sgs * 32,
@@ -1066,10 +1116,16 @@ impl MetalBackend {
                             return Ok(());
                         }
                         let pso = self.pipelines.get(kern)?;
-                        self.encode_tg(
+                        self.encode_tg_off(
                             r,
                             &pso,
-                            &[bx.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[
+                                (bx.as_ref(), 0),
+                                (&qw.codes, codes_off),
+                                (&qw.scm, scm_off),
+                                (&qw.dd, dd_off),
+                                (bd.as_ref(), 0),
+                            ],
                             &p,
                             sgs * 32,
                             32,
@@ -1079,10 +1135,14 @@ impl MetalBackend {
                     // f16/f32/bf16 weight: dequant-to-f32 device buffer, cached.
                     let bw = self.weight_buf(weight, g, bindings);
                     let pso = self.pipelines.get("linear_f32")?;
-                    self.encode_tg(
+                    self.encode_tg_off(
                         r,
                         &pso,
-                        &[bx.as_ref(), bw.as_ref(), bd.as_ref()],
+                        &[
+                            (bx.as_ref(), 0),
+                            (bw.as_ref(), w_off as u64 * 4),
+                            (bd.as_ref(), 0),
+                        ],
                         &p,
                         m * out_f * 32,
                         32,
@@ -2246,6 +2306,8 @@ impl MetalBackend {
                 r.vals[dst.0 as usize][dof..dof + n].copy_from_slice(&s[so..so + n]);
                 r.loc[dst.0 as usize] = Loc::Host;
             }
+            // On-device: the fused-QKV prefill emits one of these per projection right after the
+            // wide GEMM — a host copy would round-trip the [m, qkv] activation mid-forward.
             Op::CopyStrided {
                 src,
                 src_off,
@@ -2256,22 +2318,24 @@ impl MetalBackend {
                 rows,
                 n,
             } => {
-                let (so, ss, dof, ds, n) = (
-                    src_off as usize,
-                    src_stride as usize,
-                    dst_off as usize,
-                    dst_stride as usize,
-                    n as usize,
+                let bs = self.ensure_device(r, src);
+                // The strided write may cover only part of dst — bring the rest along.
+                let bd = self.ensure_device(r, dst);
+                let mut p = src_off.to_ne_bytes().to_vec();
+                p.extend_from_slice(&src_stride.to_ne_bytes());
+                p.extend_from_slice(&dst_off.to_ne_bytes());
+                p.extend_from_slice(&dst_stride.to_ne_bytes());
+                p.extend_from_slice(&rows.to_ne_bytes());
+                p.extend_from_slice(&n.to_ne_bytes());
+                let pso = self.pipelines.get("copy_strided_f32")?;
+                self.encode(
+                    r,
+                    &pso,
+                    &[bs.as_ref(), bd.as_ref()],
+                    &p,
+                    rows as usize * n as usize,
                 );
-                self.ensure_host(r, g, src);
-                self.ensure_host(r, g, dst);
-                let s = r.vals[src.0 as usize].clone();
-                let d = &mut r.vals[dst.0 as usize];
-                for rr in 0..rows as usize {
-                    d[dof + rr * ds..dof + rr * ds + n]
-                        .copy_from_slice(&s[so + rr * ss..so + rr * ss + n]);
-                }
-                r.loc[dst.0 as usize] = Loc::Host;
+                r.loc[dst.0 as usize] = Loc::Device;
             }
         }
         Ok(())

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -367,6 +367,26 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
 }
 
 
+// ---- Strided row copy (the fused-QKV prefill split: one wide GEMM output sliced into q/k/v).
+// Pure data movement, but on-device — a host copy here would round-trip the [m, qkv] buffer and
+// break the command buffer mid-forward.
+struct CopyStridedParams {
+    uint src_off;
+    uint src_stride;
+    uint dst_off;
+    uint dst_stride;
+    uint rows;
+    uint n;
+};
+kernel void copy_strided_f32(device const float*         src [[buffer(0)]],
+                             device float*               dst [[buffer(1)]],
+                             constant CopyStridedParams& p   [[buffer(2)]],
+                             uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.n) return;
+    uint r = gid / p.n, c = gid % p.n;
+    dst[p.dst_off + r * p.dst_stride + c] = src[p.src_off + r * p.src_stride + c];
+}
+
 // ---- Cast f32 -> f16 (prefill GEMM feeds on half activations; round-to-nearest-even).
 kernel void cast_f32_f16(device const float* src [[buffer(0)]],
                          device half*        dst [[buffer(1)]],

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -434,6 +434,136 @@ fn check_quant_linear_parity_impl(
     }
 }
 
+// Fused-QKV slices: several Linear ops share ONE concatenated [Σslices, in_f] weight, each
+// reading its rows at `w_off` (the runner's combined-QKV shape — `Op::Linear.w_off`). Every
+// slice must match a reference matmul over the dequant of just that slice's rows; the
+// non-zero offsets exercise the byte-offset binds into the codes/scm/dd streams.
+fn check_linear_woff(
+    dtype: DType,
+    wbytes: Vec<u8>,
+    m: usize,
+    in_f: usize,
+    slices: &[usize],
+    half_ops: bool,
+    tol: f32,
+) {
+    use infr_gguf::dequant::dequant_block;
+    let rows_total: usize = slices.iter().sum();
+    let mut xs = rand_f32(m * in_f, 34);
+    let mut wref = dequant_block(dtype, &wbytes).unwrap();
+    if half_ops {
+        for v in xs.iter_mut().chain(wref.iter_mut()) {
+            *v = half::f16::from_f32(*v).to_f32();
+        }
+    }
+    let be = MetalBackend::new().expect("metal backend");
+    let mut row0 = 0usize;
+    for &out_f in slices {
+        let wslice = &wref[row0 * in_f..(row0 + out_f) * in_f];
+        let reference = ref_linear(&xs, wslice, m, in_f, out_f);
+        let mut g = Graph::new();
+        let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+        let w = g.weight(TensorDesc::new(vec![rows_total, in_f], dtype));
+        let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+        g.push(Op::Linear {
+            x,
+            weight: w,
+            dst,
+            m: m as u32,
+            in_f: in_f as u32,
+            out_f: out_f as u32,
+            w_off: (row0 * in_f) as u32,
+        });
+        let bound = vec![(x, f32_bytes(&xs)), (w, wbytes.clone())];
+        let mtl = run(&be, &g, &bound, dst, m * out_f);
+        for (i, (r, mm)) in reference.iter().zip(mtl.iter()).enumerate() {
+            let err = (r - mm).abs() / r.abs().max(1.0);
+            assert!(
+                err <= tol,
+                "{dtype:?} slice@{row0} elem {i}: ref={r} metal={mm} err={err} > {tol}"
+            );
+        }
+        row0 += out_f;
+    }
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q8_0_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 35);
+    check_linear_woff(
+        DType::Q8_0,
+        quantize_q8_0(&wf),
+        1,
+        in_f,
+        &slices,
+        false,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q8_0_coop_gemm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 36);
+    check_linear_woff(
+        DType::Q8_0,
+        quantize_q8_0(&wf),
+        40,
+        in_f,
+        &slices,
+        true,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q4k_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    check_linear_woff(
+        DType::Q4K,
+        synth_q4k(256 * in_f, 37),
+        1,
+        in_f,
+        &slices,
+        false,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q4k_coop_gemm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    check_linear_woff(
+        DType::Q4K,
+        synth_q4k(256 * in_f, 38),
+        40,
+        in_f,
+        &slices,
+        true,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q6k_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    check_linear_woff(
+        DType::Q6K,
+        synth_q6k(256 * in_f, 39),
+        1,
+        in_f,
+        &slices,
+        false,
+        1e-3,
+    );
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn linear_f32_parity() {


### PR DESCRIPTION
The fused-QKV path from bcd9267 gates on `Capabilities::combined_gu`, which Metal advertises (PR #11's GatedActFused opt-in) — but Metal's Linear arm hard-errored on `w_off != 0`, killing the encoder mid-forward. Any checkpoint whose q/k/v projections share one native dtype crashed on Metal:

```
-[_MTLCommandEncoder dealloc]:134: failed assertion 'Command encoder released without endEncoding'
```

(repro: Qwen3-0.6B **Q8_0** with `INFR_METAL=1`. Q4_K_M checkpoints dodge it only because attn_v is Q6_K — the mixed dtypes keep `fuse_qkv` false. The old comment claiming Metal leaves `combined_gu` false was stale.)

## What this does

- **`w_off` on every Linear route** (GEMV, row-tiled, HGEMM, cooperative GEMM, fused-add, dense f32): `w_off` is a whole-row element offset into the shared concatenated weight, so it lands on a block boundary in every stream — the buffers bind at the matching byte offset (factored codes/scm/dd, raw K-quant blocks at 144/210 B per 256 elems, or f32 at 4 B/elem) and the kernels see the slice as a standalone `[out_f, in_f]` weight. A 4-byte-alignment guard rejects the pathological remainder instead of tripping API validation.
- **Replay tape records bind offsets**: decode's three offset GEMVs tape and replay correctly — verified token-identical replay on/off.
- **CopyStrided moves on-device**: the prefill wide-GEMM q/k/v split was a host-side copy, round-tripping the `[m, qkv]` activation every layer — 21% of Q8_0 prefill (873 → 1061 t/s with the kernel).

## Validation

Qwen3-0.6B Q8_0 on Metal: crash → token-identical vs the CPU reference with the fused path active on **both** sides, replay on/off identical, `INFR_KV_Q8` combo clean. 5 new w_off slice parity tests (Q8_0/Q4K/Q6K × GEMV + coop-GEMM), 54 GPU parity tests total; fmt/clippy(-D warnings)/test matrix green locally.

## Note on the fuse itself

With the crash fixed, fused-QKV is roughly neutral on Metal: pp512 1061 vs 1102 with the fuse disabled (−4%), tg128 82.4 vs 82.1 (wash). The Vulkan +34% came with the NARROW_N/SPLIT-K tile variants, which Metal doesn't have — M-series doesn't underfill on the split projections' grids the way a 96-WGP part does. If you'd rather Metal not pay the 4% until it grows matching tile variants, splitting the capability (`combined_gu` vs a separate `combined_qkv`) is a seam one-liner — happy to take either side of that; this PR keeps the backend correct under what the seam emits today.