### PR TITLE
perf(metal): hd=256 flash/vec kernels (gemma 3x) + honest bench sessions

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -752,18 +752,32 @@ fn cmd_bench_metal(
     {
         let model = infr_llama::CpuModel::load(gguf, tok)?;
         let measure_tg = pg.is_none() && n_gen > 0;
+        // ONE session for warmup + every rep: backend, uploaded weights, compiled pipelines and
+        // the dequant/repack weight caches persist (each rep still measures a full prefill —
+        // `bench_metal` resets the materialized tokens). A fresh backend per rep re-paid those
+        // one-time costs inside the measurement.
+        let ctx = pg.map(|(p, g)| p + g).unwrap_or(if measure_tg {
+            depth.max(1) + n_gen
+        } else {
+            n_prompt
+        }) + 2;
+        let mut sess = model.metal_session(ctx)?;
         // One untimed warmup: page-cache the mmap + build the weight caches + compile pipelines.
-        let _ = model.bench_metal(depth.max(1), if measure_tg || pg.is_some() { 1 } else { 0 });
+        let _ = model.bench_metal(
+            &mut sess,
+            depth.max(1),
+            if measure_tg || pg.is_some() { 1 } else { 0 },
+        );
         let mut samples = Vec::with_capacity(reps);
         for _ in 0..reps {
             let ts = if let Some((p, g)) = pg {
-                let s = model.bench_metal(p, g)?;
+                let s = model.bench_metal(&mut sess, p, g)?;
                 (p + g) as f64 / (s.prompt_secs + s.decode_secs)
             } else if measure_tg {
-                let s = model.bench_metal(depth.max(1), n_gen)?;
+                let s = model.bench_metal(&mut sess, depth.max(1), n_gen)?;
                 n_gen as f64 / s.decode_secs
             } else {
-                let s = model.bench_metal(n_prompt, 0)?;
+                let s = model.bench_metal(&mut sess, n_prompt, 0)?;
                 n_prompt as f64 / s.prompt_secs
             };
             samples.push(ts);

--- a/crates/infr-llama/src/cpu_backend.rs
+++ b/crates/infr-llama/src/cpu_backend.rs
@@ -403,6 +403,13 @@ impl SeamKv {
         common_prefix_len(&self.cached, prompt)
     }
 
+    /// Forget the materialized tokens WITHOUT dropping weights or buffers: the next call
+    /// re-prefills from position 0 into the same session. Bench reps use this so each rep
+    /// measures a full prefill while weights/pipelines/repack caches stay warm.
+    pub(crate) fn reset_tokens(&mut self) {
+        self.cached.clear();
+    }
+
     /// Number of token ids materialized in this slot's KV cache.
     pub(crate) fn cached_len(&self) -> usize {
         self.cached.len()

--- a/crates/infr-llama/src/cpu_backend.rs
+++ b/crates/infr-llama/src/cpu_backend.rs
@@ -406,6 +406,8 @@ impl SeamKv {
     /// Forget the materialized tokens WITHOUT dropping weights or buffers: the next call
     /// re-prefills from position 0 into the same session. Bench reps use this so each rep
     /// measures a full prefill while weights/pipelines/repack caches stay warm.
+    /// (cfg-gated with its only caller, the Metal bench session — dead code on other targets.)
+    #[cfg(target_os = "macos")]
     pub(crate) fn reset_tokens(&mut self) {
         self.cached.clear();
     }

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -419,12 +419,24 @@ impl CpuModel {
     /// [`bench`](Self::bench)): prefill `n_prompt` dummy tokens, decode `n_gen`, return the timing.
     /// Lets `infr bench` (with `INFR_METAL=1`) measure pp/tg directly comparable to `llama-bench`
     /// on the Metal build.
+    /// Runs through a persistent [`DenseMetalSession`] so backend, uploaded weights, compiled
+    /// pipelines, and the dequant/repack weight caches all survive across reps — a fresh backend
+    /// per rep re-paid every one-time cost inside the measurement (a factored-format checkpoint
+    /// re-repacked hundreds of MB per rep). The materialized tokens reset each call, so every
+    /// rep still measures a FULL prefill (llama-bench keeps one context across reps the same way).
     #[cfg(target_os = "macos")]
-    pub fn bench_metal(&self, n_prompt: usize, n_gen: usize) -> Result<crate::GenStats> {
+    pub fn bench_metal(
+        &self,
+        session: &mut DenseMetalSession,
+        n_prompt: usize,
+        n_gen: usize,
+    ) -> Result<crate::GenStats> {
         let prompt: Vec<u32> = (0..n_prompt.max(1)).map(|i| (i % 100) as u32).collect();
-        let mtl = infr_metal::MetalBackend::new().map_err(|e| anyhow!("metal init: {e}"))?;
-        let (_, stats) = crate::cpu_backend::generate_dense_metal(
-            &mtl,
+        if let Some(s) = session.state.as_mut() {
+            s.reset_tokens();
+        }
+        let (_, stats) = crate::cpu_backend::generate_dense_metal_session(
+            &session.mtl,
             &self.gguf,
             &self.cfg,
             &self.token_embd,
@@ -432,6 +444,9 @@ impl CpuModel {
             &prompt,
             n_gen,
             |_| {},
+            &mut session.state,
+            session.max_ctx,
+            None,
         )?;
         Ok(stats)
     }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -88,7 +88,7 @@ fn linear_add_peephole(
         if !matches!(g.tensors[dst.0 as usize].kind, TensorKind::Internal) {
             continue;
         }
-        if !matches!(g.desc(*weight).dtype, DType::Q4K | DType::Q6K) {
+        if !matches!(g.desc(*weight).dtype, DType::Q4K | DType::Q6K | DType::Q8_0) {
             continue;
         }
         if let Some(Op::Add {
@@ -786,6 +786,7 @@ impl MetalBackend {
         let native_kern = match g.desc(id).dtype {
             DType::Q4K => Some("linear_q4k"),
             DType::Q6K => Some("linear_q6k"),
+            DType::Q8_0 => Some("linear_q8_0"),
             _ => None,
         };
         if let Some(kern) = native_kern {
@@ -990,6 +991,7 @@ impl MetalBackend {
                         // Native kernels read raw GGUF blocks; scm/dd are dummy buffers.
                         "linear_q4k" => (e / 256 * 144, 0, 0),
                         "linear_q6k" => (e / 256 * 210, 0, 0),
+                        "linear_q8_0" => (e / 32 * 34, 0, 0),
                         "linear_quik4" => (e / 2, e / 4, dd_off),
                         "linear_quik6" => (e / 4 * 3, e / 4, dd_off),
                         _ => (e, e / 4, dd_off),
@@ -1013,6 +1015,7 @@ impl MetalBackend {
                         "linear_quik6" => "linear_quik6_hmm",
                         "linear_q4k" => "linear_q4k_hmm",
                         "linear_q6k" => "linear_q6k_hmm",
+                        "linear_q8_0" => "linear_q8_0_hmm",
                         _ => "linear_quik8_hmm",
                     };
                     let cmm_kern = match qw.kern {
@@ -1020,6 +1023,7 @@ impl MetalBackend {
                         "linear_quik6" => "linear_quik6_cmm",
                         "linear_q4k" => "linear_q4k_cmm",
                         "linear_q6k" => "linear_q6k_cmm",
+                        "linear_q8_0" => "linear_q8_0_cmm",
                         _ => "linear_quik8_cmm",
                     };
                     // Prefer the cooperative 32x64 threadgroup tile; per-simdgroup HGEMM covers
@@ -1088,13 +1092,16 @@ impl MetalBackend {
                                 "linear_quik6" => "linear_quik6_rt",
                                 "linear_q4k" => "linear_q4k_rt",
                                 "linear_q6k" => "linear_q6k_rt",
+                                "linear_q8_0" => "linear_q8_0_rt",
                                 _ => "linear_quik8_rt",
                             };
                             (rt, m.div_ceil(8) * out_f)
                         } else {
-                            // The native mul_mv-shape GEMVs cover TWO output rows per simdgroup.
+                            // The native mul_mv-shape GEMVs cover TWO output rows per simdgroup
+                            // (FOUR for Q8_0 — llama.cpp's N_R0_Q8_0).
                             let sgs = match qw.kern {
                                 "linear_q4k" | "linear_q6k" => out_f.div_ceil(2),
+                                "linear_q8_0" => out_f.div_ceil(4),
                                 _ => out_f,
                             };
                             (qw.kern, sgs)
@@ -1104,6 +1111,7 @@ impl MetalBackend {
                         if let Some(&(res, fdst)) = r.fused.get(&idx) {
                             let fk = match kern {
                                 "linear_q4k" => "linear_q4k_add",
+                                "linear_q8_0" => "linear_q8_0_add",
                                 _ => "linear_q6k_add",
                             };
                             let bres = self.ensure_device(r, res);

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -188,7 +188,7 @@ fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
             } => {
                 has_attn = true;
                 if *rows != 1
-                    || !matches!(*head_dim, 64 | 128)
+                    || !matches!(*head_dim, 64 | 128 | 256)
                     || !matches!(g.desc(*k_cache).dtype, DType::F16 | DType::Q8_0)
                 {
                     return false;
@@ -515,21 +515,27 @@ impl MetalBackend {
         let dyn_cap_ok = || -> bool {
             let kern = g.ops.iter().find_map(|op| match op {
                 Op::Attention {
-                    head_dim: hd @ (64 | 128),
+                    head_dim: hd @ (64 | 128 | 256),
                     k_cache,
                     ..
-                } => Some(match (g.desc(*k_cache).dtype == DType::Q8_0, hd) {
-                    (false, 64) => "attnvec_dyn_f16kv_hd64",
-                    (false, _) => "attnvec_dyn_f16kv_hd128",
-                    (true, 64) => "attnvec_dyn_q8kv_hd64",
-                    (true, _) => "attnvec_dyn_q8kv_hd128",
-                }),
+                } => Some((
+                    match (g.desc(*k_cache).dtype == DType::Q8_0, hd) {
+                        (false, 64) => "attnvec_dyn_f16kv_hd64",
+                        (false, 256) => "attnvec_dyn_f16kv_hd256",
+                        (false, _) => "attnvec_dyn_f16kv_hd128",
+                        (true, 64) => "attnvec_dyn_q8kv_hd64",
+                        (true, 256) => "attnvec_dyn_q8kv_hd256",
+                        (true, _) => "attnvec_dyn_q8kv_hd128",
+                    },
+                    // hd=256 instantiates at NSG=16 (threadgroup budget) — 512 threads.
+                    if *hd == 256 { 512 } else { 1024 },
+                )),
                 _ => None,
             });
-            kern.is_some_and(|kn| {
+            kern.is_some_and(|(kn, need)| {
                 self.pipelines
                     .get(kn)
-                    .map(|pl| pl.max_total_threads_per_threadgroup() >= 1024)
+                    .map(|pl| pl.max_total_threads_per_threadgroup() >= need)
                     .unwrap_or(false)
             })
         };
@@ -733,7 +739,12 @@ impl MetalBackend {
         bindings: &Bindings,
     ) -> Arc<MtlBuffer> {
         let buf = metal_buf(bindings.get(id).expect("metal backend: unbound Weight"));
-        let key = buf as *const _ as usize;
+        // Key on the UNDERLYING MTLBuffer (unified-memory contents pointer), not the wrapper
+        // address: the runner rebuilds its bindings map per prefill graph, so wrapper addresses
+        // change every forward and a wrapper-keyed cache re-repacks each one — hundreds of ms
+        // per forward on a factored-format checkpoint. The MTLBuffer lives as long as the
+        // uploaded weight, so its contents pointer is stable and unique.
+        let key = buf.raw.contents() as usize;
         if let Some(w) = self.weight_cache.lock().unwrap().get(&key) {
             return w.clone();
         }
@@ -767,7 +778,8 @@ impl MetalBackend {
         bindings: &Bindings,
     ) -> Arc<QuiWeight> {
         let buf = metal_buf(bindings.get(id).expect("metal backend: unbound Weight"));
-        let key = buf as *const _ as usize;
+        // Stable underlying-buffer key — see `weight_buf` for why the wrapper address is not.
+        let key = buf.raw.contents() as usize;
         if let Some(w) = self.qui_cache.lock().unwrap().get(&key) {
             return w.clone();
         }
@@ -1434,10 +1446,14 @@ impl MetalBackend {
                     // which is exactly what a replayed tape can't have.
                     let kern = match (g.desc(k_cache).dtype == DType::Q8_0, hd) {
                         (false, 64) => "attnvec_dyn_f16kv_hd64",
+                        (false, 256) => "attnvec_dyn_f16kv_hd256",
                         (false, _) => "attnvec_dyn_f16kv_hd128",
                         (true, 64) => "attnvec_dyn_q8kv_hd64",
+                        (true, 256) => "attnvec_dyn_q8kv_hd256",
                         (true, _) => "attnvec_dyn_q8kv_hd128",
                     };
+                    // hd=256 instantiates at NSG=16 (see the shader) — half the threadgroup.
+                    let nsg = if hd == 256 { 16 } else { 32 };
                     let pso = self.pipelines.get(kern)?;
                     let mut p = (rows as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(kv_len as u32).to_ne_bytes());
@@ -1452,8 +1468,8 @@ impl MetalBackend {
                         &pso,
                         &[bq.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref(), &posbuf],
                         &p,
-                        rows * nh * 32 * 32,
-                        32 * 32,
+                        rows * nh * nsg * 32,
+                        nsg * 32,
                     );
                     r.loc[dst.0 as usize] = Loc::Device;
                     return Ok(());
@@ -1510,23 +1526,25 @@ impl MetalBackend {
                     }
                     // The vector kernel runs one threadgroup per (row, head), covering decode
                     // and any prefill shape the flash gate declined.
-                    let vq8 = matches!(hd, 64 | 128) && kv_len >= 128 && {
-                        let kn = if hd == 64 {
-                            "attnvec_q8kv_hd64"
-                        } else {
-                            "attnvec_q8kv_hd128"
-                        };
-                        self.pipelines
-                            .get(kn)
-                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 1024)
-                            .unwrap_or(false)
+                    let vq8_kern = match hd {
+                        64 => Some("attnvec_q8kv_hd64"),
+                        128 => Some("attnvec_q8kv_hd128"),
+                        256 => Some("attnvec_q8kv_hd256"),
+                        _ => None,
                     };
+                    // hd=256 instantiates at NSG=16 (threadgroup budget) — 512 threads.
+                    let vnsg = if hd == 256 { 16 } else { 32 };
+                    let vq8 = kv_len >= 128
+                        && vq8_kern.is_some_and(|kn| {
+                            self.pipelines
+                                .get(kn)
+                                .map(|pl| {
+                                    pl.max_total_threads_per_threadgroup() >= vnsg as u64 * 32
+                                })
+                                .unwrap_or(false)
+                        });
                     let kern = if vq8 {
-                        if hd == 64 {
-                            "attnvec_q8kv_hd64"
-                        } else {
-                            "attnvec_q8kv_hd128"
-                        }
+                        vq8_kern.unwrap()
                     } else {
                         "attention_q8kv"
                     };
@@ -1539,7 +1557,7 @@ impl MetalBackend {
                     p.extend_from_slice(&scale.to_ne_bytes());
                     p.extend_from_slice(&window.to_ne_bytes());
                     p.extend_from_slice(&pos.to_ne_bytes());
-                    let nsg = if vq8 { 32 } else { 1 };
+                    let nsg = if vq8 { vnsg } else { 1 };
                     self.encode_tg(
                         r,
                         &pso,
@@ -1566,8 +1584,6 @@ impl MetalBackend {
                 // fragments load straight from the cache, Q is cast once to f16 below. Small
                 // kv_len stays scalar (also keeps the short-kv wide parity test on the exact
                 // path). See `attnflash_f16kv` for why the f32 flash attempt lost and this wins.
-                let flash = f16 && rows * nh >= 128 && kv_len >= 64 && hd <= 128 && hd % 8 == 0;
-                let split = !flash && (rows * nh < 128 || kv_len >= 128);
                 // The cooperative flash kernel (4 simdgroups per query tile, llama.cpp
                 // flash_attn_ext structure) is instantiated per compile-time head size
                 // (fully unrolled QK/PV loops) and needs a 128-thread threadgroup
@@ -1576,15 +1592,24 @@ impl MetalBackend {
                 let flash2_kern = match hd {
                     64 => Some("attnflash2_f16kv_hd64"),
                     128 => Some("attnflash2_f16kv_hd128"),
+                    256 => Some("attnflash2_f16kv_hd256"),
                     _ => None,
                 };
-                let flash2 = flash
-                    && flash2_kern.is_some_and(|kn| {
-                        self.pipelines
-                            .get(kn)
-                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
-                            .unwrap_or(false)
-                    });
+                let flash2_ok = flash2_kern.is_some_and(|kn| {
+                    self.pipelines
+                        .get(kn)
+                        .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                        .unwrap_or(false)
+                });
+                // hd > 128 has no single-simdgroup flash fallback (its register accumulator
+                // tops out at 128), so the wide gate only opens there when flash2 itself can run.
+                let flash = f16
+                    && rows * nh >= 128
+                    && kv_len >= 64
+                    && hd % 8 == 0
+                    && (hd <= 128 || flash2_ok);
+                let split = !flash && (rows * nh < 128 || kv_len >= 128);
+                let flash2 = flash && flash2_ok;
                 // The split kernels REQUIRE their full NSG*32-thread threadgroup: every simdgroup
                 // owns a strided KV slice, so a smaller launch would silently skip positions and
                 // merge uninitialized partials. maxTotalThreadsPerThreadgroup is per-PIPELINE
@@ -1604,8 +1629,11 @@ impl MetalBackend {
                 let vec_kern = match hd {
                     64 => Some("attnvec_f16kv_hd64"),
                     128 => Some("attnvec_f16kv_hd128"),
+                    256 => Some("attnvec_f16kv_hd256"),
                     _ => None,
                 };
+                // hd=256 instantiates at NSG=16 (threadgroup budget) — 512 threads.
+                let vec_nsg: usize = if hd == 256 { 16 } else { 32 };
                 let vec = !flash
                     && f16
                     && split
@@ -1613,7 +1641,7 @@ impl MetalBackend {
                     && vec_kern.is_some_and(|kn| {
                         self.pipelines
                             .get(kn)
-                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 1024)
+                            .map(|pl| pl.max_total_threads_per_threadgroup() >= vec_nsg as u64 * 32)
                             .unwrap_or(false)
                     });
                 let split32 = split
@@ -1683,7 +1711,9 @@ impl MetalBackend {
                 } else {
                     // One simdgroup per (query, head); split/vec kernels use NSG simdgroups
                     // per pair, grid still exactly rows*n_head threadgroups.
-                    let nsg = if vec || split32 {
+                    let nsg = if vec {
+                        vec_nsg
+                    } else if split32 {
                         32
                     } else if split {
                         8

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -115,6 +115,9 @@ fn linear_add_peephole(
 pub(crate) struct TapeEntry {
     pso: ComputePipelineState,
     bufs: Vec<MtlBuffer>,
+    /// Per-buffer byte offset for `set_buffer` (parallel to `bufs`; all zero except the
+    /// fused-QKV weight slices — see the Linear arm's `w_off`).
+    offs: Vec<u64>,
     params: Vec<u8>,
     threads: usize,
     tg: usize,
@@ -363,6 +366,21 @@ impl MetalBackend {
         threads: usize,
         tg: usize,
     ) {
+        let with_offs: Vec<(&MtlBuffer, u64)> = bufs.iter().map(|b| (*b, 0)).collect();
+        self.encode_tg_off(r, pso, &with_offs, params, threads, tg);
+    }
+
+    /// As `encode_tg`, but each buffer binds at a byte offset — the fused-QKV Linear slices
+    /// bind the shared concatenated weight at each projection's row offset (`Op::Linear.w_off`).
+    fn encode_tg_off(
+        &self,
+        r: &mut Resident,
+        pso: &ComputePipelineState,
+        bufs: &[(&MtlBuffer, u64)],
+        params: &[u8],
+        threads: usize,
+        tg: usize,
+    ) {
         if threads == 0 {
             return;
         }
@@ -374,8 +392,8 @@ impl MetalBackend {
         }
         let enc = r.enc.as_ref().unwrap();
         enc.set_compute_pipeline_state(pso);
-        for (i, b) in bufs.iter().enumerate() {
-            enc.set_buffer(i as u64, Some(b), 0);
+        for (i, (b, off)) in bufs.iter().enumerate() {
+            enc.set_buffer(i as u64, Some(b), *off);
         }
         if !params.is_empty() {
             enc.set_bytes(
@@ -390,7 +408,8 @@ impl MetalBackend {
         if let Some(tape) = r.tape.as_mut() {
             tape.push(TapeEntry {
                 pso: pso.clone(),
-                bufs: bufs.iter().map(|b| (*b).clone()).collect(),
+                bufs: bufs.iter().map(|(b, _)| (*b).clone()).collect(),
+                offs: bufs.iter().map(|(_, off)| *off).collect(),
                 params: params.to_vec(),
                 threads,
                 tg,
@@ -408,7 +427,7 @@ impl MetalBackend {
             for e in &tape.entries {
                 enc.set_compute_pipeline_state(&e.pso);
                 for (i, b) in e.bufs.iter().enumerate() {
-                    enc.set_buffer(i as u64, Some(b), 0);
+                    enc.set_buffer(i as u64, Some(b), e.offs[i]);
                 }
                 if !e.params.is_empty() {
                     enc.set_bytes(
@@ -931,13 +950,6 @@ impl MetalBackend {
                 out_f,
                 w_off,
             } => {
-                // Only produced by the fused-QKV runner path, which is gated on
-                // `Capabilities::combined_gu` — Metal leaves it false, so this is unreachable.
-                if w_off != 0 {
-                    return Err(Error::Unsupported(
-                        "metal: Linear w_off (fused-QKV slices) unsupported".into(),
-                    ));
-                }
                 let (m, in_f, out_f) = (m as usize, in_f as usize, out_f as usize);
                 let bx = self.ensure_device(r, x);
                 let bd = self.dev_dst(r, dst, m * out_f);
@@ -952,6 +964,32 @@ impl MetalBackend {
                     // weight block decoded once for all 8 rows, instead of the GEMV kernel
                     // re-streaming the whole weight matrix once per row.
                     let qw = self.weight_qui(weight, g, bindings);
+                    // Fused-QKV slice: `w_off` is a whole-row element offset into the shared
+                    // concatenated weight (the runner bakes it as `row0 * in_f`), so it lands on
+                    // a block boundary in every stream — bind each stream at the corresponding
+                    // byte offset and the kernels see the slice as a standalone [out_f, in_f]
+                    // weight. Native K-quant streams are raw GGUF blocks (144 B / 210 B per 256
+                    // elements); factored streams are bit-packed codes + 4 B scm per 16 elements
+                    // + 4 B (d, dmin) per 2^dshift elements.
+                    let e = w_off as u64;
+                    let dd_off = (e >> qw.dshift) * 4;
+                    let (codes_off, scm_off, dd_off) = match qw.kern {
+                        _ if w_off == 0 => (0, 0, 0),
+                        // Native kernels read raw GGUF blocks; scm/dd are dummy buffers.
+                        "linear_q4k" => (e / 256 * 144, 0, 0),
+                        "linear_q6k" => (e / 256 * 210, 0, 0),
+                        "linear_quik4" => (e / 2, e / 4, dd_off),
+                        "linear_quik6" => (e / 4 * 3, e / 4, dd_off),
+                        _ => (e, e / 4, dd_off),
+                    };
+                    // `set_buffer` offsets must stay 4-byte aligned; every real fused shape does
+                    // (in_f is a multiple of 512 or the format's stride is already 4-aligned) —
+                    // reject the pathological remainder instead of tripping API validation.
+                    if codes_off % 4 != 0 || scm_off % 4 != 0 || dd_off % 4 != 0 {
+                        return Err(Error::Unsupported(
+                            "metal: Linear w_off lands off 4-byte alignment".into(),
+                        ));
+                    }
                     // sgs = simdgroups to launch; tg = threadgroup width. GEMM tiles 8x16 per
                     // simdgroup (4 simdgroups per threadgroup for the staging tile). The GEMM
                     // kernel requires its full 128-thread threadgroup (per-simdgroup staging
@@ -992,10 +1030,16 @@ impl MetalBackend {
                     if cmm_ok {
                         // Reads f32 x directly (casts to f16 while staging) — no cast pass.
                         let pso = self.pipelines.get(cmm_kern)?;
-                        self.encode_tg(
+                        self.encode_tg_off(
                             r,
                             &pso,
-                            &[bx.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[
+                                (bx.as_ref(), 0),
+                                (&qw.codes, codes_off),
+                                (&qw.scm, scm_off),
+                                (&qw.dd, dd_off),
+                                (bd.as_ref(), 0),
+                            ],
                             &p,
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,
@@ -1011,10 +1055,16 @@ impl MetalBackend {
                         let n = (m * in_f) as u32;
                         self.encode(r, &cast, &[bx.as_ref(), &xh], &n.to_ne_bytes(), m * in_f);
                         let pso = self.pipelines.get(hmm_kern)?;
-                        self.encode_tg(
+                        self.encode_tg_off(
                             r,
                             &pso,
-                            &[xh.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[
+                                (xh.as_ref(), 0),
+                                (&qw.codes, codes_off),
+                                (&qw.scm, scm_off),
+                                (&qw.dd, dd_off),
+                                (bd.as_ref(), 0),
+                            ],
                             &p,
                             m.div_ceil(32) * (out_f / 16) * 32,
                             128,
@@ -1047,16 +1097,16 @@ impl MetalBackend {
                             let bres = self.ensure_device(r, res);
                             let bfd = self.dev_dst(r, fdst, out_f);
                             let pso = self.pipelines.get(fk)?;
-                            self.encode_tg(
+                            self.encode_tg_off(
                                 r,
                                 &pso,
                                 &[
-                                    bx.as_ref(),
-                                    &qw.codes,
-                                    &qw.scm,
-                                    &qw.dd,
-                                    bfd.as_ref(),
-                                    bres.as_ref(),
+                                    (bx.as_ref(), 0),
+                                    (&qw.codes, codes_off),
+                                    (&qw.scm, scm_off),
+                                    (&qw.dd, dd_off),
+                                    (bfd.as_ref(), 0),
+                                    (bres.as_ref(), 0),
                                 ],
                                 &p,
                                 sgs * 32,
@@ -1066,10 +1116,16 @@ impl MetalBackend {
                             return Ok(());
                         }
                         let pso = self.pipelines.get(kern)?;
-                        self.encode_tg(
+                        self.encode_tg_off(
                             r,
                             &pso,
-                            &[bx.as_ref(), &qw.codes, &qw.scm, &qw.dd, bd.as_ref()],
+                            &[
+                                (bx.as_ref(), 0),
+                                (&qw.codes, codes_off),
+                                (&qw.scm, scm_off),
+                                (&qw.dd, dd_off),
+                                (bd.as_ref(), 0),
+                            ],
                             &p,
                             sgs * 32,
                             32,
@@ -1079,10 +1135,14 @@ impl MetalBackend {
                     // f16/f32/bf16 weight: dequant-to-f32 device buffer, cached.
                     let bw = self.weight_buf(weight, g, bindings);
                     let pso = self.pipelines.get("linear_f32")?;
-                    self.encode_tg(
+                    self.encode_tg_off(
                         r,
                         &pso,
-                        &[bx.as_ref(), bw.as_ref(), bd.as_ref()],
+                        &[
+                            (bx.as_ref(), 0),
+                            (bw.as_ref(), w_off as u64 * 4),
+                            (bd.as_ref(), 0),
+                        ],
                         &p,
                         m * out_f * 32,
                         32,
@@ -2246,6 +2306,8 @@ impl MetalBackend {
                 r.vals[dst.0 as usize][dof..dof + n].copy_from_slice(&s[so..so + n]);
                 r.loc[dst.0 as usize] = Loc::Host;
             }
+            // On-device: the fused-QKV prefill emits one of these per projection right after the
+            // wide GEMM — a host copy would round-trip the [m, qkv] activation mid-forward.
             Op::CopyStrided {
                 src,
                 src_off,
@@ -2256,22 +2318,24 @@ impl MetalBackend {
                 rows,
                 n,
             } => {
-                let (so, ss, dof, ds, n) = (
-                    src_off as usize,
-                    src_stride as usize,
-                    dst_off as usize,
-                    dst_stride as usize,
-                    n as usize,
+                let bs = self.ensure_device(r, src);
+                // The strided write may cover only part of dst — bring the rest along.
+                let bd = self.ensure_device(r, dst);
+                let mut p = src_off.to_ne_bytes().to_vec();
+                p.extend_from_slice(&src_stride.to_ne_bytes());
+                p.extend_from_slice(&dst_off.to_ne_bytes());
+                p.extend_from_slice(&dst_stride.to_ne_bytes());
+                p.extend_from_slice(&rows.to_ne_bytes());
+                p.extend_from_slice(&n.to_ne_bytes());
+                let pso = self.pipelines.get("copy_strided_f32")?;
+                self.encode(
+                    r,
+                    &pso,
+                    &[bs.as_ref(), bd.as_ref()],
+                    &p,
+                    rows as usize * n as usize,
                 );
-                self.ensure_host(r, g, src);
-                self.ensure_host(r, g, dst);
-                let s = r.vals[src.0 as usize].clone();
-                let d = &mut r.vals[dst.0 as usize];
-                for rr in 0..rows as usize {
-                    d[dof + rr * ds..dof + rr * ds + n]
-                        .copy_from_slice(&s[so + rr * ss..so + rr * ss + n]);
-                }
-                r.loc[dst.0 as usize] = Loc::Host;
+                r.loc[dst.0 as usize] = Loc::Device;
             }
         }
         Ok(())

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1592,7 +1592,7 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
         // load directly from the f16 cache; fully-causal-masked 8-row KV blocks skipped (their
         // P is all zero, and skipping keeps reads within 7 rows of the limit)
         {
-            simdgroup_float8x8 lo[4];
+            simdgroup_float8x8 lo[no];
             threadgroup float* sot = so + 8u * sgitg;
             for (uint ii = 0; ii < no; ii++) simdgroup_load(lo[ii], sot + 8u * NSG * ii, hd);
             device const half* pv = v + ((ulong)ic * p.n_kv + kvh) * hd + 8u * sgitg;
@@ -1640,6 +1640,8 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
 typedef decltype(attnflash2_f16kv_t<64, 4>) attnflash2_t;
 template [[host_name("attnflash2_f16kv_hd64")]]  kernel attnflash2_t attnflash2_f16kv_t<64, 4>;
 template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_f16kv_t<128, 4>;
+// hd=256 (gemma): sq 4KB + so 8KB + ss 2KB = 14KB shared, 8 O fragments per simdgroup.
+template [[host_name("attnflash2_f16kv_hd256")]] kernel attnflash2_t attnflash2_f16kv_t<256, 4>;
 
 // ---- Vector flash attention for decode (f16 KV cache, hd 64 or 128, one query row per
 // threadgroup): the llama.cpp `kernel_flash_attn_ext_vec` structure. NSG simdgroups each own
@@ -1825,6 +1827,11 @@ template [[host_name("attnvec_f16kv_hd128")]] kernel attnvec_t attnvec_f16kv_t<1
 typedef decltype(attnvec_dyn_f16kv_t<64, 32>) attnvec_dyn_t;
 template [[host_name("attnvec_dyn_f16kv_hd64")]]  kernel attnvec_dyn_t attnvec_dyn_f16kv_t<64, 32>;
 template [[host_name("attnvec_dyn_f16kv_hd128")]] kernel attnvec_dyn_t attnvec_dyn_f16kv_t<128, 32>;
+// hd=256 (gemma) drops to NSG=16: the per-simdgroup O partials are NSG*hd*4 bytes — 32 KB at
+// NSG=32/hd=256, over the whole threadgroup budget before sq/ssc. 16 simdgroups still cut the
+// serial chain 16x vs the plain split kernel; the merge tree just starts one level lower.
+template [[host_name("attnvec_f16kv_hd256")]]     kernel attnvec_t     attnvec_f16kv_t<256, 16>;
+template [[host_name("attnvec_dyn_f16kv_hd256")]] kernel attnvec_dyn_t attnvec_dyn_f16kv_t<256, 16>;
 
 // ---- Gated DeltaNet (Qwen3-Next linear attention) + its depthwise conv, ON DEVICE. Both are
 // sequential-over-rows recurrences; the parallelism is across CHANNELS (conv: each thread owns a
@@ -2340,7 +2347,7 @@ kernel void attnflash2_q8kv_t(device const half*  q   [[buffer(0)]],
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
         {
-            simdgroup_float8x8 lo[4];
+            simdgroup_float8x8 lo[no];
             threadgroup float* sot = so + 8u * sgitg;
             for (uint ii = 0; ii < no; ii++) simdgroup_load(lo[ii], sot + 8u * NSG * ii, hd);
             threadgroup const half* pv = kvt + 8u * sgitg;
@@ -2380,4 +2387,8 @@ template [[host_name("attnvec_q8kv_hd128")]] kernel attnvec_q8_t attnvec_q8kv_t<
 typedef decltype(attnvec_dyn_q8kv_t<64, 32>) attnvec_dyn_q8_t;
 template [[host_name("attnvec_dyn_q8kv_hd64")]]  kernel attnvec_dyn_q8_t attnvec_dyn_q8kv_t<64, 32>;
 template [[host_name("attnvec_dyn_q8kv_hd128")]] kernel attnvec_dyn_q8_t attnvec_dyn_q8kv_t<128, 32>;
+// hd=256 at NSG=16 — same threadgroup-budget math as the f16 vec kernel. (No q8 flash hd256:
+// its dequant-staging tile alone is C*hd = 32 KB half — needs a C=32 variant first.)
+template [[host_name("attnvec_q8kv_hd256")]]     kernel attnvec_q8_t     attnvec_q8kv_t<256, 16>;
+template [[host_name("attnvec_dyn_q8kv_hd256")]] kernel attnvec_dyn_q8_t attnvec_dyn_q8kv_t<256, 16>;
 "#;

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -367,6 +367,26 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
 }
 
 
+// ---- Strided row copy (the fused-QKV prefill split: one wide GEMM output sliced into q/k/v).
+// Pure data movement, but on-device — a host copy here would round-trip the [m, qkv] buffer and
+// break the command buffer mid-forward.
+struct CopyStridedParams {
+    uint src_off;
+    uint src_stride;
+    uint dst_off;
+    uint dst_stride;
+    uint rows;
+    uint n;
+};
+kernel void copy_strided_f32(device const float*         src [[buffer(0)]],
+                             device float*               dst [[buffer(1)]],
+                             constant CopyStridedParams& p   [[buffer(2)]],
+                             uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.n) return;
+    uint r = gid / p.n, c = gid % p.n;
+    dst[p.dst_off + r * p.dst_stride + c] = src[p.src_off + r * p.src_stride + c];
+}
+
 // ---- Cast f32 -> f16 (prefill GEMM feeds on half activations; round-to-nearest-even).
 kernel void cast_f32_f16(device const float* src [[buffer(0)]],
                          device half*        dst [[buffer(1)]],

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -299,6 +299,16 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
         wk[4u * i + 3u] = dl3 * (float)(q & 0xFF000000u) + mn;                                    \
     }
 
+// NATIVE Q8_0 block (34 B / 32 elems): [f16 d][32 x i8]. 8.5 bpw streamed vs the factored
+// form's ~10.2 (codes + scm + dd) — the decode GEMV is bound on exactly this stream. 34 % 4 != 0,
+// so d assembles from bytes and the quants are char loads (same convention as Q6_K's byte loads).
+// wk = d * q, the exact dequantize_q8_0 product.
+#define DEC16_Q8_0(wk)                                                                            \
+    device const uchar* blk = codes + (ulong)(bi >> 1) * 34ul;                                    \
+    float d = (float)as_type<half>((ushort)(blk[0] | ((ushort)blk[1] << 8)));                     \
+    device const char* qs = (device const char*)(blk + 2u + (bi & 1u) * 16u);                     \
+    for (uint k = 0; k < 16u; k++) wk[k] = d * (float)qs[k];
+
 // GEMV: one simdgroup (32 lanes) per output element; each lane decodes one 16-element block per
 // step, coalesced across lanes, `simd_sum` reduction. m=1 decode is bound on the weight stream.
 #define GEMV_KERNEL(NAME, DEC)                                                                    \
@@ -677,6 +687,80 @@ kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
     linear_q6k_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
 }
 
+// Decode GEMV for NATIVE Q8_0 (34 B / 32-elem blocks), mul_mv shape (ported from llama.cpp's
+// kernel_mul_mv_q8_0_f32): each simdgroup computes FOUR output rows (N_R0_Q8_0); lanes fold as
+// 8 blocks in flight x 4 threads per block (8 quants each), activations load once into registers
+// and are reused across all four rows, and the inner product is d * sum(q*y) — the exact
+// dequantize_q8_0 product, reassociated. The stream is the raw 8.5 bpw weight — the factored
+// quik8 form paid ~10.2 bpw for the same values, and decode GEMV is bound on exactly this stream.
+// Same EPI epilogue contract as `linear_q4k_body`. Tail rows clamp their pointer into the weight
+// (their sums are discarded at the write).
+template<int EPI, typename PT>
+inline void linear_q8_0_body(device const float*  x,
+                             device const uchar*  codes,
+                             device float*        dst,
+                             device const float*  res,
+                             constant PT& p,
+                             float wgt, bool zeroacc,
+                             uint gid, uint lane) {
+    uint first_row = (gid / 32u) * 4u;
+    if (first_row >= p.out_f) return;
+    uint nb = p.in_f >> 5;                 // 32-element blocks per row
+    ulong row_b = (ulong)nb * 34ul;        // row stride in bytes
+    uint nrows = min(4u, p.out_f - first_row);
+
+    uint ix = lane >> 2;                   // 0..7: which of 8 blocks in flight
+    uint il = (lane & 3u) * 8u;            // this thread's 8 quants within the block
+
+    float yl[8];
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float* yb = x + ix * 32u + il;
+
+    for (uint ib = ix; ib < nb; ib += 8u) {
+        for (uint i = 0; i < 8u; i++) yl[i] = yb[i];
+        for (uint row = 0; row < 4u; row++) {
+            device const uchar* blk =
+                codes + (ulong)(first_row + min(row, nrows - 1u)) * row_b + (ulong)ib * 34ul;
+            device const char* qs = (device const char*)(blk + 2u) + il;
+            float sumq = 0.0f;
+            for (uint i = 0; i < 8u; i++) sumq += (float)qs[i] * yl[i];
+            sumf[row] += sumq * (float)as_type<half>((ushort)(blk[0] | ((ushort)blk[1] << 8)));
+        }
+        yb += 8u * 32u;
+    }
+    for (uint row = 0; row < nrows; row++) {
+        float s = simd_sum(sumf[row]);
+        if (lane == 0u) {
+            uint o = first_row + row;
+            if (EPI == 2)      dst[o] = (zeroacc ? 0.0f : dst[o]) + wgt * s;
+            else if (EPI == 1) dst[o] = s + res[o];
+            else               dst[o] = s;
+        }
+    }
+}
+
+kernel void linear_q8_0(device const float*  x     [[buffer(0)]],
+                        device const uchar*  codes [[buffer(1)]],
+                        device const uchar*  scm   [[buffer(2)]],
+                        device const uchar*  dd    [[buffer(3)]],
+                        device float*        dst   [[buffer(4)]],
+                        constant QLinParams& p     [[buffer(5)]],
+                        uint gid  [[thread_position_in_grid]],
+                        uint lane [[thread_index_in_simdgroup]]) {
+    linear_q8_0_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
+}
+kernel void linear_q8_0_add(device const float*  x     [[buffer(0)]],
+                            device const uchar*  codes [[buffer(1)]],
+                            device const uchar*  scm   [[buffer(2)]],
+                            device const uchar*  dd    [[buffer(3)]],
+                            device float*        dst   [[buffer(4)]],
+                            device const float*  res   [[buffer(5)]],
+                            constant QLinParams& p     [[buffer(6)]],
+                            uint gid  [[thread_position_in_grid]],
+                            uint lane [[thread_index_in_simdgroup]]) {
+    linear_q8_0_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
+}
+
 // ---- MoE expert GEMVs: the shared GEMV bodies, batched over the SELECTED experts — one
 // dispatch covers all n_used experts (slot = high grid bits), each picking its weight slice
 // from the device expert table (`moe_topk` below), so a whole MoE FFN is 7 dispatches with no
@@ -930,6 +1014,7 @@ RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)
 RT_KERNEL(linear_q4k_rt, DEC16_Q4K)
 RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
+RT_KERNEL(linear_q8_0_rt, DEC16_Q8_0)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as
@@ -1046,6 +1131,7 @@ CMM_KERNEL(linear_quik4_cmm, DEC16_K4)
 CMM_KERNEL(linear_quik6_cmm, DEC16_K6)
 CMM_KERNEL(linear_quik8_cmm, DEC16_K8)
 CMM_KERNEL(linear_q4k_cmm, DEC16_Q4K)
+CMM_KERNEL(linear_q8_0_cmm, DEC16_Q8_0)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
@@ -1053,6 +1139,7 @@ HGEMM_KERNEL(linear_quik6_hmm, DEC16_K6)
 HGEMM_KERNEL(linear_quik8_hmm, DEC16_K8)
 HGEMM_KERNEL(linear_q4k_hmm, DEC16_Q4K)
 HGEMM_KERNEL(linear_q6k_hmm, DEC16_Q6K)
+HGEMM_KERNEL(linear_q8_0_hmm, DEC16_Q8_0)
 
 
 // ---- RoPE (Op::Rope = the no-qk-norm llama-family rotation): INTERLEAVED pairs (2p, 2p+1) —

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -361,6 +361,14 @@ fn linear_add_fusion_q4k_parity() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_add_fusion_q8_0_parity() {
+    let (in_f, out_f) = (512usize, 384usize);
+    let wf = rand_f32(out_f * in_f, 95);
+    check_linear_add_fusion(DType::Q8_0, quantize_q8_0(&wf), in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_add_fusion_q6k_parity() {
     let (in_f, out_f) = (512usize, 384usize);
     check_linear_add_fusion(DType::Q6K, synth_q6k(out_f * in_f, 94), in_f, out_f);
@@ -650,6 +658,25 @@ fn linear_q8_0_matches_dequant_reference() {
         let err = (r - mm).abs() / r.abs().max(1.0);
         assert!(err <= 1e-3, "elem {i}: ref={r} metal={mm} err={err}");
     }
+}
+
+// Native Q8_0 half-fragment GEMM (m=18 → the hmm route; out_f % 64 != 0 keeps cmm out).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q8_0_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (18usize, 256usize, 96usize);
+    let wf = rand_f32(out_f * in_f, 96);
+    check_quant_linear_parity_impl(DType::Q8_0, quantize_q8_0(&wf), m, in_f, out_f, 1e-3, true);
+}
+
+// Native Q8_0 GEMV (m=1, the mul_mv_q8_0 shape: FOUR rows per simdgroup; out_f=94 exercises the
+// clamped tail rows of a partial 4-row group).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q8_0_gemv_matches_dequant_reference() {
+    let (m, in_f, out_f) = (1usize, 256usize, 94usize);
+    let wf = rand_f32(out_f * in_f, 97);
+    check_quant_linear_parity(DType::Q8_0, quantize_q8_0(&wf), m, in_f, out_f);
 }
 
 // K-quants are the formats real checkpoints actually ship. Exercise the Metal dequant path

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1022,6 +1022,13 @@ fn attention_q8_flash_parity() {
     q8_attention_test(17, 136, 128, 119, 5e-3, 260);
 }
 
+// hd=256 q8 decode (gemma + INFR_KV_Q8): the NSG=16 q8 vector instantiation.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_q8_vec_hd256_parity() {
+    q8_attention_test(1, 200, 256, 199, 1e-4, 270);
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn attention_gqa_causal_parity() {
@@ -1187,6 +1194,71 @@ fn attention_flash2_hd128_matches_reference() {
         (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 183))),
     ];
     assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
+// hd=256 (gemma): the cooperative flash instantiation with 8 O fragments per simdgroup.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_flash2_hd256_matches_reference() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (17usize, 136usize, 8usize, 2usize, 256usize, 119usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::SlidingWindow(64),
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 401))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 402))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 403))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
+// hd=256 decode (gemma): the NSG=16 vector flash instantiation, sliding window active (gemma's
+// local layers decode with window clipping — the shape the sweep found on the split fallback).
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_vec_hd256_sliding_window_parity() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (1usize, 200usize, 4usize, 1usize, 256usize, 199usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::SlidingWindow(96),
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 404))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 405))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 406))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
 }
 
 // Sliding-window masking through the cooperative flash kernel: the analytic per-row window

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -434,6 +434,136 @@ fn check_quant_linear_parity_impl(
     }
 }
 
+// Fused-QKV slices: several Linear ops share ONE concatenated [Σslices, in_f] weight, each
+// reading its rows at `w_off` (the runner's combined-QKV shape — `Op::Linear.w_off`). Every
+// slice must match a reference matmul over the dequant of just that slice's rows; the
+// non-zero offsets exercise the byte-offset binds into the codes/scm/dd streams.
+fn check_linear_woff(
+    dtype: DType,
+    wbytes: Vec<u8>,
+    m: usize,
+    in_f: usize,
+    slices: &[usize],
+    half_ops: bool,
+    tol: f32,
+) {
+    use infr_gguf::dequant::dequant_block;
+    let rows_total: usize = slices.iter().sum();
+    let mut xs = rand_f32(m * in_f, 34);
+    let mut wref = dequant_block(dtype, &wbytes).unwrap();
+    if half_ops {
+        for v in xs.iter_mut().chain(wref.iter_mut()) {
+            *v = half::f16::from_f32(*v).to_f32();
+        }
+    }
+    let be = MetalBackend::new().expect("metal backend");
+    let mut row0 = 0usize;
+    for &out_f in slices {
+        let wslice = &wref[row0 * in_f..(row0 + out_f) * in_f];
+        let reference = ref_linear(&xs, wslice, m, in_f, out_f);
+        let mut g = Graph::new();
+        let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+        let w = g.weight(TensorDesc::new(vec![rows_total, in_f], dtype));
+        let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+        g.push(Op::Linear {
+            x,
+            weight: w,
+            dst,
+            m: m as u32,
+            in_f: in_f as u32,
+            out_f: out_f as u32,
+            w_off: (row0 * in_f) as u32,
+        });
+        let bound = vec![(x, f32_bytes(&xs)), (w, wbytes.clone())];
+        let mtl = run(&be, &g, &bound, dst, m * out_f);
+        for (i, (r, mm)) in reference.iter().zip(mtl.iter()).enumerate() {
+            let err = (r - mm).abs() / r.abs().max(1.0);
+            assert!(
+                err <= tol,
+                "{dtype:?} slice@{row0} elem {i}: ref={r} metal={mm} err={err} > {tol}"
+            );
+        }
+        row0 += out_f;
+    }
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q8_0_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 35);
+    check_linear_woff(
+        DType::Q8_0,
+        quantize_q8_0(&wf),
+        1,
+        in_f,
+        &slices,
+        false,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q8_0_coop_gemm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 36);
+    check_linear_woff(
+        DType::Q8_0,
+        quantize_q8_0(&wf),
+        40,
+        in_f,
+        &slices,
+        true,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q4k_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    check_linear_woff(
+        DType::Q4K,
+        synth_q4k(256 * in_f, 37),
+        1,
+        in_f,
+        &slices,
+        false,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q4k_coop_gemm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    check_linear_woff(
+        DType::Q4K,
+        synth_q4k(256 * in_f, 38),
+        40,
+        in_f,
+        &slices,
+        true,
+        1e-3,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_q6k_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    check_linear_woff(
+        DType::Q6K,
+        synth_q6k(256 * in_f, 39),
+        1,
+        in_f,
+        &slices,
+        false,
+        1e-3,
+    );
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn linear_f32_parity() {


### PR DESCRIPTION
Ran the new `infr compare --sweep` on Metal (5 models) and it found two craters: **gemma3-1b at 0.22×–0.47×** of llama.cpp across all metrics, and **Q8_0 checkpoints at 0.23×** prefill. Two independent causes, both fixed here.

## 1. hd=256 had no flash/vec instantiations

Every gemma attention (hd=256) rode the split fallbacks. Added:
- `attnflash2_f16kv_hd256` (prefill) — same NSG=4 cooperative structure, 8 O fragments per simdgroup (the `lo[4]` register array was silently sized for hd≤128; now `lo[no]`), 14 KB threadgroup.
- `attnvec_{f16,q8}kv_hd256` + `dyn` variants (decode + replay tape) at **NSG=16**: the per-simdgroup O partials are `NSG·hd·4` bytes, and 32 simdgroups at hd=256 is 32 KB before sq/ssc — over budget. Routing and the replay gates now carry the head-size-dependent threadgroup requirement (512 vs 1024).
- The wide-launch gate opens for hd=256 only when flash2 itself can run (no single-simdgroup flash fallback exists past hd=128).

## 2. bench_metal rebuilt the backend every rep

Per-backend one-time costs — the dequant/repack weight caches, pipeline compiles — were re-paid **inside every measurement**. Invisible on Q4_K_M (native-kernel formats never repack), but a factored-format checkpoint re-repacked hundreds of MB per rep: gemma pp512 spent 687 ms/forward on host encode vs 203 ms of GPU. The bench now runs through one persistent `DenseMetalSession` (weights/pipelines/caches warm — llama-bench keeps one context across reps too), with `SeamKv::reset_tokens()` so each rep still measures a full prefill. Weight caches also key on the underlying MTLBuffer contents pointer rather than the rebindable wrapper address.

## Numbers (M3 Pro, vs llama.cpp Metal, same GGUFs, back-to-back)

| model | metric | before | after | vs llama.cpp |
|---|---|---|---|---|
| gemma3-1b Q4_K_M | pp512 | 673 | **2101** | 0.22× → 0.67× |
| gemma3-1b Q4_K_M | tg128 | 56 | **78.6** | 0.47× → 0.67× |
| gemma3-1b Q4_K_M | tg64@d4096 | 36 | **74.8** | 0.33× → 0.67× |
| qwen3-0.6b Q8_0 | pp512 | 1062 | **3003** | 0.23× → 0.64× |
| qwen3-0.6b Q8_0 | tg128 | 82 | **108** | 0.54× → 0.71× |

Qwen Q4_K_M also picks up ~8% pp512 from the warm-session bench (3622 → 3907).

## Validation

Long-prompt gemma (1400 tokens, window actively clipping) stays SWA-correct vs the CPU oracle — one near-tie greedy flip ("fox" vs "foxes."), the accumulation-order class we've characterized on qwen essays, both outputs verified coherent; replay on/off token-identical. 57 GPU parity tests (3 new hd=256: flash2 windowed, vec windowed at 1e-4, q8 vec at 1e-4). fmt/clippy(-D warnings)/test matrix green locally.

**Stacked on #13** (same exec.rs region — the diff collapses when that merges). Remaining gemma/Q8_0 gap is now the same GEMM-shape story as the dense models (narrow-n / split-K tile variants, the follow-up from #13's notes).

Also noting: `compare --sweep` defaults `--dev Vulkan0`, which llama-bench rejects on a Metal box — ran with `--dev MTL0`. A platform-aware default might be worth a line.