### PR TITLE
perf(metal): native Q5_0 kernels + concurrent decode replay + on-device Copy

### DIFF
--- a/crates/infr-metal/Cargo.toml
+++ b/crates/infr-metal/Cargo.toml
@@ -18,5 +18,10 @@ bytemuck.workspace = true
 metal.workspace = true
 objc.workspace = true
 
+# objc's `sel_impl!` (inside `msg_send!`) expands a `cfg(feature = "cargo-clippy")` check the
+# crate doesn't declare; register it so `-D warnings` builds don't reject `unexpected_cfgs`.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [dev-dependencies]
 infr-cpu.workspace = true

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -8,10 +8,12 @@ use infr_core::graph::{Op, TensorKind};
 use infr_core::tensor::{DType, TensorId};
 use infr_core::Result;
 use infr_gguf::dequant::dequant_block;
+use metal::foreign_types::ForeignType;
 use metal::{
     Buffer as MtlBuffer, CommandBuffer, ComputeCommandEncoder, ComputePipelineState,
     MTLResourceOptions, MTLSize,
 };
+use objc::{msg_send, sel, sel_impl};
 use std::ffi::c_void;
 use std::sync::Arc;
 
@@ -118,6 +120,10 @@ pub(crate) struct TapeEntry {
     /// Per-buffer byte offset for `set_buffer` (parallel to `bufs`; all zero except the
     /// fused-QKV weight slices — see the Linear arm's `w_off`).
     offs: Vec<u64>,
+    /// Bitmask over `bufs`: which buffers this dispatch WRITES. Replay runs a CONCURRENT
+    /// encoder and derives the exact barrier placement from these (see `replay_tape`); sites
+    /// that don't annotate record `u32::MAX` — treated as writing everything, i.e. serialized.
+    wmask: u32,
     params: Vec<u8>,
     threads: usize,
     tg: usize,
@@ -353,6 +359,19 @@ impl MetalBackend {
         self.encode_tg(r, pso, bufs, params, threads, 0);
     }
 
+    /// `encode` with a write mask — see `encode_tg_w`.
+    fn encode_w(
+        &self,
+        r: &mut Resident,
+        pso: &ComputePipelineState,
+        bufs: &[&MtlBuffer],
+        wmask: u32,
+        params: &[u8],
+        threads: usize,
+    ) {
+        self.encode_tg_w(r, pso, bufs, wmask, params, threads, 0);
+    }
+
     /// As `encode`, but with an explicit threadgroup width (`tg`; 0 = auto). The simdgroup-GEMV
     /// kernels pass 32 (one simdgroup per threadgroup) so a matvec launches `out_f` threadgroups
     /// instead of a handful of wide ones — far more threadgroups for the GPU's cores to interleave,
@@ -366,17 +385,35 @@ impl MetalBackend {
         threads: usize,
         tg: usize,
     ) {
-        let with_offs: Vec<(&MtlBuffer, u64)> = bufs.iter().map(|b| (*b, 0)).collect();
-        self.encode_tg_off(r, pso, &with_offs, params, threads, tg);
+        // No write annotation: recorded as writes-everything, so replay serializes around it.
+        self.encode_tg_w(r, pso, bufs, u32::MAX, params, threads, tg);
     }
 
-    /// As `encode_tg`, but each buffer binds at a byte offset — the fused-QKV Linear slices
+    /// `encode_tg` with an explicit WRITE mask (bit i = `bufs[i]` is written by the dispatch).
+    /// The mask only matters on the decode replay tape, where it drives exact barrier placement
+    /// under the concurrent encoder — un-annotated dispatches replay serialized.
+    fn encode_tg_w(
+        &self,
+        r: &mut Resident,
+        pso: &ComputePipelineState,
+        bufs: &[&MtlBuffer],
+        wmask: u32,
+        params: &[u8],
+        threads: usize,
+        tg: usize,
+    ) {
+        let with_offs: Vec<(&MtlBuffer, u64)> = bufs.iter().map(|b| (*b, 0)).collect();
+        self.encode_tg_off(r, pso, &with_offs, wmask, params, threads, tg);
+    }
+
+    /// As `encode_tg_w`, but each buffer binds at a byte offset — the fused-QKV Linear slices
     /// bind the shared concatenated weight at each projection's row offset (`Op::Linear.w_off`).
     fn encode_tg_off(
         &self,
         r: &mut Resident,
         pso: &ComputePipelineState,
         bufs: &[(&MtlBuffer, u64)],
+        wmask: u32,
         params: &[u8],
         threads: usize,
         tg: usize,
@@ -410,6 +447,7 @@ impl MetalBackend {
                 pso: pso.clone(),
                 bufs: bufs.iter().map(|(b, _)| (*b).clone()).collect(),
                 offs: bufs.iter().map(|(_, off)| *off).collect(),
+                wmask,
                 params: params.to_vec(),
                 threads,
                 tg,
@@ -423,8 +461,41 @@ impl MetalBackend {
     fn replay_tape(&self, tape: &Tape) {
         objc::rc::autoreleasepool(|| {
             let cb = self.queue.new_command_buffer();
-            let enc = cb.new_compute_command_encoder();
+            // CONCURRENT dispatch: with the serial type every dispatch implicitly orders after
+            // the previous one, which costs ~1 µs of pipeline drain per dispatch on runs of
+            // INDEPENDENT work (decode's q/k/v GEMVs, the two KV writes). Ordering here comes
+            // from explicit barriers, placed exactly where the recorded write masks show a
+            // hazard: this dispatch reads or writes a buffer someone wrote since the last
+            // barrier (RAW/WAW), or writes one someone read (WAR). Un-annotated entries
+            // (wmask = MAX) count every buffer as written — serialized, never under-fenced.
+            let enc =
+                cb.compute_command_encoder_with_dispatch_type(metal::MTLDispatchType::Concurrent);
+            let mut written: Vec<*const c_void> = Vec::with_capacity(8);
+            let mut read: Vec<*const c_void> = Vec::with_capacity(24);
             for e in &tape.entries {
+                let is_w = |i: usize| e.wmask & (1u32 << i.min(31)) != 0;
+                let hazard = e.bufs.iter().enumerate().any(|(i, b)| {
+                    let p = b.as_ptr() as *const c_void;
+                    written.contains(&p) || (is_w(i) && read.contains(&p))
+                });
+                if hazard {
+                    // All-buffers scope barrier: prior dispatches' buffer accesses complete
+                    // before anything encoded after. (metal-rs has no wrapper for the scope
+                    // variant; MTLBarrierScopeBuffers = 1.)
+                    unsafe {
+                        let () = msg_send![enc, memoryBarrierWithScope: 1u64];
+                    }
+                    written.clear();
+                    read.clear();
+                }
+                for (i, b) in e.bufs.iter().enumerate() {
+                    let p = b.as_ptr() as *const c_void;
+                    if is_w(i) {
+                        written.push(p);
+                    } else {
+                        read.push(p);
+                    }
+                }
                 enc.set_compute_pipeline_state(&e.pso);
                 for (i, b) in e.bufs.iter().enumerate() {
                     enc.set_buffer(i as u64, Some(b), e.offs[i]);
@@ -915,10 +986,11 @@ impl MetalBackend {
                 p.extend_from_slice(&(dim as u32).to_ne_bytes());
                 p.extend_from_slice(&eps.to_ne_bytes());
                 // One simdgroup (32 lanes) per row — see `rmsnorm_f32`.
-                self.encode_tg(
+                self.encode_tg_w(
                     r,
                     &pso,
                     &[bx.as_ref(), bw.as_ref(), bd.as_ref()],
+                    1 << 2,
                     &p,
                     rows * 32,
                     32,
@@ -1056,6 +1128,7 @@ impl MetalBackend {
                                 (&qw.dd, dd_off),
                                 (bd.as_ref(), 0),
                             ],
+                            1 << 4,
                             &p,
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,
@@ -1069,7 +1142,14 @@ impl MetalBackend {
                         ));
                         let cast = self.pipelines.get("cast_f32_f16")?;
                         let n = (m * in_f) as u32;
-                        self.encode(r, &cast, &[bx.as_ref(), &xh], &n.to_ne_bytes(), m * in_f);
+                        self.encode_w(
+                            r,
+                            &cast,
+                            &[bx.as_ref(), &xh],
+                            1 << 1,
+                            &n.to_ne_bytes(),
+                            m * in_f,
+                        );
                         let pso = self.pipelines.get(hmm_kern)?;
                         self.encode_tg_off(
                             r,
@@ -1081,6 +1161,7 @@ impl MetalBackend {
                                 (&qw.dd, dd_off),
                                 (bd.as_ref(), 0),
                             ],
+                            1 << 4,
                             &p,
                             m.div_ceil(32) * (out_f / 16) * 32,
                             128,
@@ -1128,6 +1209,7 @@ impl MetalBackend {
                                     (bfd.as_ref(), 0),
                                     (bres.as_ref(), 0),
                                 ],
+                                1 << 4,
                                 &p,
                                 sgs * 32,
                                 32,
@@ -1146,6 +1228,7 @@ impl MetalBackend {
                                 (&qw.dd, dd_off),
                                 (bd.as_ref(), 0),
                             ],
+                            1 << 4,
                             &p,
                             sgs * 32,
                             32,
@@ -1163,6 +1246,7 @@ impl MetalBackend {
                             (bw.as_ref(), w_off as u64 * 4),
                             (bd.as_ref(), 0),
                         ],
+                        1 << 2,
                         &p,
                         m * out_f * 32,
                         32,
@@ -1247,7 +1331,7 @@ impl MetalBackend {
                 p.extend_from_slice(&eps.to_ne_bytes());
                 p.extend_from_slice(&(freq_factors.is_some() as u32).to_ne_bytes());
                 // One simdgroup per (row, head) — see `qknormrope_f32`.
-                self.encode_tg(
+                self.encode_tg_w(
                     r,
                     &pso,
                     &[
@@ -1257,6 +1341,7 @@ impl MetalBackend {
                         bff.as_ref(),
                         bd.as_ref(),
                     ],
+                    1 << 4,
                     &p,
                     rows * nh * 32,
                     32,
@@ -1269,10 +1354,11 @@ impl MetalBackend {
                 let bb = self.ensure_device(r, b);
                 let bd = self.dev_dst(r, dst, n);
                 let pso = self.pipelines.get("add_f32")?;
-                self.encode(
+                self.encode_w(
                     r,
                     &pso,
                     &[ba.as_ref(), bb.as_ref(), bd.as_ref()],
+                    1 << 2,
                     &(n as u32).to_ne_bytes(),
                     n,
                 );
@@ -1321,10 +1407,11 @@ impl MetalBackend {
                 p.extend_from_slice(&(nff as u32).to_ne_bytes());
                 p.extend_from_slice(&act_code.to_ne_bytes());
                 p.extend_from_slice(&up_off.to_ne_bytes());
-                self.encode(
+                self.encode_w(
                     r,
                     &pso,
                     &[bg.as_ref(), bu.as_ref(), bd.as_ref()],
+                    1 << 2,
                     &p,
                     rows * nff,
                 );
@@ -1352,7 +1439,7 @@ impl MetalBackend {
                 p.extend_from_slice(&(nff as u32).to_ne_bytes());
                 p.extend_from_slice(&act_code.to_ne_bytes());
                 p.extend_from_slice(&0u32.to_ne_bytes()); // pad to GatedParams
-                self.encode(r, &pso, &[bg.as_ref(), bd.as_ref()], &p, rows * nff);
+                self.encode_w(r, &pso, &[bg.as_ref(), bd.as_ref()], 1 << 1, &p, rows * nff);
                 r.loc[dst.0 as usize] = Loc::Device;
             }
             Op::WriteKv {
@@ -1389,7 +1476,14 @@ impl MetalBackend {
                     let mut p = (n as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(rs as u32).to_ne_bytes());
                     let threads = if q8 { n / 32 } else { n };
-                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw, &posbuf], &p, threads);
+                    self.encode_w(
+                        r,
+                        &pso,
+                        &[bsrc.as_ref(), &cbuf.raw, &posbuf],
+                        1 << 1,
+                        &p,
+                        threads,
+                    );
                 } else {
                     let kern = match g.desc(cache).dtype {
                         DType::Q8_0 => "writekv_q8",
@@ -1400,7 +1494,7 @@ impl MetalBackend {
                     let mut p = (n as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(base as u32).to_ne_bytes());
                     let threads = if q8 { n / 32 } else { n };
-                    self.encode(r, &pso, &[bsrc.as_ref(), &cbuf.raw], &p, threads);
+                    self.encode_w(r, &pso, &[bsrc.as_ref(), &cbuf.raw], 1 << 1, &p, threads);
                 }
             }
             Op::Attention {
@@ -1471,10 +1565,11 @@ impl MetalBackend {
                     p.extend_from_slice(&scale.to_ne_bytes());
                     p.extend_from_slice(&window.to_ne_bytes());
                     p.extend_from_slice(&pos.to_ne_bytes());
-                    self.encode_tg(
+                    self.encode_tg_w(
                         r,
                         &pso,
                         &[bq.as_ref(), &kbuf.raw, &vbuf.raw, bd.as_ref(), &posbuf],
+                        1 << 3,
                         &p,
                         rows * nh * nsg * 32,
                         nsg * 32,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -183,6 +183,29 @@ fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
             | Op::GatedActFused { .. }
             | Op::Add { .. } => {}
             Op::QkNormRope { .. } => has_rope = true,
+            // MoE decode tapes only when the arm takes the fully-on-device path (the same gate
+            // as the MoeFfn arm's `device_ok`): dtypes with expert kernels, in-bounds shapes,
+            // escape hatch off. The host fallback computes on the CPU per token — a tape can't
+            // represent it.
+            Op::MoeFfn {
+                gate_exps,
+                up_exps,
+                down_exps,
+                ne,
+                n_ff_exp,
+                n_used,
+                ..
+            } => {
+                let kq = |t: &TensorId| matches!(g.desc(*t).dtype, DType::Q4K | DType::Q6K);
+                if !(kq(gate_exps) && kq(up_exps) && kq(down_exps))
+                    || *n_used > 16
+                    || *ne % 256 != 0
+                    || *n_ff_exp % 256 != 0
+                    || std::env::var("INFR_METAL_NOMOE").is_ok()
+                {
+                    return false;
+                }
+            }
             Op::WriteKv { cache, .. } => {
                 if !matches!(g.desc(*cache).dtype, DType::F16 | DType::Q8_0) {
                     return false;
@@ -1911,10 +1934,11 @@ impl MetalBackend {
                     let mut p = (rows as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(ne as u32).to_ne_bytes());
                     p.extend_from_slice(&(n_expert as u32).to_ne_bytes());
-                    self.encode_tg(
+                    self.encode_tg_w(
                         r,
                         &pso,
                         &[bx.as_ref(), rw.as_ref(), logits.as_ref()],
+                        1 << 2,
                         &p,
                         rows * n_expert * 32,
                         32,
@@ -1924,7 +1948,15 @@ impl MetalBackend {
                     let mut p = (n_expert as u32).to_ne_bytes().to_vec();
                     p.extend_from_slice(&(n_used as u32).to_ne_bytes());
                     p.extend_from_slice(&scale.to_ne_bytes());
-                    self.encode_tg(r, &pso, &[logits.as_ref(), tbl.as_ref()], &p, rows * 32, 32);
+                    self.encode_tg_w(
+                        r,
+                        &pso,
+                        &[logits.as_ref(), tbl.as_ref()],
+                        1 << 1,
+                        &p,
+                        rows * 32,
+                        32,
+                    );
                     // Expert FFN, batched over (chunk rows x selected experts) — one dispatch per
                     // stage per chunk; chunking bounds the expert scratch (a full 8k-row prefill
                     // would need ~0.5 GB of it).
@@ -2087,7 +2119,7 @@ impl MetalBackend {
                             continue;
                         }
                         let pso = self.pipelines.get(moe_kern(gdt2).unwrap().0)?;
-                        self.encode_tg(
+                        self.encode_tg_w(
                             r,
                             &pso,
                             &[
@@ -2098,12 +2130,13 @@ impl MetalBackend {
                                 gate_t.as_ref(),
                                 tbl.as_ref(),
                             ],
+                            1 << 4,
                             &pack(ne, nffx, row0),
                             cr * n_used * (nffx / 2) * 32,
                             32,
                         );
                         let pso = self.pipelines.get(moe_kern(udt2).unwrap().0)?;
-                        self.encode_tg(
+                        self.encode_tg_w(
                             r,
                             &pso,
                             &[
@@ -2114,6 +2147,7 @@ impl MetalBackend {
                                 up_t.as_ref(),
                                 tbl.as_ref(),
                             ],
+                            1 << 4,
                             &pack(ne, nffx, row0),
                             cr * n_used * (nffx / 2) * 32,
                             32,
@@ -2123,15 +2157,16 @@ impl MetalBackend {
                         p.extend_from_slice(&(nffx as u32).to_ne_bytes());
                         p.extend_from_slice(&act_code.to_ne_bytes());
                         p.extend_from_slice(&0u32.to_ne_bytes()); // up_off
-                        self.encode(
+                        self.encode_w(
                             r,
                             &pso,
                             &[gate_t.as_ref(), up_t.as_ref(), act_t.as_ref()],
+                            1 << 2,
                             &p,
                             cr * n_used * nffx,
                         );
                         let pso = self.pipelines.get(moe_kern(ddt2).unwrap().1)?;
-                        self.encode_tg(
+                        self.encode_tg_w(
                             r,
                             &pso,
                             &[
@@ -2142,6 +2177,7 @@ impl MetalBackend {
                                 ydown.as_ref(),
                                 tbl.as_ref(),
                             ],
+                            1 << 4,
                             &pack(nffx, ne, row0),
                             cr * n_used * (ne / 2) * 32,
                             32,
@@ -2151,7 +2187,7 @@ impl MetalBackend {
                         p.extend_from_slice(&(n_used as u32).to_ne_bytes());
                         p.extend_from_slice(&(cr as u32).to_ne_bytes());
                         p.extend_from_slice(&(row0 as u32).to_ne_bytes());
-                        self.encode(r, &pso, &[ydown.as_ref(), bd.as_ref()], &p, cr * ne);
+                        self.encode_w(r, &pso, &[ydown.as_ref(), bd.as_ref()], 1 << 1, &p, cr * ne);
                     }
                     r.loc[dst.0 as usize] = Loc::Device;
                     return Ok(());

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -461,6 +461,10 @@ impl MetalBackend {
     /// Re-encode a recorded tape: one command buffer, the flat dispatch list, commit + wait.
     /// This IS the per-token decode cost on the replay path — no graph walk, no host mirror,
     /// no allocation.
+    // objc's `sel_impl!` (inside `msg_send!`) emits a `cfg(feature = "cargo-clippy")` check that
+    // trips `unexpected_cfgs` under `-D warnings` — allow it here, scoped to the one fn that
+    // needs the raw selector (metal-rs has no wrapper for memoryBarrierWithScope:).
+    #[allow(unexpected_cfgs)]
     fn replay_tape(&self, tape: &Tape) {
         objc::rc::autoreleasepool(|| {
             let cb = self.queue.new_command_buffer();

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -90,7 +90,10 @@ fn linear_add_peephole(
         if !matches!(g.tensors[dst.0 as usize].kind, TensorKind::Internal) {
             continue;
         }
-        if !matches!(g.desc(*weight).dtype, DType::Q4K | DType::Q6K | DType::Q8_0) {
+        if !matches!(
+            g.desc(*weight).dtype,
+            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q5_0
+        ) {
             continue;
         }
         if let Some(Op::Add {
@@ -858,6 +861,7 @@ impl MetalBackend {
             DType::Q4K => Some("linear_q4k"),
             DType::Q6K => Some("linear_q6k"),
             DType::Q8_0 => Some("linear_q8_0"),
+            DType::Q5_0 => Some("linear_q5_0"),
             _ => None,
         };
         if let Some(kern) = native_kern {
@@ -1064,6 +1068,7 @@ impl MetalBackend {
                         "linear_q4k" => (e / 256 * 144, 0, 0),
                         "linear_q6k" => (e / 256 * 210, 0, 0),
                         "linear_q8_0" => (e / 32 * 34, 0, 0),
+                        "linear_q5_0" => (e / 32 * 22, 0, 0),
                         "linear_quik4" => (e / 2, e / 4, dd_off),
                         "linear_quik6" => (e / 4 * 3, e / 4, dd_off),
                         _ => (e, e / 4, dd_off),
@@ -1088,6 +1093,7 @@ impl MetalBackend {
                         "linear_q4k" => "linear_q4k_hmm",
                         "linear_q6k" => "linear_q6k_hmm",
                         "linear_q8_0" => "linear_q8_0_hmm",
+                        "linear_q5_0" => "linear_q5_0_hmm",
                         _ => "linear_quik8_hmm",
                     };
                     let cmm_kern = match qw.kern {
@@ -1096,6 +1102,7 @@ impl MetalBackend {
                         "linear_q4k" => "linear_q4k_cmm",
                         "linear_q6k" => "linear_q6k_cmm",
                         "linear_q8_0" => "linear_q8_0_cmm",
+                        "linear_q5_0" => "linear_q5_0_cmm",
                         _ => "linear_quik8_cmm",
                     };
                     // Prefer the cooperative 32x64 threadgroup tile; per-simdgroup HGEMM covers
@@ -1174,6 +1181,7 @@ impl MetalBackend {
                                 "linear_q4k" => "linear_q4k_rt",
                                 "linear_q6k" => "linear_q6k_rt",
                                 "linear_q8_0" => "linear_q8_0_rt",
+                                "linear_q5_0" => "linear_q5_0_rt",
                                 _ => "linear_quik8_rt",
                             };
                             (rt, m.div_ceil(8) * out_f)
@@ -1182,7 +1190,7 @@ impl MetalBackend {
                             // (FOUR for Q8_0 — llama.cpp's N_R0_Q8_0).
                             let sgs = match qw.kern {
                                 "linear_q4k" | "linear_q6k" => out_f.div_ceil(2),
-                                "linear_q8_0" => out_f.div_ceil(4),
+                                "linear_q8_0" | "linear_q5_0" => out_f.div_ceil(4),
                                 _ => out_f,
                             };
                             (qw.kern, sgs)
@@ -1193,6 +1201,7 @@ impl MetalBackend {
                             let fk = match kern {
                                 "linear_q4k" => "linear_q4k_add",
                                 "linear_q8_0" => "linear_q8_0_add",
+                                "linear_q5_0" => "linear_q5_0_add",
                                 _ => "linear_q6k_add",
                             };
                             let bres = self.ensure_device(r, res);
@@ -2424,7 +2433,9 @@ impl MetalBackend {
                 r.vals[dst.0 as usize] = out;
                 r.loc[dst.0 as usize] = Loc::Host;
             }
-            // Pure data movement (no arithmetic): done host-side, identical to the CPU reference.
+            // Pure data movement, ON-DEVICE (the rows=1 case of `copy_strided_f32`): the prefill
+            // graph extracts the last row's hidden state for the LM head with a Copy, and a host
+            // copy here forced a readback + a command-buffer break every prefill chunk.
             Op::Copy {
                 src,
                 src_off,
@@ -2432,12 +2443,17 @@ impl MetalBackend {
                 dst_off,
                 n,
             } => {
-                let (so, dof, n) = (src_off as usize, dst_off as usize, n as usize);
-                self.ensure_host(r, g, src);
-                self.ensure_host(r, g, dst);
-                let s = r.vals[src.0 as usize].clone();
-                r.vals[dst.0 as usize][dof..dof + n].copy_from_slice(&s[so..so + n]);
-                r.loc[dst.0 as usize] = Loc::Host;
+                let bs = self.ensure_device(r, src);
+                let bd = self.ensure_device(r, dst);
+                let mut p = src_off.to_ne_bytes().to_vec();
+                p.extend_from_slice(&0u32.to_ne_bytes()); // src_stride (unused at rows=1)
+                p.extend_from_slice(&dst_off.to_ne_bytes());
+                p.extend_from_slice(&0u32.to_ne_bytes()); // dst_stride
+                p.extend_from_slice(&1u32.to_ne_bytes()); // rows
+                p.extend_from_slice(&n.to_ne_bytes());
+                let pso = self.pipelines.get("copy_strided_f32")?;
+                self.encode_w(r, &pso, &[bs.as_ref(), bd.as_ref()], 1 << 1, &p, n as usize);
+                r.loc[dst.0 as usize] = Loc::Device;
             }
             // On-device: the fused-QKV prefill emits one of these per projection right after the
             // wide GEMM — a host copy would round-trip the [m, qkv] activation mid-forward.

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -98,7 +98,7 @@ fn linear_add_peephole(
         }
         if !matches!(
             g.desc(*weight).dtype,
-            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q5_0
+            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q5_0 | DType::Q4_0
         ) {
             continue;
         }
@@ -189,7 +189,7 @@ fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
             | Op::GatedAct { .. }
             | Op::GatedActFused { .. }
             | Op::Add { .. } => {}
-            Op::QkNormRope { .. } => has_rope = true,
+            Op::QkNormRope { .. } | Op::Rope { .. } => has_rope = true,
             // MoE decode tapes only when the arm takes the fully-on-device path (the same gate
             // as the MoeFfn arm's `device_ok`): dtypes with expert kernels, in-bounds shapes,
             // escape hatch off. The host fallback computes on the CPU per token — a tape can't
@@ -831,10 +831,12 @@ impl MetalBackend {
                 .ops
                 .iter()
                 .find_map(|op| match op {
-                    Op::QkNormRope { positions, .. } => Some(*positions),
+                    Op::QkNormRope { positions, .. } | Op::Rope { positions, .. } => {
+                        Some(*positions)
+                    }
                     _ => None,
                 })
-                .expect("replay_shape checked QkNormRope");
+                .expect("replay_shape checked QkNormRope/Rope");
             r.posbuf = Some(metal_buf(bindings.get(positions).unwrap()).raw.clone());
         }
         for (i, decl) in g.tensors.iter().enumerate() {
@@ -987,6 +989,7 @@ impl MetalBackend {
             DType::Q6K => Some("linear_q6k"),
             DType::Q8_0 => Some("linear_q8_0"),
             DType::Q5_0 => Some("linear_q5_0"),
+            DType::Q4_0 => Some("linear_q4_0"),
             _ => None,
         };
         if let Some(kern) = native_kern {
@@ -1231,6 +1234,7 @@ impl MetalBackend {
                         "linear_q6k" => (e / 256 * 210, 0, 0),
                         "linear_q8_0" => (e / 32 * 34, 0, 0),
                         "linear_q5_0" => (e / 32 * 22, 0, 0),
+                        "linear_q4_0" => (e / 32 * 18, 0, 0),
                         "linear_quik4" => (e / 2, e / 4, dd_off),
                         "linear_quik6" => (e / 4 * 3, e / 4, dd_off),
                         _ => (e, e / 4, dd_off),
@@ -1256,6 +1260,7 @@ impl MetalBackend {
                         "linear_q6k" => "linear_q6k_hmm",
                         "linear_q8_0" => "linear_q8_0_hmm",
                         "linear_q5_0" => "linear_q5_0_hmm",
+                        "linear_q4_0" => "linear_q4_0_hmm",
                         _ => "linear_quik8_hmm",
                     };
                     let cmm_kern = match qw.kern {
@@ -1265,6 +1270,7 @@ impl MetalBackend {
                         "linear_q6k" => "linear_q6k_cmm",
                         "linear_q8_0" => "linear_q8_0_cmm",
                         "linear_q5_0" => "linear_q5_0_cmm",
+                        "linear_q4_0" => "linear_q4_0_cmm",
                         _ => "linear_quik8_cmm",
                     };
                     // Prefer the cooperative 32x64 threadgroup tile; per-simdgroup HGEMM covers
@@ -1344,6 +1350,7 @@ impl MetalBackend {
                                 "linear_q6k" => "linear_q6k_rt",
                                 "linear_q8_0" => "linear_q8_0_rt",
                                 "linear_q5_0" => "linear_q5_0_rt",
+                                "linear_q4_0" => "linear_q4_0_rt",
                                 _ => "linear_quik8_rt",
                             };
                             (rt, m.div_ceil(8) * out_f * 32, 32)
@@ -1357,7 +1364,7 @@ impl MetalBackend {
                             // already saturate and keep NSG=1.
                             let rpg = match qw.kern {
                                 "linear_q4k" | "linear_q6k" => 2usize,
-                                "linear_q8_0" | "linear_q5_0" => 4,
+                                "linear_q8_0" | "linear_q5_0" | "linear_q4_0" => 4,
                                 _ => 1,
                             };
                             let groups = out_f.div_ceil(rpg);
@@ -1370,6 +1377,7 @@ impl MetalBackend {
                                 "linear_q6k" if in_f >= 4096 => Some("linear_q6k_ks"),
                                 "linear_q8_0" if in_f >= 2048 => Some("linear_q8_0_ks"),
                                 "linear_q5_0" if in_f >= 2048 => Some("linear_q5_0_ks"),
+                                "linear_q4_0" if in_f >= 2048 => Some("linear_q4_0_ks"),
                                 _ => None,
                             };
                             let ks = groups <= 4096
@@ -1392,10 +1400,12 @@ impl MetalBackend {
                                 "linear_q4k" => "linear_q4k_add",
                                 "linear_q8_0" => "linear_q8_0_add",
                                 "linear_q5_0" => "linear_q5_0_add",
+                                "linear_q4_0" => "linear_q4_0_add",
                                 "linear_q4k_ks" => "linear_q4k_ks_add",
                                 "linear_q6k_ks" => "linear_q6k_ks_add",
                                 "linear_q8_0_ks" => "linear_q8_0_ks_add",
                                 "linear_q5_0_ks" => "linear_q5_0_ks_add",
+                                "linear_q4_0_ks" => "linear_q4_0_ks_add",
                                 _ => "linear_q6k_add",
                             };
                             let bres = self.ensure_device(r, res);
@@ -1483,12 +1493,15 @@ impl MetalBackend {
                 p.extend_from_slice(&(rope_dim).to_ne_bytes());
                 p.extend_from_slice(&theta.to_ne_bytes());
                 p.extend_from_slice(&(freq_factors.is_some() as u32).to_ne_bytes());
-                self.encode(
+                // One thread per (row, head, pair) + pass-through dims — see `rope_f32`.
+                let per = (rope_dim as usize / 2) + (hd - rope_dim as usize);
+                self.encode_w(
                     r,
                     &pso,
                     &[bx.as_ref(), bpos.as_ref(), bff.as_ref(), bd.as_ref()],
+                    1 << 3,
                     &p,
-                    rows * nh,
+                    rows * nh * per,
                 );
                 r.loc[dst.0 as usize] = Loc::Device;
             }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -57,6 +57,13 @@ struct Resident {
     /// tensor, final dst); the absorbed Adds are in `skip`.
     fused: std::collections::HashMap<usize, (TensorId, TensorId)>,
     skip: std::collections::HashSet<usize>,
+    /// GPU-counter sampling state (`INFR_METAL_PROFILE=3`): the timestamp sample buffer, the
+    /// next free sample slot, the (op name, start-sample) log for this batch, and the op the
+    /// walk is currently encoding (sub-dispatches attribute to their parent op).
+    csb: Option<metal::CounterSampleBuffer>,
+    csb_idx: u64,
+    op_samples: Vec<(&'static str, u64)>,
+    cur_op: &'static str,
     /// Host-read override of the graph's baked position (see `run_graph`): the seam's replay
     /// loop re-executes one compiled decode graph (baked pos=0) and only rewrites the bound
     /// positions buffer, so on any decode-shaped graph the position-consuming ops (Attention,
@@ -449,10 +456,41 @@ impl MetalBackend {
             return;
         }
         if r.enc.is_none() {
-            let cb = self.queue.new_command_buffer().to_owned();
-            let enc = cb.new_compute_command_encoder().to_owned();
-            r.cb = Some(cb);
-            r.enc = Some(enc);
+            if r.cb.is_none() {
+                r.cb = Some(self.queue.new_command_buffer().to_owned());
+            }
+            let cb = r.cb.as_ref().unwrap();
+            // Counter profiling: every encoder carries a stage-boundary timestamp pair, so each
+            // op's GPU time is measured IN CONTEXT (the batch still commits once). The walk ends
+            // the encoder between ops; everything an op encodes lands in its encoder(s).
+            r.enc = Some(if let Some(set) = self.counter_set.as_ref() {
+                const CSB_CAP: u64 = 4096;
+                if r.csb.is_none() {
+                    let d = metal::CounterSampleBufferDescriptor::new();
+                    d.set_counter_set(set);
+                    d.set_sample_count(CSB_CAP);
+                    d.set_storage_mode(metal::MTLStorageMode::Shared);
+                    r.csb = self
+                        .device
+                        .new_counter_sample_buffer_with_descriptor(&d)
+                        .ok();
+                }
+                match r.csb.as_ref() {
+                    Some(csb) if r.csb_idx + 2 <= CSB_CAP => {
+                        let desc = metal::ComputePassDescriptor::new();
+                        let att = desc.sample_buffer_attachments().object_at(0).unwrap();
+                        att.set_sample_buffer(csb);
+                        att.set_start_of_encoder_sample_index(r.csb_idx);
+                        att.set_end_of_encoder_sample_index(r.csb_idx + 1);
+                        r.op_samples.push((r.cur_op, r.csb_idx));
+                        r.csb_idx += 2;
+                        cb.compute_command_encoder_with_descriptor(desc).to_owned()
+                    }
+                    _ => cb.new_compute_command_encoder().to_owned(),
+                }
+            } else {
+                cb.new_compute_command_encoder().to_owned()
+            });
         }
         let enc = r.enc.as_ref().unwrap();
         enc.set_compute_pipeline_state(pso);
@@ -562,12 +600,52 @@ impl MetalBackend {
     fn flush(&self, r: &mut Resident) {
         if let Some(enc) = r.enc.take() {
             enc.end_encoding();
-            let cb = r.cb.take().expect("metal: enc without command buffer");
+        }
+        if let Some(cb) = r.cb.take() {
             let t0 = self.profiling.then(std::time::Instant::now);
             cb.commit();
             cb.wait_until_completed();
             if let Some(t0) = t0 {
                 self.prof.lock().unwrap().add_dispatch(t0.elapsed());
+            }
+            // Counter mode: the batch is done — resolve this batch's stage-boundary timestamp
+            // pairs and attribute per op. The samples are GPU-clock ticks, not wall time:
+            // calibrate ticks→ns by bracketing the wait with two CPU/GPU timestamp
+            // correlations (sampleTimestamps) and using their ratio.
+            if r.csb_idx > 0 {
+                if let Some(csb) = r.csb.as_ref() {
+                    let (mut cpu1, mut gpu1) = (0u64, 0u64);
+                    self.device.sample_timestamps(&mut cpu1, &mut gpu1);
+                    let ns_per_tick = {
+                        // one correlation before this resolve and the one cached from init
+                        let (c0, g0) = self.ts_base;
+                        if gpu1 > g0 && cpu1 > c0 {
+                            (cpu1 - c0) as f64 / (gpu1 - g0) as f64
+                        } else {
+                            1.0
+                        }
+                    };
+                    let ts = Self::resolve_counters(csb, r.csb_idx);
+                    if std::env::var("INFR_METAL_PROF_DEBUG").is_ok() {
+                        eprintln!(
+                            "ns_per_tick={ns_per_tick:.4} first samples: {:?}",
+                            &ts[..8.min(ts.len())]
+                        );
+                    }
+                    let mut pr = self.prof.lock().unwrap();
+                    for &(name, i) in &r.op_samples {
+                        if i as usize + 1 >= ts.len() {
+                            break;
+                        }
+                        let (a, b) = (ts[i as usize], ts[i as usize + 1]);
+                        if b > a && a != u64::MAX && b != u64::MAX {
+                            let ns = ((b - a) as f64 * ns_per_tick) as u64;
+                            pr.add_op_gpu(name, std::time::Duration::from_nanos(ns));
+                        }
+                    }
+                }
+                r.csb_idx = 0;
+                r.op_samples.clear();
             }
         }
     }
@@ -645,7 +723,10 @@ impl MetalBackend {
                     .unwrap_or(false)
             })
         };
-        if replay_shape(g, bindings) && dyn_cap_ok() {
+        // Counter profiling is per-op analysis: the tape would replay decode tokens without
+        // walking ops (only the RECORDED token would ever be attributed — every per-token op
+        // reading would silently be a sample of one), so it is disabled under PROFILE=3.
+        if self.counter_set.is_none() && replay_shape(g, bindings) && dyn_cap_ok() {
             let fp = replay_fp(g, bindings);
             if let Some(tape) = self.replay.lock().unwrap().as_ref() {
                 if tape.fp == fp {
@@ -686,6 +767,10 @@ impl MetalBackend {
             posbuf: None,
             fused: std::collections::HashMap::new(),
             skip: std::collections::HashSet::new(),
+            csb: None,
+            csb_idx: 0,
+            op_samples: Vec::new(),
+            cur_op: "",
             dynpos: None,
         };
         // Decode-shaped graph (a rows==1 Attention) with a bound positions buffer: read the
@@ -778,7 +863,15 @@ impl MetalBackend {
                     continue;
                 }
                 let t0 = std::time::Instant::now();
+                r.cur_op = op_name(op);
                 self.run_op(op, idx, g, bindings, &mut r)?;
+                // Counter mode: seal this op's encoder (the command buffer stays open) so the
+                // next op's dispatches land in their own sampled encoder.
+                if self.counter_set.is_some() {
+                    if let Some(e) = r.enc.take() {
+                        e.end_encoding();
+                    }
+                }
                 let enc = t0.elapsed();
                 // Per-op mode: flush now so this op's GPU wall is isolable (breaks batching).
                 let gpu = if self.prof_ops {
@@ -957,6 +1050,30 @@ impl MetalBackend {
             std::ptr::copy_nonoverlapping(buf.raw.contents() as *const u8, v.as_mut_ptr(), v.len());
         }
         v
+    }
+
+    /// Resolve a counter-sample range to raw u64 timestamps. metal-rs 0.33's
+    /// `resolve_counter_range` computes its copy size from an EMPTY vec (0 bytes) and then
+    /// `set_len`s over uninitialized memory — this reads the returned NSData directly.
+    #[allow(unexpected_cfgs)]
+    fn resolve_counters(csb: &metal::CounterSampleBufferRef, len: u64) -> Vec<u64> {
+        use objc::{msg_send, sel, sel_impl};
+        unsafe {
+            let range = metal::NSRange {
+                location: 0,
+                length: len,
+            };
+            let data: *mut objc::runtime::Object = msg_send![csb, resolveCounterRange: range];
+            if data.is_null() {
+                return Vec::new();
+            }
+            let bytes: *const u8 = msg_send![data, bytes];
+            let nbytes: usize = msg_send![data, length];
+            let n = (nbytes / 8).min(len as usize);
+            let mut out = vec![0u64; n];
+            std::ptr::copy_nonoverlapping(bytes, out.as_mut_ptr() as *mut u8, n * 8);
+            out
+        }
     }
 
     /// Read `len` bytes at `off` from a buffer's (unified-memory) contents.

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1206,7 +1206,7 @@ impl MetalBackend {
                             128,
                         );
                     } else {
-                        let (kern, sgs): (&'static str, usize) = if m > 1 {
+                        let (kern, threads, tgw): (&'static str, usize, usize) = if m > 1 {
                             let rt = match qw.kern {
                                 "linear_quik4" => "linear_quik4_rt",
                                 "linear_quik6" => "linear_quik6_rt",
@@ -1216,16 +1216,44 @@ impl MetalBackend {
                                 "linear_q5_0" => "linear_q5_0_rt",
                                 _ => "linear_quik8_rt",
                             };
-                            (rt, m.div_ceil(8) * out_f)
+                            (rt, m.div_ceil(8) * out_f * 32, 32)
                         } else {
                             // The native mul_mv-shape GEMVs cover TWO output rows per simdgroup
-                            // (FOUR for Q8_0 — llama.cpp's N_R0_Q8_0).
-                            let sgs = match qw.kern {
-                                "linear_q4k" | "linear_q6k" => out_f.div_ceil(2),
-                                "linear_q8_0" | "linear_q5_0" => out_f.div_ceil(4),
-                                _ => out_f,
+                            // (FOUR for Q8_0/Q5_0). Small/mid row counts underfill the GPU with
+                            // one simdgroup per row group AND serialize the whole k-dim, so they
+                            // take the k-SPLIT variant: 4 cooperating simdgroups per row group
+                            // (needs the full 128-thread threadgroup — cap-gated with a fall
+                            // back to the single-simdgroup form). Big row counts (the LM head)
+                            // already saturate and keep NSG=1.
+                            let rpg = match qw.kern {
+                                "linear_q4k" | "linear_q6k" => 2usize,
+                                "linear_q8_0" | "linear_q5_0" => 4,
+                                _ => 1,
                             };
-                            (qw.kern, sgs)
+                            let groups = out_f.div_ceil(rpg);
+                            // The k-dim must be deep enough that each of the 4 simdgroups gets
+                            // at least two of the body's blocks-in-flight passes — a shallow k
+                            // (0.6B's in_f=1024 is FOUR Q4_K superblocks) leaves simdgroups
+                            // idle and pays the reduce for nothing (measured -8% there).
+                            let ks_kern = match qw.kern {
+                                "linear_q4k" if in_f >= 8192 => Some("linear_q4k_ks"),
+                                "linear_q6k" if in_f >= 4096 => Some("linear_q6k_ks"),
+                                "linear_q8_0" if in_f >= 2048 => Some("linear_q8_0_ks"),
+                                "linear_q5_0" if in_f >= 2048 => Some("linear_q5_0_ks"),
+                                _ => None,
+                            };
+                            let ks = groups <= 4096
+                                && ks_kern.is_some_and(|kn| {
+                                    self.pipelines
+                                        .get(kn)
+                                        .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                                        .unwrap_or(false)
+                                });
+                            if ks {
+                                (ks_kern.unwrap(), groups * 128, 128)
+                            } else {
+                                (qw.kern, groups * 32, 32)
+                            }
                         };
                         // Residual peephole: this Linear absorbed the following Add — take the
                         // fused-residual variant and write the Add's dst directly.
@@ -1234,6 +1262,10 @@ impl MetalBackend {
                                 "linear_q4k" => "linear_q4k_add",
                                 "linear_q8_0" => "linear_q8_0_add",
                                 "linear_q5_0" => "linear_q5_0_add",
+                                "linear_q4k_ks" => "linear_q4k_ks_add",
+                                "linear_q6k_ks" => "linear_q6k_ks_add",
+                                "linear_q8_0_ks" => "linear_q8_0_ks_add",
+                                "linear_q5_0_ks" => "linear_q5_0_ks_add",
                                 _ => "linear_q6k_add",
                             };
                             let bres = self.ensure_device(r, res);
@@ -1252,8 +1284,8 @@ impl MetalBackend {
                                 ],
                                 1 << 4,
                                 &p,
-                                sgs * 32,
-                                32,
+                                threads,
+                                tgw,
                             );
                             r.loc[fdst.0 as usize] = Loc::Device;
                             return Ok(());
@@ -1271,8 +1303,8 @@ impl MetalBackend {
                             ],
                             1 << 4,
                             &p,
-                            sgs * 32,
-                            32,
+                            threads,
+                            tgw,
                         );
                     }
                 } else {

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1134,19 +1134,32 @@ impl MetalBackend {
                 let bx = self.ensure_device(r, x);
                 let bw = self.weight_buf(weight, g, bindings);
                 let bd = self.dev_dst(r, dst, rows * dim);
-                let pso = self.pipelines.get("rmsnorm_f32")?;
+                // Decode (few rows): the WIDE kernel — 8 simdgroups per row; the 32-lane form
+                // is latency-bound on dim/32 serial loads (~20 us/launch at dim 1152). Prefill
+                // keeps one simdgroup per row (the rows themselves fill the GPU).
+                let wide = rows <= 4
+                    && self
+                        .pipelines
+                        .get("rmsnorm_wide_f32")
+                        .map(|pl| pl.max_total_threads_per_threadgroup() >= 256)
+                        .unwrap_or(false);
+                let pso = self.pipelines.get(if wide {
+                    "rmsnorm_wide_f32"
+                } else {
+                    "rmsnorm_f32"
+                })?;
                 let mut p = (rows as u32).to_ne_bytes().to_vec();
                 p.extend_from_slice(&(dim as u32).to_ne_bytes());
                 p.extend_from_slice(&eps.to_ne_bytes());
-                // One simdgroup (32 lanes) per row — see `rmsnorm_f32`.
+                let tgw = if wide { 256 } else { 32 };
                 self.encode_tg_w(
                     r,
                     &pso,
                     &[bx.as_ref(), bw.as_ref(), bd.as_ref()],
                     1 << 2,
                     &p,
-                    rows * 32,
-                    32,
+                    rows * tgw,
+                    tgw,
                 );
                 r.loc[dst.0 as usize] = Loc::Device;
             }
@@ -1512,7 +1525,19 @@ impl MetalBackend {
                     None => Arc::new(self.zeros_buf(1)),
                 };
                 let bd = self.dev_dst(r, dst, rows * nh * hd);
-                let pso = self.pipelines.get("qknormrope_f32")?;
+                // Decode: the WIDE kernel — see `rmsnorm_wide_f32` (a decode row launches only
+                // n_head simdgroups on the 32-lane form and serializes head_dim/32 loads).
+                let wide = rows <= 4
+                    && self
+                        .pipelines
+                        .get("qknormrope_wide_f32")
+                        .map(|pl| pl.max_total_threads_per_threadgroup() >= 256)
+                        .unwrap_or(false);
+                let pso = self.pipelines.get(if wide {
+                    "qknormrope_wide_f32"
+                } else {
+                    "qknormrope_f32"
+                })?;
                 let mut p = (rows as u32).to_ne_bytes().to_vec();
                 p.extend_from_slice(&(nh as u32).to_ne_bytes());
                 p.extend_from_slice(&(hd as u32).to_ne_bytes());
@@ -1520,7 +1545,8 @@ impl MetalBackend {
                 p.extend_from_slice(&theta.to_ne_bytes());
                 p.extend_from_slice(&eps.to_ne_bytes());
                 p.extend_from_slice(&(freq_factors.is_some() as u32).to_ne_bytes());
-                // One simdgroup per (row, head) — see `qknormrope_f32`.
+                // One simdgroup per (row, head) — 8 on the wide decode form.
+                let tgw = if wide { 256 } else { 32 };
                 self.encode_tg_w(
                     r,
                     &pso,
@@ -1533,8 +1559,8 @@ impl MetalBackend {
                     ],
                     1 << 4,
                     &p,
-                    rows * nh * 32,
-                    32,
+                    rows * nh * tgw,
+                    tgw,
                 );
                 r.loc[dst.0 as usize] = Loc::Device;
             }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -13,7 +13,6 @@ use metal::{
     Buffer as MtlBuffer, CommandBuffer, ComputeCommandEncoder, ComputePipelineState,
     MTLResourceOptions, MTLSize,
 };
-use objc::{msg_send, sel, sel_impl};
 use std::ffi::c_void;
 use std::sync::Arc;
 
@@ -395,6 +394,7 @@ impl MetalBackend {
     /// `encode_tg` with an explicit WRITE mask (bit i = `bufs[i]` is written by the dispatch).
     /// The mask only matters on the decode replay tape, where it drives exact barrier placement
     /// under the concurrent encoder — un-annotated dispatches replay serialized.
+    #[allow(clippy::too_many_arguments)]
     fn encode_tg_w(
         &self,
         r: &mut Resident,
@@ -411,6 +411,7 @@ impl MetalBackend {
 
     /// As `encode_tg_w`, but each buffer binds at a byte offset — the fused-QKV Linear slices
     /// bind the shared concatenated weight at each projection's row offset (`Op::Linear.w_off`).
+    #[allow(clippy::too_many_arguments)]
     fn encode_tg_off(
         &self,
         r: &mut Resident,
@@ -461,10 +462,6 @@ impl MetalBackend {
     /// Re-encode a recorded tape: one command buffer, the flat dispatch list, commit + wait.
     /// This IS the per-token decode cost on the replay path — no graph walk, no host mirror,
     /// no allocation.
-    // objc's `sel_impl!` (inside `msg_send!`) emits a `cfg(feature = "cargo-clippy")` check that
-    // trips `unexpected_cfgs` under `-D warnings` — allow it here, scoped to the one fn that
-    // needs the raw selector (metal-rs has no wrapper for memoryBarrierWithScope:).
-    #[allow(unexpected_cfgs)]
     fn replay_tape(&self, tape: &Tape) {
         objc::rc::autoreleasepool(|| {
             let cb = self.queue.new_command_buffer();
@@ -479,6 +476,9 @@ impl MetalBackend {
                 cb.compute_command_encoder_with_dispatch_type(metal::MTLDispatchType::Concurrent);
             let mut written: Vec<*const c_void> = Vec::with_capacity(8);
             let mut read: Vec<*const c_void> = Vec::with_capacity(24);
+            // Every buffer touched since the last barrier (owned refs into the tape entries) —
+            // the resource list the barrier fences.
+            let mut touched: Vec<&MtlBuffer> = Vec::with_capacity(32);
             for e in &tape.entries {
                 let is_w = |i: usize| e.wmask & (1u32 << i.min(31)) != 0;
                 let hazard = e.bufs.iter().enumerate().any(|(i, b)| {
@@ -486,14 +486,16 @@ impl MetalBackend {
                     written.contains(&p) || (is_w(i) && read.contains(&p))
                 });
                 if hazard {
-                    // All-buffers scope barrier: prior dispatches' buffer accesses complete
-                    // before anything encoded after. (metal-rs has no wrapper for the scope
-                    // variant; MTLBarrierScopeBuffers = 1.)
-                    unsafe {
-                        let () = msg_send![enc, memoryBarrierWithScope: 1u64];
-                    }
+                    // Barrier over every buffer touched since the last one: prior dispatches'
+                    // accesses to those resources complete before anything encoded after.
+                    let refs: Vec<&metal::ResourceRef> = touched
+                        .iter()
+                        .map(|b| b.as_ref() as &metal::ResourceRef)
+                        .collect();
+                    enc.memory_barrier_with_resources(&refs);
                     written.clear();
                     read.clear();
+                    touched.clear();
                 }
                 for (i, b) in e.bufs.iter().enumerate() {
                     let p = b.as_ptr() as *const c_void;
@@ -501,6 +503,9 @@ impl MetalBackend {
                         written.push(p);
                     } else {
                         read.push(p);
+                    }
+                    if !touched.iter().any(|t| t.as_ptr() as *const c_void == p) {
+                        touched.push(b);
                     }
                 }
                 enc.set_compute_pipeline_state(&e.pso);

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -16,7 +16,10 @@
 //! `Op::Linear` weights are kept in the compact factored form (`dequant_factored`: bit-packed
 //! 4/6/8-bit codes + one i16 `(sc, m)` per 16 elems + one f16 `(d, dmin)` per quant block) and
 //! decoded inline by the `linear_quik*` kernels, so the kernels stay format-agnostic and never blow
-//! a quant weight up to f32. `INFR_METAL_PROFILE=1` prints a per-op / GPU-wall breakdown on drop.
+//! a quant weight up to f32. `INFR_METAL_PROFILE=1` prints a per-op / GPU-wall breakdown on drop;
+//! `=2` isolates per-op GPU wall by flushing after each op (distorts totals); `=3` samples
+//! stage-boundary GPU timestamps per op inside ONE command buffer — true in-context per-op GPU
+//! time (the decode tape is disabled so every token's ops are walked and attributed).
 //!
 //! Not bit-for-bit identical to the CPU everywhere: quantized `Op::Linear` reconstructs the exact
 //! `dequant` value but dots in f32, whereas the CPU path quantizes the *activation* to Q8 and uses
@@ -84,6 +87,15 @@ pub struct MetalBackend {
     /// per op — costs the batching, so it's an analysis mode, not the fast path.
     pub(crate) profiling: bool,
     pub(crate) prof_ops: bool,
+    /// GPU-counter profiling (`INFR_METAL_PROFILE=3`): per-op GPU time from stage-boundary
+    /// timestamp samples — one encoder per op inside ONE command buffer, so the numbers are
+    /// in-context (no per-op flush distortion). `None` when the device lacks stage-boundary
+    /// sampling or the timestamp counter set.
+    pub(crate) counter_set: Option<metal::CounterSet>,
+    /// One (cpu_ns, gpu_ticks) correlation taken at init — with a second one at resolve time,
+    /// the ratio converts GPU-clock ticks to nanoseconds (the domains drift only with clock
+    /// rate changes; a long baseline keeps the estimate stable).
+    pub(crate) ts_base: (u64, u64),
     pub(crate) prof: std::sync::Mutex<profile::Profile>,
     /// The recorded decode tape for the seam's record-once replay (`Capabilities::decode_replay`);
     /// single slot, same single-generation lifetime as the weight caches (one backend per
@@ -104,6 +116,32 @@ unsafe impl Sync for MetalBackend {}
 impl MetalBackend {
     pub fn new() -> Result<Self> {
         let device = Device::system_default().ok_or_else(|| be("no Metal device found"))?;
+        let counter_set = (std::env::var("INFR_METAL_PROFILE").as_deref() == Ok("3"))
+            .then(|| {
+                if !device
+                    .supports_counter_sampling(metal::MTLCounterSamplingPoint::AtStageBoundary)
+                {
+                    eprintln!(
+                        "[infr-metal] PROFILE=3: no stage-boundary counter sampling on this \
+                         device — falling back to encode-only profiling"
+                    );
+                    return None;
+                }
+                let set = device
+                    .counter_sets()
+                    .into_iter()
+                    .find(|cs| cs.name() == "timestamp");
+                if set.is_none() {
+                    eprintln!("[infr-metal] PROFILE=3: no timestamp counter set — falling back");
+                }
+                set
+            })
+            .flatten();
+        let ts_base = {
+            let (mut c, mut g) = (0u64, 0u64);
+            device.sample_timestamps(&mut c, &mut g);
+            (c, g)
+        };
         let queue = device.new_command_queue();
         let pipelines = shaders::Pipelines::build(&device)?;
         Ok(Self {
@@ -115,6 +153,8 @@ impl MetalBackend {
             weight_pb: std::sync::Arc::new(std::sync::Mutex::new(None)),
             profiling: std::env::var("INFR_METAL_PROFILE").is_ok(),
             prof_ops: std::env::var("INFR_METAL_PROFILE").as_deref() == Ok("2"),
+            counter_set,
+            ts_base,
             prof: std::sync::Mutex::new(profile::Profile::default()),
             replay: std::sync::Mutex::new(None),
             scratch: std::sync::Mutex::new(std::collections::HashMap::new()),

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -807,27 +807,50 @@ inline void linear_q5_0_body(device const float*  x,
     uint il = (lane & 3u) * 8u;            // this thread's 8 quants within the block
     bool hi = il >= 16u;
     uint jq = hi ? il - 16u : il;          // nibble byte offset within qs
-    uint jh = hi ? il - 4u : il;           // qh shift base: hi bit e sits at (e-16)+12
 
     float yl[8];
     float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
     device const float* yb = x + ix * 32u + il;
 
     for (uint ib = ix; ib < nb; ib += 8u) {
-        for (uint i = 0; i < 8u; i++) yl[i] = yb[i];
+        float sumy = 0.0f;
+        for (uint i = 0; i < 8u; i++) {
+            yl[i] = yb[i];
+            sumy += yb[i];
+        }
         for (uint row = 0; row < 4u; row++) {
             device const uchar* blk =
                 codes + (ulong)(first_row + min(row, nrows - 1u)) * row_b + (ulong)ib * 22ul;
-            uint qh = (uint)blk[2] | ((uint)blk[3] << 8) | ((uint)blk[4] << 16)
-                | ((uint)blk[5] << 24);
-            device const uchar* qs = blk + 6u + jq;
-            float sumq = 0.0f;
-            for (uint i = 0; i < 8u; i++) {
-                uint q = hi ? ((uint)(qs[i] >> 4) | ((qh >> (jh + i)) & 0x10u))
-                            : ((uint)(qs[i] & 0x0Fu) | (((qh >> (jh + i)) << 4) & 0x10u));
-                sumq += ((float)q - 16.0f) * yl[i];
-            }
-            sumf[row] += sumq * (float)as_type<half>((ushort)(blk[0] | ((ushort)blk[1] << 8)));
+            // 22-byte blocks keep every field on an even address: d and qh load as ushorts,
+            // the thread's 8 nibble-source bytes as two 4-byte words — 5 loads per (row, block)
+            // instead of 14 byte loads. Extraction stays in registers, q4k-body style: 4
+            // elements live as the bytes of one uint (nibbles OR'd with the spread qh bits),
+            // the dot runs on byte-masked floats with exact 1/256-power scale folding, and the
+            // -16 offset factors out through sumy — no per-element subtract or shift chain.
+            // (The qh bit for element e is bit e for BOTH nibble halves — the reference's two
+            // expressions land on the same bit.)
+            device const ushort* b16 = (device const ushort*)blk;
+            uint qh = (uint)b16[1] | ((uint)b16[2] << 16);
+            device const ushort* qsp = (device const ushort*)(blk + 6u + jq);
+            uint w0 = (uint)qsp[0] | ((uint)qsp[1] << 16);
+            uint w1 = (uint)qsp[2] | ((uint)qsp[3] << 16);
+            uint n0 = hi ? (w0 >> 4) & 0x0F0F0F0Fu : w0 & 0x0F0F0F0Fu;
+            uint n1 = hi ? (w1 >> 4) & 0x0F0F0F0Fu : w1 & 0x0F0F0F0Fu;
+            uint hb = (qh >> il) & 0xFFu;   // this thread's 8 high bits (element i at bit i)
+            uint q40 = n0 | ((hb & 1u) << 4) | ((hb & 2u) << 11) | ((hb & 4u) << 18)
+                | ((hb & 8u) << 25);
+            uint hb1 = hb >> 4;
+            uint q41 = n1 | ((hb1 & 1u) << 4) | ((hb1 & 2u) << 11) | ((hb1 & 4u) << 18)
+                | ((hb1 & 8u) << 25);
+            float4 acc;
+            acc.x = (float)(q40 & 0x000000FFu) * yl[0] + (float)(q41 & 0x000000FFu) * yl[4];
+            acc.y = (float)(q40 & 0x0000FF00u) * yl[1] + (float)(q41 & 0x0000FF00u) * yl[5];
+            acc.z = (float)(q40 & 0x00FF0000u) * yl[2] + (float)(q41 & 0x00FF0000u) * yl[6];
+            acc.w = (float)(q40 & 0xFF000000u) * yl[3] + (float)(q41 & 0xFF000000u) * yl[7];
+            float d = (float)as_type<half>(b16[0]);
+            sumf[row] += d
+                * (acc.x + acc.y * (1.0f / 256.0f) + acc.z * (1.0f / 65536.0f)
+                    + acc.w * (1.0f / 16777216.0f) - 16.0f * sumy);
         }
         yb += 8u * 32u;
     }

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -328,6 +328,23 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
         wk[4u * i + 3u] = dl3 * (float)(q & 0xFF000000u) + mn;                                    \
     }
 
+// NATIVE Q4_0 block (18 B / 32 elems): [f16 d][16 B nibbles] — 4.5 bpw streamed vs the
+// factored form's ~6.1. Element e < 16 is the low nibble of qs[e], e >= 16 the high nibble of
+// qs[e-16]; value = d * (q - 8), exact per element.
+#define DEC16_Q4_0(wk)                                                                            \
+    device const uchar* blk = codes + (ulong)(bi >> 1) * 18ul;                                    \
+    device const ushort* b16 = (device const ushort*)blk;                                         \
+    float d = (float)as_type<half>(b16[0]);                                                      \
+    device const ushort* q16 = (device const ushort*)(blk + 2u);                                  \
+    uint hi4 = bi & 1u;                                                                           \
+    for (uint k = 0; k < 8u; k++) {                                                               \
+        ushort u = q16[k];                                                                        \
+        uint b0 = hi4 ? ((u >> 4) & 0x0Fu) : (u & 0x0Fu);                                         \
+        uint b1 = hi4 ? ((u >> 12) & 0x0Fu) : ((u >> 8) & 0x0Fu);                                 \
+        wk[2u * k]      = d * ((float)b0 - 8.0f);                                                 \
+        wk[2u * k + 1u] = d * ((float)b1 - 8.0f);                                                 \
+    }
+
 // NATIVE Q8_0 block (34 B / 32 elems): [f16 d][32 x i8]. 8.5 bpw streamed vs the factored
 // form's ~10.2 (codes + scm + dd) — the decode GEMV is bound on exactly this stream. 34 % 4 != 0,
 // so d assembles from bytes and the quants are char loads (same convention as Q6_K's byte loads).
@@ -917,6 +934,112 @@ kernel void linear_q8_0_ks_add(device const float*  x     [[buffer(0)]],
     linear_q8_0_body<1, 4>(x, codes, dst, res, p, 0.0f, false, gid, lane, sgitg, red);
 }
 
+// Decode GEMV for NATIVE Q4_0 (18 B / 32-elem blocks) — `linear_q5_0_body` minus the high-bit
+// stream: 4 rows per simdgroup, 8 blocks in flight, nibbles masked into byte lanes for the
+// masked-FMA dot with exact 1/256-power folding, the -8 offset factored through sumy.
+template<int EPI, uint NSG, typename PT>
+inline void linear_q4_0_body(device const float*  x,
+                             device const uchar*  codes,
+                             device float*        dst,
+                             device const float*  res,
+                             constant PT& p,
+                             float wgt, bool zeroacc,
+                             uint gid, uint lane,
+                             ushort sgitg, threadgroup float* red) {
+    uint first_row = (gid / (32u * NSG)) * 4u;
+    if (first_row >= p.out_f) return;
+    uint nb = p.in_f >> 5;
+    ulong row_b = (ulong)nb * 18ul;
+    uint nrows = min(4u, p.out_f - first_row);
+
+    uint ix = lane >> 2;
+    uint il = (lane & 3u) * 8u;
+    bool hi = il >= 16u;
+    uint jq = hi ? il - 16u : il;
+
+    float yl[8];
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float* yb = x + (sgitg * 8u + ix) * 32u + il;
+
+    for (uint ib = sgitg * 8u + ix; ib < nb; ib += NSG * 8u) {
+        float sumy = 0.0f;
+        for (uint i = 0; i < 8u; i++) {
+            yl[i] = yb[i];
+            sumy += yb[i];
+        }
+        for (uint row = 0; row < 4u; row++) {
+            device const uchar* blk =
+                codes + (ulong)(first_row + min(row, nrows - 1u)) * row_b + (ulong)ib * 18ul;
+            device const ushort* b16 = (device const ushort*)blk;
+            device const ushort* qsp = (device const ushort*)(blk + 2u + jq);
+            uint w0 = (uint)qsp[0] | ((uint)qsp[1] << 16);
+            uint w1 = (uint)qsp[2] | ((uint)qsp[3] << 16);
+            uint q40 = hi ? (w0 >> 4) & 0x0F0F0F0Fu : w0 & 0x0F0F0F0Fu;
+            uint q41 = hi ? (w1 >> 4) & 0x0F0F0F0Fu : w1 & 0x0F0F0F0Fu;
+            float4 acc;
+            acc.x = (float)(q40 & 0x000000FFu) * yl[0] + (float)(q41 & 0x000000FFu) * yl[4];
+            acc.y = (float)(q40 & 0x0000FF00u) * yl[1] + (float)(q41 & 0x0000FF00u) * yl[5];
+            acc.z = (float)(q40 & 0x00FF0000u) * yl[2] + (float)(q41 & 0x00FF0000u) * yl[6];
+            acc.w = (float)(q40 & 0xFF000000u) * yl[3] + (float)(q41 & 0xFF000000u) * yl[7];
+            float d = (float)as_type<half>(b16[0]);
+            sumf[row] += d
+                * (acc.x + acc.y * (1.0f / 256.0f) + acc.z * (1.0f / 65536.0f)
+                    + acc.w * (1.0f / 16777216.0f) - 8.0f * sumy);
+        }
+        yb += NSG * 8u * 32u;
+    }
+    GEMV_EPILOGUE_N(4u, nrows)
+}
+
+kernel void linear_q4_0(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4];
+    linear_q4_0_body<0, 1>(x, codes, dst, x, p, 0.0f, false, gid, lane, 0, red);
+}
+kernel void linear_q4_0_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4];
+    linear_q4_0_body<1, 1>(x, codes, dst, res, p, 0.0f, false, gid, lane, 0, red);
+}
+kernel void linear_q4_0_ks(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint sgitg [[simdgroup_index_in_threadgroup]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 4];
+    linear_q4_0_body<0, 4>(x, codes, dst, x, p, 0.0f, false, gid, lane, sgitg, red);
+}
+kernel void linear_q4_0_ks_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint sgitg [[simdgroup_index_in_threadgroup]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 4];
+    linear_q4_0_body<1, 4>(x, codes, dst, res, p, 0.0f, false, gid, lane, sgitg, red);
+}
+
 // Decode GEMV for NATIVE Q5_0 (22 B / 32-elem blocks), same mul_mv shape as `linear_q8_0_body`:
 // four output rows per simdgroup, 8 blocks in flight x 4 threads per block (8 quants each),
 // activations loaded once and reused across rows. Each thread's 8 elements sit in one nibble
@@ -1298,6 +1421,7 @@ RT_KERNEL(linear_q4k_rt, DEC16_Q4K)
 RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
 RT_KERNEL(linear_q8_0_rt, DEC16_Q8_0)
 RT_KERNEL(linear_q5_0_rt, DEC16_Q5_0)
+RT_KERNEL(linear_q4_0_rt, DEC16_Q4_0)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as
@@ -1416,6 +1540,7 @@ CMM_KERNEL(linear_quik8_cmm, DEC16_K8)
 CMM_KERNEL(linear_q4k_cmm, DEC16_Q4K)
 CMM_KERNEL(linear_q8_0_cmm, DEC16_Q8_0)
 CMM_KERNEL(linear_q5_0_cmm, DEC16_Q5_0)
+CMM_KERNEL(linear_q4_0_cmm, DEC16_Q4_0)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
@@ -1425,6 +1550,7 @@ HGEMM_KERNEL(linear_q4k_hmm, DEC16_Q4K)
 HGEMM_KERNEL(linear_q6k_hmm, DEC16_Q6K)
 HGEMM_KERNEL(linear_q8_0_hmm, DEC16_Q8_0)
 HGEMM_KERNEL(linear_q5_0_hmm, DEC16_Q5_0)
+HGEMM_KERNEL(linear_q4_0_hmm, DEC16_Q4_0)
 
 
 // ---- RoPE (Op::Rope = the no-qk-norm llama-family rotation): INTERLEAVED pairs (2p, 2p+1) —
@@ -1432,27 +1558,36 @@ HGEMM_KERNEL(linear_q5_0_hmm, DEC16_Q5_0)
 // is the NEOX split-half used by qwen/gemma; the styles are NOT interchangeable.) Rotates the
 // first rope_dim of each head; dims beyond pass through. One thread per (row, head).
 struct RopeParams { uint rows; uint n_head; uint head_dim; uint rope_dim; float theta; uint has_ff; };
+// One thread per (row, head, rotation pair) — the previous one-thread-per-head form rotated
+// rope_dim/2 pairs SERIALLY (trig included) and copied the whole head, which left a decode row
+// on a single simdgroup (the counter profiler measured it at 19% of TinyLlama decode). Threads
+// past the pairs copy the pass-through dims. Per-element float expressions are unchanged.
 kernel void rope_f32(device const float* x   [[buffer(0)]],
                      device const float* pos [[buffer(1)]],
                      device const float* ff  [[buffer(2)]],
                      device float*       dst [[buffer(3)]],
                      constant RopeParams& p  [[buffer(4)]],
                      uint gid [[thread_position_in_grid]]) {
-    if (gid >= p.rows * p.n_head) return;
-    uint r = gid / p.n_head;
-    uint base = gid * p.head_dim;
-    for (uint i = 0; i < p.head_dim; i++) dst[base + i] = x[base + i]; // pass-through
     uint hf = p.rope_dim / 2;
-    float p0 = pos[r];
-    for (uint pp = 0; pp < hf; pp++) {
-        uint i0 = 2 * pp, i1 = 2 * pp + 1;
-        float ang = p0 * pow(p.theta, -2.0f * (float)pp / (float)p.rope_dim);
-        if (p.has_ff != 0) ang /= ff[pp];
-        float c = cos(ang), s = sin(ang);
-        float a = x[base + i0], b = x[base + i1];
-        dst[base + i0] = a * c - b * s;
-        dst[base + i1] = a * s + b * c;
+    uint per = hf + (p.head_dim - p.rope_dim);
+    uint rh = gid / per;
+    if (rh >= p.rows * p.n_head) return;
+    uint k = gid % per;
+    uint r = rh / p.n_head;
+    uint base = rh * p.head_dim;
+    if (k >= hf) {
+        uint i = p.rope_dim + (k - hf);
+        dst[base + i] = x[base + i];
+        return;
     }
+    uint i0 = 2 * k, i1 = 2 * k + 1;
+    float p0 = pos[r];
+    float ang = p0 * pow(p.theta, -2.0f * (float)k / (float)p.rope_dim);
+    if (p.has_ff != 0) ang /= ff[k];
+    float c = cos(ang), s = sin(ang);
+    float a = x[base + i0], b = x[base + i1];
+    dst[base + i0] = a * c - b * s;
+    dst[base + i1] = a * s + b * c;
 }
 
 // ---- Fused per-head RMSNorm + RoPE (QkNormRope): rmsnorm (× weight) then rotate the normed head.

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -309,6 +309,29 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
     device const char* qs = (device const char*)(blk + 2u + (bi & 1u) * 16u);                     \
     for (uint k = 0; k < 16u; k++) wk[k] = d * (float)qs[k];
 
+// NATIVE Q5_0 block (22 B / 32 elems): [f16 d][4 B qh][16 B nibbles]. 5.5 bpw streamed vs the
+// factored form's ~8.6 (5-bit codes land in the 6-bit packing + scm + dd) — gemma Q4_K_M ships
+// its q/k/v/gate/up projections as Q5_0, so this is that model family's dominant weight stream.
+// Element e < 16: low nibble of qs[e] plus bit e of qh as bit 4; element e >= 16: high nibble of
+// qs[e-16] plus bit e of qh. Value = d * (q - 16) — every intermediate is exact in f32, so it
+// matches the dequant reference bit-for-bit.
+#define DEC16_Q5_0(wk)                                                                            \
+    device const uchar* blk = codes + (ulong)(bi >> 1) * 22ul;                                    \
+    float d = (float)as_type<half>((ushort)(blk[0] | ((ushort)blk[1] << 8)));                     \
+    uint qh = (uint)blk[2] | ((uint)blk[3] << 8) | ((uint)blk[4] << 16) | ((uint)blk[5] << 24);   \
+    device const uchar* qs = blk + 6u;                                                            \
+    if ((bi & 1u) == 0u) {                                                                        \
+        for (uint k = 0; k < 16u; k++) {                                                          \
+            uint q = (uint)(qs[k] & 0x0Fu) | (((qh >> k) << 4) & 0x10u);                          \
+            wk[k] = d * ((float)q - 16.0f);                                                       \
+        }                                                                                         \
+    } else {                                                                                      \
+        for (uint k = 0; k < 16u; k++) {                                                          \
+            uint q = (uint)(qs[k] >> 4) | ((qh >> (k + 12u)) & 0x10u);                            \
+            wk[k] = d * ((float)q - 16.0f);                                                       \
+        }                                                                                         \
+    }
+
 // GEMV: one simdgroup (32 lanes) per output element; each lane decodes one 16-element block per
 // step, coalesced across lanes, `simd_sum` reduction. m=1 decode is bound on the weight stream.
 #define GEMV_KERNEL(NAME, DEC)                                                                    \
@@ -761,6 +784,86 @@ kernel void linear_q8_0_add(device const float*  x     [[buffer(0)]],
     linear_q8_0_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
 }
 
+// Decode GEMV for NATIVE Q5_0 (22 B / 32-elem blocks), same mul_mv shape as `linear_q8_0_body`:
+// four output rows per simdgroup, 8 blocks in flight x 4 threads per block (8 quants each),
+// activations loaded once and reused across rows. Each thread's 8 elements sit in one nibble
+// half (il in {0,8} low, {16,24} high), so the qh bit extraction is uniform per thread.
+// wk = d * (q - 16), the exact dequantize_q5_0 value, reassociated over the dot only.
+template<int EPI, typename PT>
+inline void linear_q5_0_body(device const float*  x,
+                             device const uchar*  codes,
+                             device float*        dst,
+                             device const float*  res,
+                             constant PT& p,
+                             float wgt, bool zeroacc,
+                             uint gid, uint lane) {
+    uint first_row = (gid / 32u) * 4u;
+    if (first_row >= p.out_f) return;
+    uint nb = p.in_f >> 5;                 // 32-element blocks per row
+    ulong row_b = (ulong)nb * 22ul;        // row stride in bytes
+    uint nrows = min(4u, p.out_f - first_row);
+
+    uint ix = lane >> 2;                   // 0..7: which of 8 blocks in flight
+    uint il = (lane & 3u) * 8u;            // this thread's 8 quants within the block
+    bool hi = il >= 16u;
+    uint jq = hi ? il - 16u : il;          // nibble byte offset within qs
+    uint jh = hi ? il - 4u : il;           // qh shift base: hi bit e sits at (e-16)+12
+
+    float yl[8];
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float* yb = x + ix * 32u + il;
+
+    for (uint ib = ix; ib < nb; ib += 8u) {
+        for (uint i = 0; i < 8u; i++) yl[i] = yb[i];
+        for (uint row = 0; row < 4u; row++) {
+            device const uchar* blk =
+                codes + (ulong)(first_row + min(row, nrows - 1u)) * row_b + (ulong)ib * 22ul;
+            uint qh = (uint)blk[2] | ((uint)blk[3] << 8) | ((uint)blk[4] << 16)
+                | ((uint)blk[5] << 24);
+            device const uchar* qs = blk + 6u + jq;
+            float sumq = 0.0f;
+            for (uint i = 0; i < 8u; i++) {
+                uint q = hi ? ((uint)(qs[i] >> 4) | ((qh >> (jh + i)) & 0x10u))
+                            : ((uint)(qs[i] & 0x0Fu) | (((qh >> (jh + i)) << 4) & 0x10u));
+                sumq += ((float)q - 16.0f) * yl[i];
+            }
+            sumf[row] += sumq * (float)as_type<half>((ushort)(blk[0] | ((ushort)blk[1] << 8)));
+        }
+        yb += 8u * 32u;
+    }
+    for (uint row = 0; row < nrows; row++) {
+        float s = simd_sum(sumf[row]);
+        if (lane == 0u) {
+            uint o = first_row + row;
+            if (EPI == 2)      dst[o] = (zeroacc ? 0.0f : dst[o]) + wgt * s;
+            else if (EPI == 1) dst[o] = s + res[o];
+            else               dst[o] = s;
+        }
+    }
+}
+
+kernel void linear_q5_0(device const float*  x     [[buffer(0)]],
+                        device const uchar*  codes [[buffer(1)]],
+                        device const uchar*  scm   [[buffer(2)]],
+                        device const uchar*  dd    [[buffer(3)]],
+                        device float*        dst   [[buffer(4)]],
+                        constant QLinParams& p     [[buffer(5)]],
+                        uint gid  [[thread_position_in_grid]],
+                        uint lane [[thread_index_in_simdgroup]]) {
+    linear_q5_0_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
+}
+kernel void linear_q5_0_add(device const float*  x     [[buffer(0)]],
+                            device const uchar*  codes [[buffer(1)]],
+                            device const uchar*  scm   [[buffer(2)]],
+                            device const uchar*  dd    [[buffer(3)]],
+                            device float*        dst   [[buffer(4)]],
+                            device const float*  res   [[buffer(5)]],
+                            constant QLinParams& p     [[buffer(6)]],
+                            uint gid  [[thread_position_in_grid]],
+                            uint lane [[thread_index_in_simdgroup]]) {
+    linear_q5_0_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
+}
+
 // ---- MoE expert GEMVs: the shared GEMV bodies, batched over the SELECTED experts — one
 // dispatch covers all n_used experts (slot = high grid bits), each picking its weight slice
 // from the device expert table (`moe_topk` below), so a whole MoE FFN is 7 dispatches with no
@@ -1015,6 +1118,7 @@ RT_KERNEL(linear_quik8_rt, DEC16_K8)
 RT_KERNEL(linear_q4k_rt, DEC16_Q4K)
 RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
 RT_KERNEL(linear_q8_0_rt, DEC16_Q8_0)
+RT_KERNEL(linear_q5_0_rt, DEC16_Q5_0)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as
@@ -1132,6 +1236,7 @@ CMM_KERNEL(linear_quik6_cmm, DEC16_K6)
 CMM_KERNEL(linear_quik8_cmm, DEC16_K8)
 CMM_KERNEL(linear_q4k_cmm, DEC16_Q4K)
 CMM_KERNEL(linear_q8_0_cmm, DEC16_Q8_0)
+CMM_KERNEL(linear_q5_0_cmm, DEC16_Q5_0)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
@@ -1140,6 +1245,7 @@ HGEMM_KERNEL(linear_quik8_hmm, DEC16_K8)
 HGEMM_KERNEL(linear_q4k_hmm, DEC16_Q4K)
 HGEMM_KERNEL(linear_q6k_hmm, DEC16_Q6K)
 HGEMM_KERNEL(linear_q8_0_hmm, DEC16_Q8_0)
+HGEMM_KERNEL(linear_q5_0_hmm, DEC16_Q5_0)
 
 
 // ---- RoPE (Op::Rope = the no-qk-norm llama-family rotation): INTERLEAVED pairs (2p, 2p+1) —

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -503,6 +503,42 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
     }                                                                                             \
 }
 
+// Shared GEMV epilogue: reduce each row's partial across the simdgroup, then — when the k-dim
+// is SPLIT across NSG simdgroups (the ks variants; small/mid GEMVs underfill the GPU with one
+// simdgroup per row group and serialize the whole k-loop) — across the threadgroup via `red`
+// (NSG * R floats), simdgroup 0 folding and writing with the EPI contract. NSG == 1 keeps the
+// original single-simdgroup store; the branch is compile-time.
+// R = rows per group; LIM = live-row bound (R or a clamped nrows).
+#define GEMV_EPILOGUE_N(R, LIM)                                                                   \
+    for (uint row = 0; row < (LIM) && first_row + row < p.out_f; row++)                           \
+        sumf[row] = simd_sum(sumf[row]);                                                          \
+    if (NSG == 1u) {                                                                              \
+        if (lane == 0u) {                                                                         \
+            for (uint row = 0; row < (LIM) && first_row + row < p.out_f; row++) {                 \
+                uint o = first_row + row;                                                         \
+                float s = sumf[row];                                                              \
+                if (EPI == 2)      dst[o] = (zeroacc ? 0.0f : dst[o]) + wgt * s;                  \
+                else if (EPI == 1) dst[o] = s + res[o];                                           \
+                else               dst[o] = s;                                                    \
+            }                                                                                     \
+        }                                                                                         \
+    } else {                                                                                      \
+        if (lane == 0u)                                                                           \
+            for (uint row = 0; row < (R); row++) red[sgitg * (R) + row] = sumf[row];              \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        if (sgitg == 0 && lane == 0u) {                                                           \
+            for (uint row = 0; row < (LIM) && first_row + row < p.out_f; row++) {                 \
+                float s = 0.0f;                                                                   \
+                for (uint g = 0; g < NSG; g++) s += red[g * (R) + row];                           \
+                uint o = first_row + row;                                                         \
+                if (EPI == 2)      dst[o] = (zeroacc ? 0.0f : dst[o]) + wgt * s;                  \
+                else if (EPI == 1) dst[o] = s + res[o];                                           \
+                else               dst[o] = s;                                                    \
+            }                                                                                     \
+        }                                                                                         \
+    }
+#define GEMV_EPILOGUE(R) GEMV_EPILOGUE_N(R, R)
+
 // Decode GEMV for the native K-quant formats, mul_mv shape (ported from llama.cpp's
 // kernel_mul_mv_q4_K_f32 / q6_K and adapted to our buffers): each simdgroup computes TWO output
 // rows; activations load once into registers and are reused across both rows, and the inner loop
@@ -516,15 +552,16 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
 // decode o_proj/down_proj + Add peephole — one dispatch and no sublayer-output round-trip).
 // EPI epilogue modes: 0 = dst = s; 1 = dst = s + res (fused residual Add); 2 = MoE accumulate,
 // dst = (zeroacc ? 0 : dst) + wgt*s (the weighted expert sum, first expert zeroes).
-template<int EPI, typename PT>
+template<int EPI, uint NSG, typename PT>
 inline void linear_q4k_body(device const float*  x,
                             device const uchar*  codes,
                             device float*        dst,
                             device const float*  res,
                             constant PT& p,
                             float wgt, bool zeroacc,
-                            uint gid, uint lane) {
-    uint first_row = (gid / 32u) * 2u;
+                            uint gid, uint lane,
+                            ushort sgitg, threadgroup float* red) {
+    uint first_row = (gid / (32u * NSG)) * 2u;
     if (first_row >= p.out_f) return;
     uint nb = p.in_f >> 8;                 // 256-element blocks per row
     ulong row_b = (ulong)nb * 144ul;       // row stride in bytes
@@ -538,12 +575,12 @@ inline void linear_q4k_body(device const float*  x,
 
     float yl[16], yh[16];
     float sumf[2] = {0.0f, 0.0f};
-    device const float* y4 = x + ix * 256u + 64u * iq + 8u * ir;
+    device const float* y4 = x + (sgitg * 4u + ix) * 256u + 64u * iq + 8u * ir;
 
     ushort sc16[4];
     thread const uchar* sc8 = (thread const uchar*)sc16;
 
-    for (uint ib = ix; ib < nb; ib += 4u) {
+    for (uint ib = sgitg * 4u + ix; ib < nb; ib += NSG * 4u) {
         float4 sumy = float4(0.0f);
         for (uint i = 0; i < 8u; i++) {
             yl[i]      = y4[i];        sumy[0] += yl[i];
@@ -584,16 +621,9 @@ inline void linear_q4k_body(device const float*  x,
             sc += row_b / 2u;
             dh += row_b / 2u;
         }
-        y4 += 4u * 256u;
+        y4 += NSG * 4u * 256u;
     }
-    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
-        float s = simd_sum(sumf[row]);
-        if (lane == 0u) {
-            if (EPI == 2)      dst[first_row + row] = (zeroacc ? 0.0f : dst[first_row + row]) + wgt * s;
-            else if (EPI == 1) dst[first_row + row] = s + res[first_row + row];
-            else               dst[first_row + row] = s;
-        }
-    }
+    GEMV_EPILOGUE(2u)
 }
 
 kernel void linear_q4k(device const float*  x     [[buffer(0)]],
@@ -604,7 +634,8 @@ kernel void linear_q4k(device const float*  x     [[buffer(0)]],
                        constant QLinParams& p     [[buffer(5)]],
                        uint gid  [[thread_position_in_grid]],
                        uint lane [[thread_index_in_simdgroup]]) {
-    linear_q4k_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
+    threadgroup float red[2];
+    linear_q4k_body<0, 1>(x, codes, dst, x, p, 0.0f, false, gid, lane, 0, red);
 }
 kernel void linear_q4k_add(device const float*  x     [[buffer(0)]],
                            device const uchar*  codes [[buffer(1)]],
@@ -615,18 +646,47 @@ kernel void linear_q4k_add(device const float*  x     [[buffer(0)]],
                            constant QLinParams& p     [[buffer(6)]],
                            uint gid  [[thread_position_in_grid]],
                            uint lane [[thread_index_in_simdgroup]]) {
-    linear_q4k_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
+    threadgroup float red[2];
+    linear_q4k_body<1, 1>(x, codes, dst, res, p, 0.0f, false, gid, lane, 0, red);
+}
+// k-split variant: 4 simdgroups share the row group, each covering a strided quarter of the
+// k-dim blocks — 4x the threadgroups on small/mid GEMVs and a quarter of the serial chain.
+kernel void linear_q4k_ks(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint sgitg [[simdgroup_index_in_threadgroup]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 2];
+    linear_q4k_body<0, 4>(x, codes, dst, x, p, 0.0f, false, gid, lane, sgitg, red);
+}
+kernel void linear_q4k_ks_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint sgitg [[simdgroup_index_in_threadgroup]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 2];
+    linear_q4k_body<1, 4>(x, codes, dst, res, p, 0.0f, false, gid, lane, sgitg, red);
 }
 
-template<int EPI, typename PT>
+template<int EPI, uint NSG, typename PT>
 inline void linear_q6k_body(device const float*  x,
                             device const uchar*  codes,
                             device float*        dst,
                             device const float*  res,
                             constant PT& p,
                             float wgt, bool zeroacc,
-                            uint gid, uint lane) {
-    uint first_row = (gid / 32u) * 2u;
+                            uint gid, uint lane,
+                            ushort sgitg, threadgroup float* red) {
+    uint first_row = (gid / (32u * NSG)) * 2u;
     if (first_row >= p.out_f) return;
     uint nb = p.in_f >> 8;
     ulong row_b = (ulong)nb * 210ul;
@@ -646,7 +706,7 @@ inline void linear_q6k_body(device const float*  x,
     float sumf[2] = {0.0f, 0.0f};
     float yl[16];
 
-    for (uint i = ix; i < nb; i += 2u) {
+    for (uint i = sgitg * 2u + ix; i < nb; i += NSG * 2u) {
         device const uchar* blk = xr + (ulong)i * 210ul;
         device const uchar* q1 = blk + ql_off;
         device const uchar* q2 = q1 + 32u;
@@ -678,14 +738,7 @@ inline void linear_q6k_body(device const float*  x,
             dh += row_b / 2u;
         }
     }
-    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
-        float s = simd_sum(sumf[row]);
-        if (lane == 0u) {
-            if (EPI == 2)      dst[first_row + row] = (zeroacc ? 0.0f : dst[first_row + row]) + wgt * s;
-            else if (EPI == 1) dst[first_row + row] = s + res[first_row + row];
-            else               dst[first_row + row] = s;
-        }
-    }
+    GEMV_EPILOGUE(2u)
 }
 
 kernel void linear_q6k(device const float*  x     [[buffer(0)]],
@@ -696,7 +749,8 @@ kernel void linear_q6k(device const float*  x     [[buffer(0)]],
                        constant QLinParams& p     [[buffer(5)]],
                        uint gid  [[thread_position_in_grid]],
                        uint lane [[thread_index_in_simdgroup]]) {
-    linear_q6k_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
+    threadgroup float red[2];
+    linear_q6k_body<0, 1>(x, codes, dst, x, p, 0.0f, false, gid, lane, 0, red);
 }
 kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
                            device const uchar*  codes [[buffer(1)]],
@@ -707,7 +761,35 @@ kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
                            constant QLinParams& p     [[buffer(6)]],
                            uint gid  [[thread_position_in_grid]],
                            uint lane [[thread_index_in_simdgroup]]) {
-    linear_q6k_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
+    threadgroup float red[2];
+    linear_q6k_body<1, 1>(x, codes, dst, res, p, 0.0f, false, gid, lane, 0, red);
+}
+// k-split variant: 4 simdgroups share the row group, each covering a strided quarter of the
+// k-dim blocks — 4x the threadgroups on small/mid GEMVs and a quarter of the serial chain.
+kernel void linear_q6k_ks(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint sgitg [[simdgroup_index_in_threadgroup]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 2];
+    linear_q6k_body<0, 4>(x, codes, dst, x, p, 0.0f, false, gid, lane, sgitg, red);
+}
+kernel void linear_q6k_ks_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint sgitg [[simdgroup_index_in_threadgroup]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 2];
+    linear_q6k_body<1, 4>(x, codes, dst, res, p, 0.0f, false, gid, lane, sgitg, red);
 }
 
 // Decode GEMV for NATIVE Q8_0 (34 B / 32-elem blocks), mul_mv shape (ported from llama.cpp's
@@ -718,15 +800,16 @@ kernel void linear_q6k_add(device const float*  x     [[buffer(0)]],
 // quik8 form paid ~10.2 bpw for the same values, and decode GEMV is bound on exactly this stream.
 // Same EPI epilogue contract as `linear_q4k_body`. Tail rows clamp their pointer into the weight
 // (their sums are discarded at the write).
-template<int EPI, typename PT>
+template<int EPI, uint NSG, typename PT>
 inline void linear_q8_0_body(device const float*  x,
                              device const uchar*  codes,
                              device float*        dst,
                              device const float*  res,
                              constant PT& p,
                              float wgt, bool zeroacc,
-                             uint gid, uint lane) {
-    uint first_row = (gid / 32u) * 4u;
+                             uint gid, uint lane,
+                             ushort sgitg, threadgroup float* red) {
+    uint first_row = (gid / (32u * NSG)) * 4u;
     if (first_row >= p.out_f) return;
     uint nb = p.in_f >> 5;                 // 32-element blocks per row
     ulong row_b = (ulong)nb * 34ul;        // row stride in bytes
@@ -737,9 +820,9 @@ inline void linear_q8_0_body(device const float*  x,
 
     float yl[8];
     float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-    device const float* yb = x + ix * 32u + il;
+    device const float* yb = x + (sgitg * 8u + ix) * 32u + il;
 
-    for (uint ib = ix; ib < nb; ib += 8u) {
+    for (uint ib = sgitg * 8u + ix; ib < nb; ib += NSG * 8u) {
         for (uint i = 0; i < 8u; i++) yl[i] = yb[i];
         for (uint row = 0; row < 4u; row++) {
             device const uchar* blk =
@@ -749,39 +832,60 @@ inline void linear_q8_0_body(device const float*  x,
             for (uint i = 0; i < 8u; i++) sumq += (float)qs[i] * yl[i];
             sumf[row] += sumq * (float)as_type<half>((ushort)(blk[0] | ((ushort)blk[1] << 8)));
         }
-        yb += 8u * 32u;
+        yb += NSG * 8u * 32u;
     }
-    for (uint row = 0; row < nrows; row++) {
-        float s = simd_sum(sumf[row]);
-        if (lane == 0u) {
-            uint o = first_row + row;
-            if (EPI == 2)      dst[o] = (zeroacc ? 0.0f : dst[o]) + wgt * s;
-            else if (EPI == 1) dst[o] = s + res[o];
-            else               dst[o] = s;
-        }
-    }
+    GEMV_EPILOGUE_N(4u, nrows)
 }
 
 kernel void linear_q8_0(device const float*  x     [[buffer(0)]],
-                        device const uchar*  codes [[buffer(1)]],
-                        device const uchar*  scm   [[buffer(2)]],
-                        device const uchar*  dd    [[buffer(3)]],
-                        device float*        dst   [[buffer(4)]],
-                        constant QLinParams& p     [[buffer(5)]],
-                        uint gid  [[thread_position_in_grid]],
-                        uint lane [[thread_index_in_simdgroup]]) {
-    linear_q8_0_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4];
+    linear_q8_0_body<0, 1>(x, codes, dst, x, p, 0.0f, false, gid, lane, 0, red);
 }
 kernel void linear_q8_0_add(device const float*  x     [[buffer(0)]],
-                            device const uchar*  codes [[buffer(1)]],
-                            device const uchar*  scm   [[buffer(2)]],
-                            device const uchar*  dd    [[buffer(3)]],
-                            device float*        dst   [[buffer(4)]],
-                            device const float*  res   [[buffer(5)]],
-                            constant QLinParams& p     [[buffer(6)]],
-                            uint gid  [[thread_position_in_grid]],
-                            uint lane [[thread_index_in_simdgroup]]) {
-    linear_q8_0_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4];
+    linear_q8_0_body<1, 1>(x, codes, dst, res, p, 0.0f, false, gid, lane, 0, red);
+}
+// k-split variant: 4 simdgroups share the row group, each covering a strided quarter of the
+// k-dim blocks — 4x the threadgroups on small/mid GEMVs and a quarter of the serial chain.
+kernel void linear_q8_0_ks(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint sgitg [[simdgroup_index_in_threadgroup]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 4];
+    linear_q8_0_body<0, 4>(x, codes, dst, x, p, 0.0f, false, gid, lane, sgitg, red);
+}
+kernel void linear_q8_0_ks_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint sgitg [[simdgroup_index_in_threadgroup]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 4];
+    linear_q8_0_body<1, 4>(x, codes, dst, res, p, 0.0f, false, gid, lane, sgitg, red);
 }
 
 // Decode GEMV for NATIVE Q5_0 (22 B / 32-elem blocks), same mul_mv shape as `linear_q8_0_body`:
@@ -789,15 +893,16 @@ kernel void linear_q8_0_add(device const float*  x     [[buffer(0)]],
 // activations loaded once and reused across rows. Each thread's 8 elements sit in one nibble
 // half (il in {0,8} low, {16,24} high), so the qh bit extraction is uniform per thread.
 // wk = d * (q - 16), the exact dequantize_q5_0 value, reassociated over the dot only.
-template<int EPI, typename PT>
+template<int EPI, uint NSG, typename PT>
 inline void linear_q5_0_body(device const float*  x,
                              device const uchar*  codes,
                              device float*        dst,
                              device const float*  res,
                              constant PT& p,
                              float wgt, bool zeroacc,
-                             uint gid, uint lane) {
-    uint first_row = (gid / 32u) * 4u;
+                             uint gid, uint lane,
+                             ushort sgitg, threadgroup float* red) {
+    uint first_row = (gid / (32u * NSG)) * 4u;
     if (first_row >= p.out_f) return;
     uint nb = p.in_f >> 5;                 // 32-element blocks per row
     ulong row_b = (ulong)nb * 22ul;        // row stride in bytes
@@ -810,9 +915,9 @@ inline void linear_q5_0_body(device const float*  x,
 
     float yl[8];
     float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-    device const float* yb = x + ix * 32u + il;
+    device const float* yb = x + (sgitg * 8u + ix) * 32u + il;
 
-    for (uint ib = ix; ib < nb; ib += 8u) {
+    for (uint ib = sgitg * 8u + ix; ib < nb; ib += NSG * 8u) {
         float sumy = 0.0f;
         for (uint i = 0; i < 8u; i++) {
             yl[i] = yb[i];
@@ -852,39 +957,60 @@ inline void linear_q5_0_body(device const float*  x,
                 * (acc.x + acc.y * (1.0f / 256.0f) + acc.z * (1.0f / 65536.0f)
                     + acc.w * (1.0f / 16777216.0f) - 16.0f * sumy);
         }
-        yb += 8u * 32u;
+        yb += NSG * 8u * 32u;
     }
-    for (uint row = 0; row < nrows; row++) {
-        float s = simd_sum(sumf[row]);
-        if (lane == 0u) {
-            uint o = first_row + row;
-            if (EPI == 2)      dst[o] = (zeroacc ? 0.0f : dst[o]) + wgt * s;
-            else if (EPI == 1) dst[o] = s + res[o];
-            else               dst[o] = s;
-        }
-    }
+    GEMV_EPILOGUE_N(4u, nrows)
 }
 
 kernel void linear_q5_0(device const float*  x     [[buffer(0)]],
-                        device const uchar*  codes [[buffer(1)]],
-                        device const uchar*  scm   [[buffer(2)]],
-                        device const uchar*  dd    [[buffer(3)]],
-                        device float*        dst   [[buffer(4)]],
-                        constant QLinParams& p     [[buffer(5)]],
-                        uint gid  [[thread_position_in_grid]],
-                        uint lane [[thread_index_in_simdgroup]]) {
-    linear_q5_0_body<0>(x, codes, dst, x, p, 0.0f, false, gid, lane);
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4];
+    linear_q5_0_body<0, 1>(x, codes, dst, x, p, 0.0f, false, gid, lane, 0, red);
 }
 kernel void linear_q5_0_add(device const float*  x     [[buffer(0)]],
-                            device const uchar*  codes [[buffer(1)]],
-                            device const uchar*  scm   [[buffer(2)]],
-                            device const uchar*  dd    [[buffer(3)]],
-                            device float*        dst   [[buffer(4)]],
-                            device const float*  res   [[buffer(5)]],
-                            constant QLinParams& p     [[buffer(6)]],
-                            uint gid  [[thread_position_in_grid]],
-                            uint lane [[thread_index_in_simdgroup]]) {
-    linear_q5_0_body<1>(x, codes, dst, res, p, 0.0f, false, gid, lane);
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4];
+    linear_q5_0_body<1, 1>(x, codes, dst, res, p, 0.0f, false, gid, lane, 0, red);
+}
+// k-split variant: 4 simdgroups share the row group, each covering a strided quarter of the
+// k-dim blocks — 4x the threadgroups on small/mid GEMVs and a quarter of the serial chain.
+kernel void linear_q5_0_ks(device const float*  x     [[buffer(0)]],
+                       device const uchar*  codes [[buffer(1)]],
+                       device const uchar*  scm   [[buffer(2)]],
+                       device const uchar*  dd    [[buffer(3)]],
+                       device float*        dst   [[buffer(4)]],
+                       constant QLinParams& p     [[buffer(5)]],
+                       uint gid  [[thread_position_in_grid]],
+                       uint sgitg [[simdgroup_index_in_threadgroup]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 4];
+    linear_q5_0_body<0, 4>(x, codes, dst, x, p, 0.0f, false, gid, lane, sgitg, red);
+}
+kernel void linear_q5_0_ks_add(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           device const float*  res   [[buffer(5)]],
+                           constant QLinParams& p     [[buffer(6)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint sgitg [[simdgroup_index_in_threadgroup]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[4 * 4];
+    linear_q5_0_body<1, 4>(x, codes, dst, res, p, 0.0f, false, gid, lane, sgitg, red);
 }
 
 // ---- MoE expert GEMVs: the shared GEMV bodies, batched over the SELECTED experts — one
@@ -919,7 +1045,8 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
                                         : x + (ulong)(p.row0 + row) * p.in_f;                     \
     device float* ds = dst + (ulong)(row * p.n_used + slot) * p.out_f;                            \
     uint g2 = (rem % per_out) * 32u + lane;  /* body sees a per-(row, expert) grid */             \
-    BODY<EPI>(xs, ec, ds, xs, p, w, true, g2, lane);                                              \
+    threadgroup float red[2];                                                                     \
+    BODY<EPI, 1>(xs, ec, ds, xs, p, w, true, g2, lane, 0, red);                                   \
 }
 MOE_WRAP(linear_q4k_moe,     linear_q4k_body, 0, 144ul)
 MOE_WRAP(linear_q4k_moe_acc, linear_q4k_body, 2, 144ul)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -105,6 +105,35 @@ kernel void rmsnorm_f32(device const float* x   [[buffer(0)]],
     for (uint i = lane; i < p.dim; i += 32u) dst[base + i] = x[base + i] * s * w[i];
 }
 
+// Wide RMSNorm for DECODE (rows == 1): 8 simdgroups (256 threads) cooperate on the one row.
+// The 32-lane kernel is latency-bound on its dim/32 serial loads — ~20 us per launch at
+// dim=1152 (the counter profiler's first catch: gemma decode fires 105 of these per token,
+// 20% of its GPU time). Partials fold through threadgroup memory; every thread re-sums the 8
+// partials to skip a second barrier.
+kernel void rmsnorm_wide_f32(device const float* x   [[buffer(0)]],
+                             device const float* w   [[buffer(1)]],
+                             device float*       dst [[buffer(2)]],
+                             constant RmsParams& p   [[buffer(3)]],
+                             uint tid  [[thread_position_in_threadgroup]],
+                             uint row  [[threadgroup_position_in_grid]],
+                             uint sg   [[simdgroup_index_in_threadgroup]],
+                             uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[8];
+    if (row >= p.rows) return;
+    uint base = row * p.dim;
+    float ss = 0.0f;
+    for (uint i = tid; i < p.dim; i += 256u) {
+        float v = x[base + i];
+        ss += v * v;
+    }
+    ss = simd_sum(ss);
+    if (lane == 0u) red[sg] = ss;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float tot = red[0] + red[1] + red[2] + red[3] + red[4] + red[5] + red[6] + red[7];
+    float s = 1.0f / sqrt(tot / (float)p.dim + p.eps);
+    for (uint i = tid; i < p.dim; i += 256u) dst[base + i] = x[base + i] * s * w[i];
+}
+
 // per-head RMSNorm: one SIMD group (32 lanes) per (row, head), weight indexed within head_dim.
 struct QkNormParams { uint rows; uint n_head; uint head_dim; float eps; };
 kernel void qknorm_f32(device const float* x   [[buffer(0)]],
@@ -1460,6 +1489,50 @@ kernel void qknormrope_f32(device const float* x   [[buffer(0)]],
         dst[base + i1] = a * sn + b * c;
     }
     for (uint i = p.rope_dim + lane; i < p.head_dim; i += 32u) dst[base + i] = x[base + i] * s * w[i];
+}
+
+// Wide fused QkNorm+RoPE for DECODE (rows == 1): 8 simdgroups (256 threads) per (row, head) —
+// same latency story as `rmsnorm_wide_f32` (the 32-lane form serializes head_dim/32 loads and a
+// decode row only launches n_head simdgroups; gemma has FOUR heads).
+kernel void qknormrope_wide_f32(device const float* x   [[buffer(0)]],
+                                device const float* w   [[buffer(1)]],
+                                device const int*   pos [[buffer(2)]],
+                                device const float* ff  [[buffer(3)]],
+                                device float*       dst [[buffer(4)]],
+                                constant QkRopeParams& p [[buffer(5)]],
+                                uint tid  [[thread_position_in_threadgroup]],
+                                uint grp  [[threadgroup_position_in_grid]],
+                                uint sg   [[simdgroup_index_in_threadgroup]],
+                                uint lane [[thread_index_in_simdgroup]]) {
+    threadgroup float red[8];
+    if (grp >= p.rows * p.n_head) return;
+    uint r = grp / p.n_head;
+    uint base = grp * p.head_dim;
+    float ss = 0.0f;
+    for (uint i = tid; i < p.head_dim; i += 256u) {
+        float v = x[base + i];
+        ss += v * v;
+    }
+    ss = simd_sum(ss);
+    if (lane == 0u) red[sg] = ss;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float tot = red[0] + red[1] + red[2] + red[3] + red[4] + red[5] + red[6] + red[7];
+    float s = 1.0f / sqrt(tot / (float)p.head_dim + p.eps);
+    uint hf = p.rope_dim / 2;
+    float p0 = (float)pos[r];
+    for (uint pp = tid; pp < hf; pp += 256u) {
+        uint i0 = pp, i1 = pp + hf;
+        float ang = p0 * pow(p.theta, -2.0f * (float)pp / (float)p.rope_dim);
+        if (p.has_ff != 0) ang /= ff[pp];
+        float c = cos(ang), sn = sin(ang);
+        float a = x[base + i0] * s * w[i0];
+        float b = x[base + i1] * s * w[i1];
+        dst[base + i0] = a * c - b * sn;
+        dst[base + i1] = a * sn + b * c;
+    }
+    for (uint i = p.rope_dim + tid; i < p.head_dim; i += 256u) {
+        dst[base + i] = x[base + i] * s * w[i];
+    }
 }
 
 // ---- Gated FFN activation: dst[r,i] = act(gate[r,i]) * up[r, i + up_off]. act: 0=SiLU,1=GELU,2=Sigmoid

--- a/crates/infr-metal/tests/dispatch_overhead.rs
+++ b/crates/infr-metal/tests/dispatch_overhead.rs
@@ -58,6 +58,71 @@ fn dispatch_overhead() {
     }
 }
 
+// Serial vs concurrent dispatch types on a DEPENDENT chain: with MTLDispatchTypeSerial every
+// dispatch implicitly orders after the previous one; with Concurrent, ordering exists only at
+// explicit memory barriers, so runs of independent dispatches (decode's q/k/v GEMVs, the two
+// KV writes) can overlap. This measures what barrier GRANULARITY is worth on a decode-shaped
+// dispatch count.
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn dispatch_concurrency() {
+    use metal::MTLDispatchType;
+    let dev = Device::system_default().unwrap();
+    let queue = dev.new_command_queue();
+    let lib = dev
+        .new_library_with_source(MSL, &metal::CompileOptions::new())
+        .unwrap();
+    let f = lib.get_function("tick", None).unwrap();
+    let pso = dev.new_compute_pipeline_state_with_function(&f).unwrap();
+
+    let n = 4096usize; // ~decode-token dispatch count x 10 for signal
+    let bufs: Vec<_> = (0..8)
+        .map(|_| dev.new_buffer(4096, MTLResourceOptions::StorageModeShared))
+        .collect();
+
+    // group = how many round-robin dispatches run between barriers (1 = fully serialized).
+    for (label, group) in [
+        ("serial encoder", 0usize),
+        ("concurrent, barrier each", 1),
+        ("concurrent, barrier per 4", 4),
+        ("concurrent, no barriers", n),
+    ] {
+        for rep in 0..4 {
+            let cb = queue.new_command_buffer();
+            let enc = if group == 0 {
+                cb.new_compute_command_encoder().to_owned()
+            } else {
+                cb.compute_command_encoder_with_dispatch_type(MTLDispatchType::Concurrent)
+                    .to_owned()
+            };
+            enc.set_compute_pipeline_state(&pso);
+            for i in 0..n {
+                enc.set_buffer(0, Some(&bufs[i % 8]), 0);
+                enc.dispatch_threads(MTLSize::new(32, 1, 1), MTLSize::new(32, 1, 1));
+                if group > 0 && group < n && (i + 1) % group == 0 {
+                    let refs: Vec<&metal::ResourceRef> = bufs
+                        .iter()
+                        .map(|b| b.as_ref() as &metal::ResourceRef)
+                        .collect();
+                    enc.memory_barrier_with_resources(&refs);
+                }
+            }
+            enc.end_encoding();
+            let t0 = std::time::Instant::now();
+            cb.commit();
+            cb.wait_until_completed();
+            let dt = t0.elapsed();
+            if rep > 0 {
+                println!(
+                    "{label}: {n} kernels in {:.2} ms -> {:.2} us/kernel",
+                    dt.as_secs_f64() * 1e3,
+                    dt.as_secs_f64() * 1e6 / n as f64
+                );
+            }
+        }
+    }
+}
+
 const MSL_BW: &str = r#"
 #include <metal_stdlib>
 using namespace metal;

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -119,3 +119,110 @@ fn gemv_bandwidth() {
         "quik4-ffn",
     );
 }
+
+fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
+    let mut out = Vec::new();
+    for blk_i in 0..(n_elem / 32) {
+        let mut blk = vec![0u8; 22];
+        blk[0..2].copy_from_slice(&half::f16::from_f32(0.04).to_le_bytes());
+        blk[2..22].copy_from_slice(&lcg_bytes(seed ^ blk_i as u32, 20));
+        out.extend_from_slice(&blk);
+    }
+    out
+}
+
+fn quantize_q8_0(w: &[f32]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for blk in w.chunks(32) {
+        let amax = blk.iter().fold(0f32, |m, &v| m.max(v.abs()));
+        let d = if amax > 0.0 { amax / 127.0 } else { 0.0 };
+        out.extend_from_slice(&half::f16::from_f32(d).to_le_bytes());
+        for &v in blk {
+            let q = if d > 0.0 {
+                (v / d).round().clamp(-127.0, 127.0) as i8
+            } else {
+                0
+            };
+            out.push(q as u8);
+        }
+    }
+    out
+}
+
+// Chained bench: K identical GEMVs over K DISTINCT weight copies in ONE graph (one command
+// buffer) — the per-cb commit+wait overhead amortizes away and the number reflects the
+// in-decode-chain cost. Distinct weights so the stream is not cache-resident.
+fn bench_chained(dtype: DType, wbytes: &[u8], in_f: usize, out_f: usize, bpw: f64, label: &str) {
+    let be = MetalBackend::new().unwrap();
+    let k = 8usize;
+    let xs: Vec<f32> = (0..in_f).map(|i| (i % 7) as f32 * 0.01).collect();
+
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![1, in_f], DType::F32));
+    let ws: Vec<_> = (0..k)
+        .map(|_| g.weight(TensorDesc::new(vec![out_f, in_f], dtype)))
+        .collect();
+    let dst = g.output(TensorDesc::new(vec![1, out_f], DType::F32));
+    for w in &ws {
+        g.push(Op::Linear {
+            x,
+            weight: *w,
+            dst,
+            m: 1,
+            in_f: in_f as u32,
+            out_f: out_f as u32,
+            w_off: 0,
+        });
+    }
+
+    let xb = be.alloc(in_f * 4, BufferUsage::Activations).unwrap();
+    be.upload(xb.as_ref(), bytemuck::cast_slice(&xs)).unwrap();
+    let mut wbs = Vec::new();
+    for _ in 0..k {
+        let wb = be.alloc(wbytes.len(), BufferUsage::Weights).unwrap();
+        be.upload(wb.as_ref(), wbytes).unwrap();
+        wbs.push(wb);
+    }
+    let ob = be.alloc(out_f * 4, BufferUsage::Activations).unwrap();
+
+    let mut binds = Bindings::new();
+    binds.bind(x, xb.as_ref());
+    for (w, wb) in ws.iter().zip(&wbs) {
+        binds.bind(*w, wb.as_ref());
+    }
+    binds.bind(dst, ob.as_ref());
+    let plan = be.compile(&g).unwrap();
+    be.execute(plan.as_ref(), &binds).unwrap();
+    let reps = 20;
+    let t0 = std::time::Instant::now();
+    for _ in 0..reps {
+        be.execute(plan.as_ref(), &binds).unwrap();
+    }
+    let dt = t0.elapsed().as_secs_f64() / (reps * k) as f64;
+    let bytes = (out_f * in_f) as f64 * bpw / 8.0;
+    println!(
+        "{label}: {out_f}x{in_f} chained -> {:.3} ms/gemv, {:.1} GB/s (stream {:.1} MB)",
+        dt * 1e3,
+        bytes / dt / 1e9,
+        bytes / 1e6
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn gemv_bandwidth_gemma_shapes() {
+    // gemma3-1b decode shapes, chained (in-decode-chain cost, cb overhead amortized)
+    let wq5 = synth_q5_0(6912 * 1152, 11);
+    bench_chained(DType::Q5_0, &wq5, 1152, 6912, 5.5, "q5_0 gate/up");
+    let wq6 = synth_q6k(6912 * 1152, 12);
+    bench_chained(DType::Q6K, &wq6, 1152, 6912, 6.5625, "q6k down");
+    let wq4 = synth_q4k(1024 * 1152, 13);
+    bench_chained(DType::Q4K, &wq4, 1024, 1152, 4.5, "q4k o");
+    let wq5q = synth_q5_0(1152 * 1024, 14);
+    bench_chained(DType::Q5_0, &wq5q, 1152, 1024, 5.5, "q5_0 q");
+    let wf: Vec<f32> = (0..(65536usize * 1152))
+        .map(|i| (i % 13) as f32 * 0.01)
+        .collect();
+    let w8 = quantize_q8_0(&wf);
+    bench_chained(DType::Q8_0, &w8, 1152, 65536, 8.5, "q8_0 head/4");
+}

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -720,6 +720,57 @@ fn linear_add_fusion_q5_0_parity() {
     check_linear_add_fusion(DType::Q5_0, synth_q5_0(out_f * in_f, 101), in_f, out_f);
 }
 
+// Native Q4_0: quantizer + GEMV/HGEMM/coop-GEMM/add-fusion (TinyLlama-class checkpoints ship
+// this format; it rode the factored path at ~6.1 bpw vs the native 4.5).
+fn quantize_q4_0(w: &[f32]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for blk in w.chunks(32) {
+        let amax = blk
+            .iter()
+            .fold(0f32, |m, &v| if v.abs() > m.abs() { v } else { m });
+        let d = amax / -8.0;
+        let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+        out.extend_from_slice(&half::f16::from_f32(d).to_le_bytes());
+        for j in 0..16 {
+            let q = |v: f32| ((v * id + 8.5) as u8).min(15);
+            out.push(q(blk[j]) | (q(blk[j + 16]) << 4));
+        }
+    }
+    out
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4_0_gemv_matches_dequant_reference() {
+    let (m, in_f, out_f) = (1usize, 256usize, 94usize);
+    let wf = rand_f32(out_f * in_f, 102);
+    check_quant_linear_parity(DType::Q4_0, quantize_q4_0(&wf), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4_0_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (18usize, 256usize, 96usize);
+    let wf = rand_f32(out_f * in_f, 103);
+    check_quant_linear_parity_impl(DType::Q4_0, quantize_q4_0(&wf), m, in_f, out_f, 1e-3, true);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4_0_coop_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    let wf = rand_f32(out_f * in_f, 104);
+    check_quant_linear_parity_impl(DType::Q4_0, quantize_q4_0(&wf), m, in_f, out_f, 1e-3, true);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_add_fusion_q4_0_parity() {
+    let (in_f, out_f) = (512usize, 384usize);
+    let wf = rand_f32(out_f * in_f, 105);
+    check_linear_add_fusion(DType::Q4_0, quantize_q4_0(&wf), in_f, out_f);
+}
+
 // Native Q8_0 half-fragment GEMM (m=18 → the hmm route; out_f % 64 != 0 keeps cmm out).
 #[test]
 #[ignore = "requires a Metal GPU"]

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -261,6 +261,20 @@ fn quantize_q8_0(w: &[f32]) -> Vec<u8> {
     out
 }
 
+// Well-formed Q5_0 blocks (22 B / 32 elems: [f16 d][4 B qh][16 B nibbles]) — like the k-quant
+// synths, any nibble/bit payload decodes to finite values; only d must be a sane f16.
+fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
+    assert_eq!(n_elem % 32, 0, "Q5_0 blocks are 32 elems");
+    let mut out = Vec::new();
+    for blk_i in 0..(n_elem / 32) {
+        let mut blk = vec![0u8; 22];
+        blk[0..2].copy_from_slice(&half::f16::from_f32(0.04).to_le_bytes());
+        blk[2..22].copy_from_slice(&lcg_bytes(seed ^ blk_i as u32, 20));
+        out.extend_from_slice(&blk);
+    }
+    out
+}
+
 // A deterministic LCG byte stream — arbitrary but reproducible payload for the k-quant nibble
 // fields (which decode to finite values for *any* byte pattern).
 fn lcg_bytes(mut seed: u32, n: usize) -> Vec<u8> {
@@ -658,6 +672,52 @@ fn linear_q8_0_matches_dequant_reference() {
         let err = (r - mm).abs() / r.abs().max(1.0);
         assert!(err <= 1e-3, "elem {i}: ref={r} metal={mm} err={err}");
     }
+}
+
+// Native Q5_0: GEMV (four rows per simdgroup, out_f=94 exercises clamped tail rows), HGEMM,
+// coop-GEMM, and the Linear+Add fusion — the gemma-family dominant weight format.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q5_0_gemv_matches_dequant_reference() {
+    let (m, in_f, out_f) = (1usize, 256usize, 94usize);
+    check_quant_linear_parity(DType::Q5_0, synth_q5_0(out_f * in_f, 98), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q5_0_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (18usize, 256usize, 96usize);
+    check_quant_linear_parity_impl(
+        DType::Q5_0,
+        synth_q5_0(out_f * in_f, 99),
+        m,
+        in_f,
+        out_f,
+        1e-3,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q5_0_coop_gemm_matches_dequant_reference() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    check_quant_linear_parity_impl(
+        DType::Q5_0,
+        synth_q5_0(out_f * in_f, 100),
+        m,
+        in_f,
+        out_f,
+        1e-3,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_add_fusion_q5_0_parity() {
+    let (in_f, out_f) = (512usize, 384usize);
+    check_linear_add_fusion(DType::Q5_0, synth_q5_0(out_f * in_f, 101), in_f, out_f);
 }
 
 // Native Q8_0 half-fragment GEMM (m=18 → the hmm route; out_f % 64 != 0 keeps cmm out).

--- a/docs/METAL.md
+++ b/docs/METAL.md
@@ -1,33 +1,31 @@
 # infr-metal — Apple GPU backend architecture
 
-State as of 2026-07-02 (PRs #4/#5/#6 merged, #10 = the flash_attn_ext arc).
-`crates/infr-metal` implements the same
+State as of 2026-07-03 (PRs #4-#14 merged, #15 = native legacy quants + replay
+concurrency + counter profiler). `crates/infr-metal` implements the same
 `Backend` seam as `infr-cpu` and `infr-vulkan` on Apple's Metal API. It started
 as a correctness-first reference (per-op command buffers, dequant-to-f32
 everything) and was rebuilt profiling-first; this doc records the architecture
 that emerged and the measured reasoning behind it.
 
-## Numbers (M3 Pro 18-core, Qwen3 Q4_K_M, `infr bench` vs `llama-bench`, same GGUF)
+## Numbers (M3 Pro 18-core, `infr compare --sweep --dev MTL0`, same GGUFs)
 
-(One idle-machine run, both engines back-to-back, 2-3 reps each.)
+| model | pp512 | tg128 | tg64@d4096 |
+| --- | --- | --- | --- |
+| Qwen3-0.6B Q4_K_M | 0.89× | 0.98× | 1.00× |
+| Qwen3-4B Q4_K_M | 0.93× | 1.00× | 0.96× |
+| Qwen3-0.6B Q8_0 | 0.84× | 0.97× | 0.99× |
+| Qwen3-MoE-2.4B Q4_K_M | 0.87× | 0.96× | 0.99× |
+| gemma3-1b Q4_K_M | 0.84× | 0.96× | 0.92× |
+| TinyLlama-1.1B Q4_0 | 0.85× | **1.02×** | **1.02×** |
 
-| model | metric | infr-metal | llama.cpp | gap |
-| --- | --- | --- | --- | --- |
-| 0.6B | tg128 | 158 tok/s | 193 | 1.23× |
-| 0.6B | tg128 @ d16384 | 49.7 tok/s | 46.6 | **infr ahead** |
-| 0.6B | pp2048 | 3508 tok/s | 3751 | 1.07× |
-| 0.6B | pp8192 | 2233 tok/s | 2342 | 1.05× |
-| 4B | tg128 | 40.5 tok/s | 46.6 | 1.15× |
-| 4B | tg128 @ d16384 | 21.8 tok/s | 24.4 | 1.12× |
-| 4B | pp2048 | 569 tok/s | 603 | 1.06× |
-| 4B | pp8192 | 455 tok/s | 489 | 1.07× |
-
-Decode is weight-stream bound: the GEMV kernels run ~107 GB/s of a measured
-~133 GB/s read roofline, and the per-token host cost is ~0.2 ms (the recorded
-decode-replay tape re-encodes the whole forward with no graph walk). The
-remaining gap vs llama.cpp is effective-bandwidth tail (dispatch ramp on
-36-66 MB matrices + the serial small-op chain), not kernel structure — the
-mul_mv port matches their N_R0/N_SG configuration exactly.
+(ratios = infr / llama.cpp; >1 = infr ahead.) **Decode is at parity.** The
+prefill band decomposes by ablation (strip the dequant scale math: −2.4% of
+GEMM time; strip ALL weight loads + decode: −9%) to a tile floor of ~6.9
+TFLOPS — ~53% of the f16 `simdgroup_matrix` peak and about llama.cpp's own
+effective rate — so what remains there is MMA/tile scheduling margin, not an
+addressable component. Decode was weight-stream + launch-latency bound; the
+levers that closed it are recorded below in the order the profiler surfaced
+them.
 
 From the naive reference implementation: decode ~44×, prefill ~250×+. Model
 load is ~10× faster than the repack era and resident weight memory is the raw
@@ -59,7 +57,8 @@ single-generation lifetime:
 - **Native GGUF blocks — Q4_K, Q6_K** (the formats real checkpoints ship): the
   bound weight buffer is used AS-IS. No host repack, no extra residency;
   kernels decode raw block bytes in-place (`DEC16_Q4K`/`DEC16_Q6K`, one
-  16-element sub-block per call; `get_scale_min_k4` ported). ~4.5 / ~6.6 bpw
+  16-element sub-block per call; `get_scale_min_k4` ported), and the 32-element legacy formats Q8_0 (34 B),
+  Q5_0 (22 B) and Q4_0 (18 B) — every format real checkpoints ship. ~4.5-8.5 bpw
   on the wire. Two hard-won details: the Q6_K sub-block selector must be
   branch-free (a 4-way `if` serializes the simdgroup — measured 2.3× slower),
   and Q6_K blocks are 210 B (2-aligned) so only byte/ushort loads are legal,
@@ -80,6 +79,7 @@ into `wk[16]`; three kernel shapes instantiate each format:
 | shape | route | precision |
 | --- | --- | --- |
 | `linear_*` GEMV | m == 1 (decode) | exact f32 (bit-for-bit dequant, f32 dot) |
+| `linear_*_ks` k-split GEMV | m == 1, row groups ≤ 4096 AND k deep enough to feed 4 simdgroups twice | exact f32, reassociated |
 | `linear_*_rt` row-tiled | 1 < m < 16, or out_f % 16 ≠ 0 | exact f32 |
 | `linear_*_cmm` cooperative GEMM | m ≥ 16 && out_f % 64 == 0 | f16 operands, f32 accumulate |
 | `linear_*_hmm` per-simdgroup GEMM | m ≥ 16 && out_f % 16 == 0 (fallback) | f16 operands, f32 accumulate |
@@ -122,9 +122,9 @@ O(kv_len) chain:
   f16 cache; softmax by query rows, all 32 lanes on float2 scores, M/S stats
   pinned in the owning simdgroup's registers; P·V by output columns with O
   fragments held in registers). Analytic causal/window masking, zero-padded
-  partial query tiles. Templated over compile-time head_dim (hd=64/128
-  instantiations — the fully-unrolled loops were worth +38% alone); NSG=8
-  benched slower.
+  partial query tiles. Templated over compile-time head_dim (hd 64/128/256
+  instantiations — the fully-unrolled loops were worth +38% alone; hd=256 is
+  gemma, whose absence was a 3× prefill crater); NSG=8 benched slower.
 - **`attnflash_f16kv`** — the single-simdgroup flash kernel, kept for
   hd % 8 == 0 shapes outside the hd 64/128 instantiations: one simdgroup per
   (8-query tile, head), K^T/V 8×8 fragments direct from the f16 cache, scalar
@@ -134,7 +134,9 @@ O(kv_len) chain:
   blocks may read up to 7 rows past the causal limit — always inside the
   bound cache buffer — and are masked.
 - **`attnvec_f16kv` (hd 64/128)** — the llama.cpp `kernel_flash_attn_ext_vec`
-  structure for long-context decode (kv_len ≥ 128): 32 simdgroups per
+  structure for long-context decode (kv_len ≥ 128; hd 64/128 at NSG=32,
+  hd=256 at NSG=16 — its per-simdgroup O partials are NSG·hd·4 B and 32
+  simdgroups would blow the threadgroup budget): NSG simdgroups per
   (query, head), each owning interleaved 32-position KV blocks with a private
   online softmax — 4 KV rows × 8-lane dots per pass, shuffle-tree reduce, ONE
   simd_max/simd_sum per block (the split kernels below run that chain once
@@ -171,15 +173,49 @@ bandwidth for ALU: 0.6B tg128@d16384 62.7 t/s (+26% over the f16 cache, +35%
 over llama.cpp's), 4B ~-6% (already weight-stream-bound); pp8192 runs at ~68%
 of the f16 flash. Enable it for the footprint, and for small models at depth.
 
+## Decode latency: wide small-op kernels + the replay tape
+
+The GPU-counter profiler's first reading found gemma decode spending 20% of
+its GPU time in RmsNorm: 105 launches/token, each a single 32-lane simdgroup
+serializing dim/32 dependent loads (~20 µs) with nothing else resident at
+rows==1. The same disease showed in three more places, each fixed the same
+way:
+
+- `rmsnorm_wide_f32` / `qknormrope_wide_f32`: 8 simdgroups per row (per head
+  for rope), partials folded through threadgroup memory, routed at rows ≤ 4.
+  Fleet decode +8-19%.
+- `rope_f32` ran ONE THREAD per (row, head) — serial pairs, trig included,
+  plus a whole-head copy (19% of TinyLlama decode). Now one thread per
+  rotation pair.
+- The k-split GEMVs above (4 simdgroups per row group) — small/mid GEMVs
+  underfill the GPU and serialize the whole k-dim.
+
+The decode replay tape (`Capabilities::decode_replay`) records one token's
+dispatches and re-encodes them per token with **no graph walk** — and replays
+on a CONCURRENT encoder: each recorded dispatch carries a write mask
+(`TapeEntry.wmask`), and barriers are placed exactly at RAW/WAW/WAR hazards,
+so independent runs (q/k/v GEMVs, the two KV writes) overlap. Un-annotated
+dispatches record writes-everything and replay serialized — never
+under-fenced. MoE decode tapes (the device expert path resolves all data
+dependence on-GPU), and so does the llama arch (`Op::Rope` reads the bound
+positions buffer, replay-safe by construction).
+
 ## Profiling
 
 `INFR_METAL_PROFILE=1`: per-op CPU-encode + GPU commit+wait wall, printed on
 drop. `INFR_METAL_PROFILE=2`: additionally flushes after each op to attribute
-GPU wall per op — costs the batching (analysis mode, not the fast path).
+GPU wall per op — costs the batching AND, because the replay tape re-executes
+decode tokens without walking ops, only ever attributes the RECORDED token.
+`INFR_METAL_PROFILE=3` is the honest mode: `MTLCounterSampleBuffer`
+stage-boundary timestamps, one encoder per op inside ONE command buffer —
+true in-context per-op GPU time, with the tape disabled so every token
+attributes. (Apple silicon samples at stage boundaries only, not dispatch
+boundaries; metal-rs 0.33's `resolve_counter_range` returns uninitialized
+memory, so the resolve reads the NSData directly.)
 
 ## Tests
 
-`tests/parity.rs` — 39 GPU parity tests vs the CPU reference: every op, and
+`tests/parity.rs` — 68 GPU parity tests vs the CPU reference: every op, and
 for quantized Linear every (format × kernel shape) pair including partial
 tiles; attention covers unsplit/split8/split32/flash/flash2/vec, sliding
 windows at both tile and block granularity, partial query tiles, and the
@@ -204,11 +240,28 @@ kept so the floors above stay reproducible.
   private and the first cooperative tile: nothing / worse.
 - Linear threadgroup-width sweep (32→1024), uint4-wide GEMV loads, select-based
   `get_scale_min_k4`: all flat.
+- NSG=2 mid-k GEMV split: wash-to-negative (the reduce tax eats the halved
+  chain at gemma's ne=1152 shapes).
+- Vectorized DEC16 staging loads in the GEMM path: no change (staging is
+  hidden behind the MMAs).
+- B-direct cooperative GEMM (activation fragments straight from a pre-cast
+  f16 buffer, no B staging — the Vulkan A_GLOBAL idea): wash on M3; B staging
+  was already free.
+- Ungated k-split: −8% on 0.6B (in_f=1024 is four Q4_K superblocks; three of
+  four simdgroups idle and the reduce is pure tax) — hence the per-format
+  k-depth gates.
 
-## Remaining levers (est. ≤ 15% each on this model class)
+## Remaining levers
 
-Decode GEMV lane remap (llama.cpp's access pattern; the byte win of native
-blocks was partly eaten by scatter), per-format dequant micro-tuning in the
-GEMM staging, MoE path (`Op::MoeFfn` is still host-side here), decode graph
-replay (CPU encode is 2.5 ms/forward and becomes the wall below ~5 ms GPU),
-attention at small-model scale.
+Decode is at parity; prefill sits at the measured tile floor. What's left
+needs a new evidence class or new hardware:
+
+- Prefill GEMM: ~53% of f16 simdgroup_matrix peak, same class as llama.cpp —
+  Xcode's per-line shader profiler (not installed on the dev box) is the next
+  instrument if the last ~10-15% ever matters.
+- Metal-4 tensor ops: the hardware step change; `has tensor = false` on M3,
+  likely M5-only.
+- gemma decode at depth (0.92×): +0.58 ms/token of hd=256 vec attention on
+  the global layers — 4% of one cell, measured and parked.
+- The routing gates (k-split thresholds, wide-norm rows ≤ 4) were tuned on an
+  M3 Pro; a boot-time micro-sweep would adapt them across M1-M4.

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -63,12 +63,29 @@ Rules that exist because we got burned:
   bit-for-bit alone (verify tg128 before/after); a decode change must leave pp
   alone.
 
+## Archiving sweeps
+
+`scripts/perf-sweep.sh <models...>` (with `INFR_METAL=1` on macOS) runs the
+sweep and archives the matrix under `target/perf/<utc>-<sha>.txt` — keep the
+model list fixed so every commit's ratios are a diff away, and paste the
+matrix into the PR when a slice lands.
+
 ## Profiling
 
 ```bash
 INFR_PROF2=1 infr bench "$M" -p 512 -n 0 -r 1   # per-op GPU timestamps
 INFR_PROF_PF=1 ...                              # per-chunk prefill wall time
 ```
+
+Metal uses `INFR_METAL_PROFILE` instead: `=1` encode/GPU wall split, `=3`
+per-op GPU time from stage-boundary counter samples — **the only honest per-op
+mode**: the decode replay tape re-executes tokens without walking ops, so the
+flush mode (`=2`) silently attributes a sample of one token. `=3` disables the
+tape for the run. Sweep with `--dev MTL0` (llama-bench rejects `Vulkan0` on a
+Metal box). Micro-probes live in `crates/infr-metal/tests/`
+(`gemv_bw`, `dispatch_overhead`) — chained-dispatch numbers there are
+thermally unstable across back-to-back runs; trust e2e benches for accept /
+revert calls.
 
 - `INFR_PROF2` prints one block per submit. **Trust the percentages and per-op
   relative times; the absolute µs totals can overflow.** The op label breakdown

--- a/scripts/perf-sweep.sh
+++ b/scripts/perf-sweep.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Perf snapshot: run the model x quant sweep vs llama.cpp and archive the matrix
+# under target/perf/<utc>-<sha>.txt, so every commit's ratios are a diff away.
+#
+#   INFR_METAL=1 scripts/perf-sweep.sh model1.gguf model2.gguf ...
+#   scripts/perf-sweep.sh model1.gguf ...          # Vulkan (default backend)
+#
+# Pass the SAME model list every time — the archive is only comparable when the
+# rows line up. r=3, idle machine, nothing else on the GPU (see docs/PERF.md).
+set -euo pipefail
+[ $# -ge 1 ] || { echo "usage: [INFR_METAL=1] $0 <model.gguf>..." >&2; exit 1; }
+
+cargo build --release -p infr-cli
+
+dev="Vulkan0"
+if [ "${INFR_METAL:-}" = "1" ] && [ "$(uname)" = "Darwin" ]; then dev="MTL0"; fi
+
+sha=$(git rev-parse --short HEAD)
+dirty=$(git diff --quiet && echo "" || echo "-dirty")
+out="target/perf/$(date -u +%Y%m%dT%H%M%SZ)-${sha}${dirty}.txt"
+mkdir -p target/perf
+
+{
+  echo "commit: ${sha}${dirty}  date: $(date -u +%FT%TZ)  dev: ${dev}"
+  echo "models: $*"
+  echo
+  ./target/release/infr compare --sweep --dev "$dev" "$@" 2>/dev/null
+} | tee "$out"
+
+echo
+echo "archived: $out"
+ls target/perf | tail -5


### PR DESCRIPTION
Two levers from the post-#14 board, plus one commit that missed the #14 merge window.

## Native Q5_0 kernels — gemma prefill +18%

gemma Q4_K_M ships its q/k/v/gate/up projections as **Q5_0** (117 of its tensors — ne=1152 isn't a multiple of 256, so K-quant superblocks can't cover those axes), and Q5_0 rode the factored path at ~8.6 bpw streamed vs the raw block's 5.5. Same treatment as #14's Q8_0: `DEC16_Q5_0` into the shared RT/CMM/HGEMM shapes, a mul_mv-shape GEMV (4 rows/simdgroup, 8 blocks in flight, nibble-half-uniform qh extraction per thread), fused-residual peephole variant, w_off slice binds.

gemma3-1b vs llama.cpp Metal, same GGUF: **pp512 2209 → 2606 (0.71× → 0.84×)**, tg64@d4096 74.8 → 82.2 (+10%), tg128 +2% (decode at this size is latency-bound, not stream-bound). Qwen models unchanged.

## Concurrent decode replay (cherry-picked — pushed to #14 right after the merge)

Short-context decode sat at 0.78–0.87× across every model while depth decode was 0.86–0.91× — per-token serial cost, not bandwidth. A probe (`dispatch_overhead.rs::dispatch_concurrency`) measured the serial encoder at ~1.3 µs/dispatch vs ~0.5 µs concurrent with grouped barriers. The replay tape now encodes `MTLDispatchTypeConcurrent` with exact RAW/WAW/WAR barriers derived from per-dispatch write masks recorded at tape time (`TapeEntry.wmask`); un-annotated dispatches record writes-everything and replay serialized — never under-fenced. Normal graph walk unchanged. tg128 +2–4% across models (0.6B 158 → 164); token streams identical replay on/off.

## On-device Op::Copy

The prefill graph extracts the last row's hidden state for the LM head via `Op::Copy`, which was host-side on Metal — a GPU readback + command-buffer break every prefill chunk. Now the rows=1 case of `copy_strided_f32`.

## Validation

64 GPU parity tests (4 new Q5_0: GEMV tail rows, HGEMM, coop-GEMM, add-fusion), long-prompt gemma SWA-correct vs the CPU oracle, replay on/off identical, fmt/clippy(-D warnings)/test matrix green locally including the Linux angle.