### PR TITLE
feat(engine): speculative decoding on the Metal seam — draft-verify, token-identical

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -894,6 +894,9 @@ fn cmd_bench_qwen35(
     std::env::set_var("INFR_Q35_IGNORE_EOS", "1"); // fixed tg count, no early stop
     let mut m: Box<dyn ChatModel> = if cpu {
         Box::new(infr_llama::model::Qwen35Chat::new_cpu(gguf.to_path_buf()))
+    } else if std::env::var("INFR_METAL").is_ok() {
+        // Metal seam (there is no Vulkan loader on macOS — `new()` would dlopen-fail).
+        Box::new(infr_llama::model::Qwen35Chat::new_metal(gguf.to_path_buf()))
     } else {
         Box::new(infr_llama::model::Qwen35Chat::new(gguf.to_path_buf()))
     };

--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -438,12 +438,13 @@ fn cmd_run(model: &str, message: Option<&str>) -> anyhow::Result<()> {
                     let target = infr_llama::CpuModel::load(&gguf, tok.as_deref())?;
                     let draft =
                         infr_llama::CpuModel::load(std::path::Path::new(&draft_path), None)?;
-                    // Verify cost is nearly flat in k (one batched forward), so a larger k
-                    // amortizes it; 8 balances the draft cost against acceptance decay.
+                    // Upper bound on the draft length; the driver adapts the actual k per
+                    // round to recent acceptance (verify cost scales with rows on this
+                    // hardware, so over-drafting low-acceptance text costs real time).
                     let k = std::env::var("INFR_SPEC_K")
                         .ok()
                         .and_then(|v| v.parse().ok())
-                        .unwrap_or(8);
+                        .unwrap_or(6);
                     let (tb, db) = (
                         std::fs::metadata(&gguf).map(|m| m.len()).unwrap_or(0),
                         std::fs::metadata(&draft_path).map(|m| m.len()).unwrap_or(0),

--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -431,9 +431,39 @@ fn cmd_run(model: &str, message: Option<&str>) -> anyhow::Result<()> {
             );
             #[cfg(target_os = "macos")]
             {
-                Box::new(infr_llama::model::MetalSeamChat::new(
-                    infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
-                ))
+                // INFR_SPEC_DRAFT=<gguf>: speculative decoding — a small same-tokenizer draft
+                // proposes k tokens (INFR_SPEC_K, default 4), one batched target forward
+                // verifies. Greedy-only; pays off for ~8B-class targets (issue #16).
+                if let Ok(draft_path) = std::env::var("INFR_SPEC_DRAFT") {
+                    let target = infr_llama::CpuModel::load(&gguf, tok.as_deref())?;
+                    let draft =
+                        infr_llama::CpuModel::load(std::path::Path::new(&draft_path), None)?;
+                    // Verify cost is nearly flat in k (one batched forward), so a larger k
+                    // amortizes it; 8 balances the draft cost against acceptance decay.
+                    let k = std::env::var("INFR_SPEC_K")
+                        .ok()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(8);
+                    let (tb, db) = (
+                        std::fs::metadata(&gguf).map(|m| m.len()).unwrap_or(0),
+                        std::fs::metadata(&draft_path).map(|m| m.len()).unwrap_or(0),
+                    );
+                    if db * 4 > tb {
+                        eprintln!(
+                            "[spec] warning: draft is more than 1/4 the target's size — \
+                             speculation only pays when the target is much larger (see #16)"
+                        );
+                    }
+                    std::env::set_var("INFR_TEMP", "0");
+                    eprintln!(
+                        "[metal spec — target + {k}-token draft verify, greedy (INFR_TEMP=0)]"
+                    );
+                    Box::new(infr_llama::model::SpecMetalChat::new(target, draft, k))
+                } else {
+                    Box::new(infr_llama::model::MetalSeamChat::new(
+                        infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
+                    ))
+                }
             }
             #[cfg(not(target_os = "macos"))]
             {

--- a/crates/infr-llama/src/cpu_backend.rs
+++ b/crates/infr-llama/src/cpu_backend.rs
@@ -115,6 +115,7 @@ pub(crate) fn generate_dense_cpu(
         &mut None,
         prompt.len() + max_new + 1,
         None,
+        None,
     )
 }
 
@@ -253,6 +254,7 @@ pub(crate) fn generate_dense_gpu_session(
         state,
         want_ctx,
         constraint,
+        None,
     )
 }
 
@@ -323,7 +325,50 @@ pub(crate) fn generate_dense_metal_session(
         state,
         want_ctx,
         constraint,
+        None,
     )
+}
+
+/// Speculative VERIFY on the Metal seam: one batched forward of `tokens`' un-cached suffix with
+/// the LM head on every suffix row. Returns the [m, vocab] logits plus the graph-execute
+/// seconds, and leaves the session's KV + `cached` covering all of `tokens` — the caller
+/// commits the accepted prefix and the next call's prefix diff overwrites whatever was
+/// speculatively written past it.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn verify_dense_metal2(
+    mtl: &infr_metal::MetalBackend,
+    g: &Gguf,
+    cfg: &Config,
+    token_embd: &[f32],
+    ple: Option<&PerLayerEmbd>,
+    tokens: &[u32],
+    state: &mut Option<SeamKv>,
+    want_ctx: usize,
+) -> AResult<(Vec<f32>, f64)> {
+    let mut logits = Vec::new();
+    let (_, stats) = generate_dense_backend(
+        mtl,
+        &|_name, tb, dt, _n| {
+            let buf = mtl
+                .alloc(tb.len().max(1), BufferUsage::Weights)
+                .map_err(|e| anyhow!("{e}"))?;
+            mtl.upload(buf.as_ref(), &tb).map_err(|e| anyhow!("{e}"))?;
+            Ok((buf, dt))
+        },
+        g,
+        cfg,
+        token_embd,
+        ple,
+        tokens,
+        0,
+        |_| {},
+        state,
+        want_ctx,
+        None,
+        Some(&mut logits),
+    )?;
+    Ok((logits, stats.prompt_secs))
 }
 
 /// Backend-generic dense decode runner. Builds the agnostic decode [`Graph`] per token and runs it
@@ -590,6 +635,7 @@ pub(crate) fn generate_dense_backend(
     state: &mut Option<SeamKv>,
     want_ctx: usize,
     mut constraint: Option<&mut crate::grammar::Constraint>,
+    verify: Option<&mut Vec<f32>>,
 ) -> AResult<(Vec<u32>, GenStats)> {
     let c = cfg;
     let (ne, nh) = (c.n_embd, c.n_head);
@@ -976,9 +1022,10 @@ pub(crate) fn generate_dense_backend(
 
     // Build a forward graph for `batch` tokens starting at absolute position `start_pos`.
     // `batch = 1` is the normal decode path; `batch > 1` is the batched-prefill path.
-    // Scratch tensors scale by `batch`; the LM head always runs on the LAST token only
-    // (extracted via Op::Copy for batch > 1) so the logits output is always [vocab].
-    let build = |batch: usize, start_pos: usize| -> (Graph, DecodeHandles) {
+    // Scratch tensors scale by `batch`; the LM head runs on the last `logits_rows` tokens —
+    // 1 everywhere except speculative VERIFY, which needs the distribution after every
+    // candidate (logits output = [logits_rows, vocab], logits_rows ∈ {1, batch}).
+    let build = |batch: usize, start_pos: usize, logits_rows: usize| -> (Graph, DecodeHandles) {
         let mut g = Graph::new();
         let f32d = |n: usize| TensorDesc::new(vec![n], DType::F32);
         // KV cache dtype: f16 by default (halves memory vs f32, tightens CPU↔GPU parity); Q8_0
@@ -1121,7 +1168,7 @@ pub(crate) fn generate_dense_backend(
         } else {
             None
         };
-        let logits = g.output(f32d(c.vocab));
+        let logits = g.output(f32d(c.vocab * logits_rows));
 
         // scratch (sized to the per-layer max × batch; ops reallocate dst, so these are upper bounds)
         let hn = g.internal(f32d(batch * ne));
@@ -1673,10 +1720,11 @@ pub(crate) fn generate_dense_backend(
             dim: ne as u32,
             eps,
         });
-        // For batch > 1: the LM head runs only on the LAST token's hidden state — extract it
-        // via Op::Copy before the projection so the logits output is always [vocab] regardless
-        // of batch size. (For batch = 1, `hn` is already the single token's hidden state.)
-        let lm_in = if batch > 1 {
+        // For batch > 1 with logits_rows == 1: the LM head runs only on the LAST token's
+        // hidden state — extract it via Op::Copy before the projection so the logits output is
+        // [vocab]. Speculative verify passes logits_rows == batch and runs the head over every
+        // row instead (no Copy).
+        let lm_in = if batch > 1 && logits_rows == 1 {
             let hn_last = g.internal(f32d(ne));
             g.push(Op::Copy {
                 src: hn,
@@ -1693,7 +1741,7 @@ pub(crate) fn generate_dense_backend(
             x: lm_in,
             weight: w_lm,
             dst: logits,
-            m: 1,
+            m: logits_rows as u32,
             in_f: ne as u32,
             out_f: c.vocab as u32,
             w_off: 0,
@@ -1703,7 +1751,7 @@ pub(crate) fn generate_dense_backend(
                 x: logits,
                 dst: logits,
                 cap: c.final_softcap,
-                n: c.vocab as u32,
+                n: (c.vocab * logits_rows) as u32,
             });
         }
         (
@@ -1720,6 +1768,71 @@ pub(crate) fn generate_dense_backend(
             },
         )
     };
+
+    // ── speculative VERIFY ──────────────────────────────────────────────────────────
+    // One batched forward over the un-cached suffix with the LM head on EVERY row: returns
+    // [m, vocab] logits (the distribution after each suffix token) and generates nothing.
+    // The suffix-prefill contract doubles as the accept/rollback mechanism: the caller
+    // truncates its committed token list and the next call's prefix diff overwrites the
+    // stale KV rows. Dense non-E2B models only (mirrors the batched-prefill guard).
+    if let Some(out_logits) = verify {
+        if c.moe.is_some() || ple.is_some() {
+            return Err(anyhow!("speculative verify: dense non-E2B models only"));
+        }
+        let vf_scale = if gemma { (ne as f32).sqrt() } else { 1.0 };
+        let m = prompt.len() - start;
+        let mut vf_hidden: Vec<f32> = Vec::with_capacity(m * ne);
+        for &tok in &prompt[start..] {
+            let base = tok as usize * ne;
+            vf_hidden.extend(token_embd[base..base + ne].iter().map(|&x| x * vf_scale));
+        }
+        let vf_positions: Vec<i32> = (start as i32..(start + m) as i32).collect();
+        let vf_hidden_buf = be
+            .alloc(m * ne * 4, BufferUsage::Staging)
+            .map_err(|e| anyhow!("{e}"))?;
+        let vf_pos_buf = be
+            .alloc(m * 4, BufferUsage::Staging)
+            .map_err(|e| anyhow!("{e}"))?;
+        let vf_logits_buf = be
+            .alloc(m * c.vocab * 4, BufferUsage::Staging)
+            .map_err(|e| anyhow!("{e}"))?;
+        be.upload(vf_hidden_buf.as_ref(), bytemuck::cast_slice(&vf_hidden))
+            .map_err(|e| anyhow!("{e}"))?;
+        be.upload(vf_pos_buf.as_ref(), bytemuck::cast_slice(&vf_positions))
+            .map_err(|e| anyhow!("{e}"))?;
+        let (vg, vh) = build(m, start, m);
+        let vplan = be.compile(&vg).map_err(|e| anyhow!("{e}"))?;
+        let mut vb = Bindings::new();
+        vb.bind(vh.hidden, vf_hidden_buf.as_ref());
+        vb.bind(vh.positions, vf_pos_buf.as_ref());
+        if let (Some(rid), Some((rb, _))) = (vh.rope_freqs, &rf_buf) {
+            vb.bind(rid, rb.as_ref());
+        }
+        for l in 0..c.n_layer {
+            vb.bind(vh.k_cache[l], kbufs[l].as_ref());
+            vb.bind(vh.v_cache[l], vbufs[l].as_ref());
+        }
+        for (i, wid) in vh.weights.iter().enumerate() {
+            vb.bind(*wid, wbufs[i].as_ref());
+        }
+        vb.bind(vh.logits, vf_logits_buf.as_ref());
+        let t0 = std::time::Instant::now();
+        be.execute(vplan.as_ref(), &vb)
+            .map_err(|e| anyhow!("{e}"))?;
+        out_logits.resize(m * c.vocab, 0.0);
+        be.download(vf_logits_buf.as_ref(), bytemuck::cast_slice_mut(out_logits))
+            .map_err(|e| anyhow!("{e}"))?;
+        cached.extend_from_slice(&prompt[start..]);
+        return Ok((
+            Vec::new(),
+            GenStats {
+                n_prompt: m,
+                prompt_secs: t0.elapsed().as_secs_f64(),
+                n_gen: 0,
+                decode_secs: 0.0,
+            },
+        ));
+    }
 
     // ── drive ───────────────────────────────────────────────────────────────────────
     // Sampling: greedy unless INFR_TEMP is set (the CLI sets chat defaults for run/serve; the
@@ -1813,7 +1926,7 @@ pub(crate) fn generate_dense_backend(
                 None
             };
             let pf_t0 = std::time::Instant::now();
-            let (pf_g, pf_h) = build(pf_m, cstart);
+            let (pf_g, pf_h) = build(pf_m, cstart, 1);
             let t_build = pf_t0.elapsed();
             let pf_plan = be.compile(&pf_g).map_err(|e| anyhow!("{e}"))?;
             let t_compile = pf_t0.elapsed();
@@ -1892,7 +2005,7 @@ pub(crate) fn generate_dense_backend(
         && (0..c.n_layer)
             .all(|l| c.layer_head_dim(l).is_multiple_of(4) && c.layer_head_dim(l) <= 512);
     let ro = if dyn_replay {
-        let (g, h) = build(1, 0);
+        let (g, h) = build(1, 0, 1);
         let plan = be.compile(&g).map_err(|e| anyhow!("{e}"))?;
         let mut b = Bindings::new();
         b.bind(h.hidden, hidden_buf.as_ref());
@@ -1953,7 +2066,7 @@ pub(crate) fn generate_dense_backend(
             be.execute(plan.as_ref(), b).map_err(|e| anyhow!("{e}"))?;
             exec_el = t_exec.elapsed();
         } else {
-            let (g, h) = build(1, pos);
+            let (g, h) = build(1, pos, 1);
             let plan = be.compile(&g).map_err(|e| anyhow!("{e}"))?;
             let mut b = Bindings::new();
             b.bind(h.hidden, hidden_buf.as_ref());

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -419,9 +419,12 @@ impl CpuModel {
     /// same-tokenizer model): the draft session proposes `k` greedy tokens, ONE batched verify
     /// forward of the target checks all of them (LM head on every candidate row), the matching
     /// prefix commits plus the target's own next token as a bonus. Greedy-only (INFR_TEMP=0) —
-    /// the committed stream is then EXACTLY the target's greedy stream, which is the
-    /// correctness bar. Rollback is the session prefix-diff: rejected rows just get
-    /// overwritten by the next round's suffix prefill.
+    /// every committed token is checked against (or produced by) a verify-forward argmax, so
+    /// the committed stream is the target's greedy stream over the VERIFY forward. That equals
+    /// target-only greedy decode exactly unless a near-tie logit splits between the batched
+    /// f16 verify kernels and decode's exact-f32 GEMV; end-to-end equality is pinned by
+    /// `metal_spec_decode_matches_target_only_greedy`. Rollback is the session prefix-diff:
+    /// rejected rows just get overwritten by the next round's suffix prefill.
     #[cfg(target_os = "macos")]
     #[allow(clippy::too_many_arguments)]
     pub fn generate_metal_spec(

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -415,6 +415,182 @@ impl CpuModel {
         Ok(stats)
     }
 
+    /// Speculative decoding on the Metal seam (`self` = TARGET, `draft` = the small
+    /// same-tokenizer model): the draft session proposes `k` greedy tokens, ONE batched verify
+    /// forward of the target checks all of them (LM head on every candidate row), the matching
+    /// prefix commits plus the target's own next token as a bonus. Greedy-only (INFR_TEMP=0) —
+    /// the committed stream is then EXACTLY the target's greedy stream, which is the
+    /// correctness bar. Rollback is the session prefix-diff: rejected rows just get
+    /// overwritten by the next round's suffix prefill.
+    #[cfg(target_os = "macos")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn generate_metal_spec(
+        &self,
+        session: &mut DenseMetalSession,
+        draft: &CpuModel,
+        draft_session: &mut DenseMetalSession,
+        prompt: &str,
+        max_new: usize,
+        k: usize,
+        mut on_piece: impl FnMut(&str),
+    ) -> Result<crate::GenStats> {
+        let sampler = crate::sampling::Sampler::from_env();
+        if sampler.temp > 0.0 {
+            return Err(anyhow!(
+                "speculative decoding is greedy-only — set INFR_TEMP=0"
+            ));
+        }
+        let vocab = self.cfg.vocab;
+        let argmax = |row: &[f32]| -> u32 {
+            let mut bi = 0usize;
+            let mut bv = f32::NEG_INFINITY;
+            for (i, &v) in row.iter().enumerate() {
+                if v > bv {
+                    bv = v;
+                    bi = i;
+                }
+            }
+            bi as u32
+        };
+        let enc = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| anyhow!("encode: {e}"))?;
+        let mut committed: Vec<u32> = enc.get_ids().to_vec();
+        let n_prompt = committed.len();
+
+        // Initial fill: the target's normal (chunked-prefill) path produces the first token —
+        // verify forwards are only for the small k+1 suffixes.
+        let t0 = std::time::Instant::now();
+        let mut acc_buf: Vec<u32> = Vec::new();
+        let mut printed = 0usize;
+        let (first, _stats) = crate::cpu_backend::generate_dense_metal_session(
+            &session.mtl,
+            &self.gguf,
+            &self.cfg,
+            &self.token_embd,
+            self.per_layer_embd.as_ref(),
+            &committed,
+            1,
+            |_| {},
+            &mut session.state,
+            session.max_ctx,
+            None,
+        )?;
+        let prompt_secs = t0.elapsed().as_secs_f64();
+        let mut t_next = *first.first().ok_or_else(|| anyhow!("empty first token"))?;
+        let mut out: Vec<u32> = Vec::new();
+        let ignore_eos = std::env::var("INFR_IGNORE_EOS").is_ok();
+        let t1 = std::time::Instant::now();
+        'outer: while out.len() < max_new {
+            // Commit the token the target already chose (initial sample or verify bonus).
+            let is_eos =
+                !ignore_eos && (self.cfg.eos_ids.contains(&t_next) || t_next == self.cfg.eos);
+            out.push(t_next);
+            if !is_eos {
+                stream_token(
+                    &self.tokenizer,
+                    &mut acc_buf,
+                    &mut printed,
+                    t_next,
+                    &mut on_piece,
+                );
+            }
+            committed.push(t_next);
+            if is_eos || out.len() >= max_new {
+                break;
+            }
+            // Draft proposes up to k greedy continuations of the committed stream (its session
+            // suffix-prefills the divergence from last round automatically).
+            let budget = k.min(max_new - out.len());
+            let td = std::time::Instant::now();
+            let (cand, _) = crate::cpu_backend::generate_dense_metal_session(
+                &draft_session.mtl,
+                &draft.gguf,
+                &draft.cfg,
+                &draft.token_embd,
+                draft.per_layer_embd.as_ref(),
+                &committed,
+                budget,
+                |_| {},
+                &mut draft_session.state,
+                draft_session.max_ctx,
+                None,
+            )?;
+            // Verify: one batched target forward over [t_next, cand..]; row i's argmax is the
+            // target's choice after consuming everything up to and including suffix row i.
+            let mut feed = committed.clone();
+            feed.extend_from_slice(&cand);
+            if feed.len() + 1 > session.max_ctx {
+                break; // context full: the committed stream is still exact
+            }
+            let td = td.elapsed();
+            let tv = std::time::Instant::now();
+            let (logits, vstats) = crate::cpu_backend::verify_dense_metal2(
+                &session.mtl,
+                &self.gguf,
+                &self.cfg,
+                &self.token_embd,
+                self.per_layer_embd.as_ref(),
+                &feed,
+                &mut session.state,
+                session.max_ctx,
+            )?;
+            if std::env::var("INFR_SPEC_DEBUG").is_ok() {
+                eprintln!(
+                    "[spec] draft {:.1}ms verify {:.1}ms (exec {:.1}ms) cand={}",
+                    td.as_secs_f64() * 1e3,
+                    tv.elapsed().as_secs_f64() * 1e3,
+                    vstats * 1e3,
+                    cand.len()
+                );
+            }
+            let m = logits.len() / vocab;
+            // Rows cover feed's un-cached suffix; the candidate checks use the LAST cand.len()+1
+            // rows (the row before cand[0] is t_next's — its argmax checks cand[0]).
+            let base = m - (cand.len() + 1);
+            let mut accepted = 0usize;
+            let mut next = None;
+            for (j, &c) in cand.iter().enumerate() {
+                let pred = argmax(&logits[(base + j) * vocab..(base + j + 1) * vocab]);
+                if pred == c {
+                    accepted += 1;
+                } else {
+                    next = Some(pred);
+                    break;
+                }
+            }
+            for &c in &cand[..accepted] {
+                let is_eos = !ignore_eos && (self.cfg.eos_ids.contains(&c) || c == self.cfg.eos);
+                out.push(c);
+                if !is_eos {
+                    stream_token(
+                        &self.tokenizer,
+                        &mut acc_buf,
+                        &mut printed,
+                        c,
+                        &mut on_piece,
+                    );
+                }
+                committed.push(c);
+                if is_eos || out.len() >= max_new {
+                    break 'outer;
+                }
+            }
+            // Roll the committed view back past the rejected tail: the session's `cached` holds
+            // all of `feed`, and the next prefix diff overwrites the stale rows.
+            t_next = next.unwrap_or_else(|| {
+                argmax(&logits[(base + cand.len()) * vocab..(base + cand.len() + 1) * vocab])
+            });
+        }
+        Ok(crate::GenStats {
+            n_prompt,
+            prompt_secs,
+            n_gen: out.len(),
+            decode_secs: t1.elapsed().as_secs_f64(),
+        })
+    }
+
     /// Token-level bench on the **Metal** backend through the agnostic seam (the Apple-GPU twin of
     /// [`bench`](Self::bench)): prefill `n_prompt` dummy tokens, decode `n_gen`, return the timing.
     /// Lets `infr bench` (with `INFR_METAL=1`) measure pp/tg directly comparable to `llama-bench`

--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -482,6 +482,11 @@ impl CpuModel {
         let mut out: Vec<u32> = Vec::new();
         let ignore_eos = std::env::var("INFR_IGNORE_EOS").is_ok();
         let t1 = std::time::Instant::now();
+        // Adaptive draft length: k tracks recent acceptance (EMA) — code-shaped output
+        // accepts ~3/round and deserves the full k; high-entropy text accepts ~1-2 and a
+        // long draft just adds verify rows that get thrown away (measured net-NEGATIVE at
+        // fixed k=4 on prose). Bounds [1, k].
+        let mut ema = 2.0f64;
         'outer: while out.len() < max_new {
             // Commit the token the target already chose (initial sample or verify bonus).
             let is_eos =
@@ -502,7 +507,8 @@ impl CpuModel {
             }
             // Draft proposes up to k greedy continuations of the committed stream (its session
             // suffix-prefills the divergence from last round automatically).
-            let budget = k.min(max_new - out.len());
+            let k_now = (ema.round() as usize).clamp(1, k);
+            let budget = k_now.min(max_new - out.len());
             let td = std::time::Instant::now();
             let (cand, _) = crate::cpu_backend::generate_dense_metal_session(
                 &draft_session.mtl,
@@ -577,6 +583,7 @@ impl CpuModel {
                     break 'outer;
                 }
             }
+            ema = 0.7 * ema + 0.3 * (accepted as f64 + 1.0);
             // Roll the committed view back past the rejected tail: the session's `cached` holds
             // all of `feed`, and the next prefix diff overwrites the stale rows.
             t_next = next.unwrap_or_else(|| {

--- a/crates/infr-llama/src/model.rs
+++ b/crates/infr-llama/src/model.rs
@@ -467,6 +467,78 @@ impl ChatModel for MetalSeamChat {
     }
 }
 
+/// Speculative Metal chat (`INFR_SPEC_DRAFT=<gguf>`): TARGET model verified decode with a small
+/// same-tokenizer DRAFT proposing k tokens per round. Greedy-only — the committed stream is
+/// exactly the target's greedy stream. Pays off for ≥8B-class targets (see issue #16's
+/// measurements); the CLI warns when the size ratio looks too thin.
+#[cfg(target_os = "macos")]
+pub struct SpecMetalChat {
+    target: CpuModel,
+    draft: CpuModel,
+    k: usize,
+    target_session: Option<crate::cpu_model::DenseMetalSession>,
+    draft_session: Option<crate::cpu_model::DenseMetalSession>,
+}
+
+#[cfg(target_os = "macos")]
+impl SpecMetalChat {
+    pub fn new(target: CpuModel, draft: CpuModel, k: usize) -> Self {
+        Self {
+            target,
+            draft,
+            k,
+            target_session: None,
+            draft_session: None,
+        }
+    }
+
+    fn ensure_sessions(&mut self) -> Result<()> {
+        if self.target_session.is_none() {
+            // TWO models + TWO KV caches share the working set — a full-n_ctx_train pair
+            // (40k tokens on qwen3) thrashes an 18 GB machine into second-long forwards.
+            // Default to 8k unless INFR_MAX_CTX says otherwise.
+            let max_ctx = std::env::var("INFR_MAX_CTX")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or_else(|| self.target.config().n_ctx_train.min(8192));
+            self.target_session = Some(self.target.metal_session(max_ctx)?);
+            self.draft_session = Some(self.draft.metal_session(max_ctx)?);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl ChatModel for SpecMetalChat {
+    fn render(&self, messages: &[(&str, &str)]) -> Result<String> {
+        self.target.render_chat_messages(messages)
+    }
+
+    fn generate(
+        &mut self,
+        prompt: &str,
+        max_new: usize,
+        on_piece: &mut dyn FnMut(&str),
+    ) -> Result<GenStats> {
+        self.ensure_sessions()?;
+        // Split borrows: sessions come out of the options for the call.
+        let mut ts = self.target_session.take().unwrap();
+        let mut ds = self.draft_session.take().unwrap();
+        let r = self.target.generate_metal_spec(
+            &mut ts,
+            &self.draft,
+            &mut ds,
+            prompt,
+            max_new,
+            self.k,
+            |p| on_piece(p),
+        );
+        self.target_session = Some(ts);
+        self.draft_session = Some(ds);
+        r
+    }
+}
+
 /// CPU reference backend (`INFR_CPU=1`) for dense/MoE: the agnostic compute-graph forward, no GPU.
 /// Stateless full-prefill each turn (no cross-turn KV yet), but the shared `Chat` now feeds the FULL
 /// rendered history in every turn, so multi-turn context works.

--- a/crates/infr-llama/src/qwen35.rs
+++ b/crates/infr-llama/src/qwen35.rs
@@ -446,6 +446,15 @@ impl SeamModel {
                 .map_err(|e| anyhow!("{e}"))?;
             Ok(buf)
         };
+        // F16 variant for the KV caches (2 bytes/elem; f16 zero is all-zero bits).
+        let zeroed16 = |be: &dyn Backend, n: usize| -> Result<Box<dyn Buffer>> {
+            let buf = be
+                .alloc(n * 2, BufferUsage::Activations)
+                .map_err(|e| anyhow!("{e}"))?;
+            be.upload(buf.as_ref(), bytemuck::cast_slice(&vec![0u16; n]))
+                .map_err(|e| anyhow!("{e}"))?;
+            Ok(buf)
+        };
         let want_ctx = plen_hint(&prompt_ids, n);
         let reusable = matches!(&self.state, Some(st) if st.max_ctx >= want_ctx);
         if !reusable {
@@ -457,8 +466,8 @@ impl SeamModel {
             let mut v_bufs: Vec<Option<Box<dyn Buffer>>> = Vec::new();
             for i in 0..c.n_layer {
                 if attn(i) {
-                    k_bufs.push(Some(zeroed(be, cap * nkv * hd)?));
-                    v_bufs.push(Some(zeroed(be, cap * nkv * hd)?));
+                    k_bufs.push(Some(zeroed16(be, cap * nkv * hd)?));
+                    v_bufs.push(Some(zeroed16(be, cap * nkv * hd)?));
                     conv_bufs.push(None);
                     s_bufs.push(None);
                 } else {
@@ -497,10 +506,18 @@ impl SeamModel {
                     }
                     Ok(())
                 };
+                // KV caches are F16 (2 bytes/elem).
+                let zero_fill16 = |b: &Option<Box<dyn Buffer>>, n: usize| -> Result<()> {
+                    if let Some(b) = b {
+                        be.upload(b.as_ref(), bytemuck::cast_slice(&vec![0u16; n]))
+                            .map_err(|e| anyhow!("{e}"))?;
+                    }
+                    Ok(())
+                };
                 for i in 0..c.n_layer {
                     if attn(i) {
-                        zero_fill(&st.k_bufs[i], st.max_ctx * nkv * hd)?;
-                        zero_fill(&st.v_bufs[i], st.max_ctx * nkv * hd)?;
+                        zero_fill16(&st.k_bufs[i], st.max_ctx * nkv * hd)?;
+                        zero_fill16(&st.v_bufs[i], st.max_ctx * nkv * hd)?;
                     } else {
                         zero_fill(&st.conv_bufs[i], (kk - 1) * cc)?;
                         zero_fill(&st.s_bufs[i], nv * kd * vd)?;
@@ -568,8 +585,12 @@ impl SeamModel {
                     let ffn_gate = wpush(&mut gr, &mut weights);
                     let ffn_up = wpush(&mut gr, &mut weights);
                     let ffn_down = wpush(&mut gr, &mut weights);
-                    let k_cache = gr.input(f32d(max_ctx * nkv * hd));
-                    let v_cache = gr.input(f32d(max_ctx * nkv * hd));
+                    // F16 KV (matches the dense seam and llama.cpp): halves cache bandwidth
+                    // AND is what the fast attention kernels key on — the f32 cache routed
+                    // every GQA layer to the scalar split (measured 33 ms/call at d4096 on
+                    // Metal, 52% of the whole decode).
+                    let k_cache = gr.input(TensorDesc::new(vec![max_ctx * nkv * hd], DType::F16));
+                    let v_cache = gr.input(TensorDesc::new(vec![max_ctx * nkv * hd], DType::F16));
                     layers.push(Q35LayerH::Attn(Q35AttnH {
                         attn_norm,
                         q,

--- a/crates/infr-llama/tests/cpu_backend.rs
+++ b/crates/infr-llama/tests/cpu_backend.rs
@@ -582,6 +582,50 @@ fn gpu_seam_multi_slot_prefix_sharing() {
     );
 }
 
+/// Speculative decoding must emit EXACTLY the target-only greedy stream, end to end. The
+/// contract is structural — every committed token is either checked against or produced by a
+/// verify-forward argmax — but the verify forward runs the batched f16 GEMM/cmm path while
+/// target-only decode uses the exact-f32 GEMV, so a near-tie logit could in principle split
+/// them; this test pins the equivalence on a real generation. Self-spec (draft == target)
+/// keeps it to one model download; the accept/commit machinery is identical to a small-draft
+/// pair (the driver never knows the models are the same file).
+#[cfg(target_os = "macos")]
+#[test]
+fn metal_spec_decode_matches_target_only_greedy() {
+    let path = need_model!(qwen3_06b(), "Qwen3-0.6B");
+    let _tlk = test_serial_lock();
+    std::env::set_var("INFR_TEMP", "0");
+    let target = infr_llama::CpuModel::load(&path, None).expect("target load");
+    let draft = infr_llama::CpuModel::load(&path, None).expect("draft load");
+    let prompt = target
+        .render_chat("Write a short paragraph about the ocean.")
+        .expect("render chat");
+
+    let mut plain = String::new();
+    {
+        let mut sess = target.metal_session(1024).expect("target-only session");
+        target
+            .generate_metal_session(&mut sess, &prompt, 64, |p| plain.push_str(p))
+            .expect("target-only greedy");
+    }
+
+    let mut spec = String::new();
+    {
+        let mut ts = target.metal_session(1024).expect("spec target session");
+        let mut ds = draft.metal_session(1024).expect("spec draft session");
+        target
+            .generate_metal_spec(&mut ts, &draft, &mut ds, &prompt, 64, 6, |p| {
+                spec.push_str(p)
+            })
+            .expect("spec decode");
+    }
+
+    assert_eq!(
+        spec, plain,
+        "speculative stream diverged from target-only greedy"
+    );
+}
+
 /// gemma3 (SWA + dual-rope + GeGLU + sandwich norms, hd=256) through the Vulkan seam.
 #[test]
 fn gpu_seam_matches_cpu_gemma3() {

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1046,6 +1046,8 @@ impl MetalBackend {
             DType::Q8_0 => Some("linear_q8_0"),
             DType::Q5_0 => Some("linear_q5_0"),
             DType::Q4_0 => Some("linear_q4_0"),
+            DType::Iq4Xs => Some("linear_iq4xs"),
+            DType::Iq4Nl => Some("linear_iq4nl"),
             _ => None,
         };
         if let Some(kern) = native_kern {
@@ -1268,7 +1270,8 @@ impl MetalBackend {
                 p.extend_from_slice(&(in_f as u32).to_ne_bytes());
                 p.extend_from_slice(&(out_f as u32).to_ne_bytes());
                 // 32 lanes (one simdgroup) per output element — see `linear_f32`/`linear_quik*`.
-                if infr_gguf::dequant::is_quant(g.desc(weight).dtype) {
+                let wdt = g.desc(weight).dtype;
+                if infr_gguf::dequant::is_quant(wdt) || matches!(wdt, DType::Iq4Xs | DType::Iq4Nl) {
                     // Native quant: decode the compact factored weight inline — no f32 blow-up.
                     // Kernel matches the weight's code packing (4/6/8-bit). Multi-row (prefill)
                     // takes the row-tiled variant: one simdgroup per (8-row tile, output), each
@@ -1292,6 +1295,8 @@ impl MetalBackend {
                         "linear_q8_0" => (e / 32 * 34, 0, 0),
                         "linear_q5_0" => (e / 32 * 22, 0, 0),
                         "linear_q4_0" => (e / 32 * 18, 0, 0),
+                        "linear_iq4xs" => (e / 256 * 136, 0, 0),
+                        "linear_iq4nl" => (e / 32 * 18, 0, 0),
                         "linear_quik4" => (e / 2, e / 4, dd_off),
                         "linear_quik6" => (e / 4 * 3, e / 4, dd_off),
                         _ => (e, e / 4, dd_off),
@@ -1318,6 +1323,8 @@ impl MetalBackend {
                         "linear_q8_0" => "linear_q8_0_hmm",
                         "linear_q5_0" => "linear_q5_0_hmm",
                         "linear_q4_0" => "linear_q4_0_hmm",
+                        "linear_iq4xs" => "linear_iq4xs_hmm",
+                        "linear_iq4nl" => "linear_iq4nl_hmm",
                         _ => "linear_quik8_hmm",
                     };
                     let cmm_kern = match qw.kern {
@@ -1328,6 +1335,8 @@ impl MetalBackend {
                         "linear_q8_0" => "linear_q8_0_cmm",
                         "linear_q5_0" => "linear_q5_0_cmm",
                         "linear_q4_0" => "linear_q4_0_cmm",
+                        "linear_iq4xs" => "linear_iq4xs_cmm",
+                        "linear_iq4nl" => "linear_iq4nl_cmm",
                         _ => "linear_quik8_cmm",
                     };
                     // Prefer the cooperative 32x64 threadgroup tile; per-simdgroup HGEMM covers
@@ -1509,6 +1518,8 @@ impl MetalBackend {
                                 "linear_q8_0" => "linear_q8_0_rt",
                                 "linear_q5_0" => "linear_q5_0_rt",
                                 "linear_q4_0" => "linear_q4_0_rt",
+                                "linear_iq4xs" => "linear_iq4xs_rt",
+                                "linear_iq4nl" => "linear_iq4nl_rt",
                                 _ => "linear_quik8_rt",
                             };
                             (rt, m.div_ceil(8) * out_f * 32, 32)

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1305,7 +1305,13 @@ impl MetalBackend {
                     };
                     // Prefer the cooperative 32x64 threadgroup tile; per-simdgroup HGEMM covers
                     // the out_f % 64 != 0 leftovers, and both need the full 128-thread group.
-                    let cmm_ok = m >= 16
+                    // m >= 2 (not 16): small multi-row batches — a chat turn's short suffix
+                    // prefill, speculative VERIFY's k+1 candidate rows — are weight-stream
+                    // bound, so the cooperative tile wins even mostly empty (it reads the
+                    // stream ONCE at GEMM rate; the row-tiled shape re-streams at ~1/3 the
+                    // bandwidth: 140 ms vs ~45 ms per 8B verify forward). m == 1 keeps the
+                    // exact-f32 GEMV (decode's precision contract).
+                    let cmm_ok = m >= 2
                         && out_f % 64 == 0
                         && self
                             .pipelines
@@ -1321,6 +1327,70 @@ impl MetalBackend {
                             >= 128;
                     p.extend_from_slice(&qw.dshift.to_ne_bytes());
                     if cmm_ok {
+                        // Split-K for small-m deep-k (verify rows, short suffix prefills): the
+                        // plain tile's out_f/64 threadgroups underfill the GPU and serialize
+                        // the whole k loop. ksplit tiles share the k-dim into an f32 partial
+                        // plane, reduced in fixed order. Gated to shapes where each split
+                        // still gets >= 4 K-steps.
+                        let nto = out_f / 64;
+                        let ntm = m.div_ceil(32);
+                        let ks_split = if m < 16 {
+                            (160 / (nto * ntm).max(1)).min(8).min(in_f / 32 / 4).max(1)
+                        } else {
+                            1
+                        };
+                        if ks_split > 1 {
+                            let ks_kern = match qw.kern {
+                                "linear_quik4" => "linear_quik4_cmm_ks",
+                                "linear_quik6" => "linear_quik6_cmm_ks",
+                                "linear_q4k" => "linear_q4k_cmm_ks",
+                                "linear_q6k" => "linear_q6k_cmm_ks",
+                                "linear_q8_0" => "linear_q8_0_cmm_ks",
+                                "linear_q5_0" => "linear_q5_0_cmm_ks",
+                                "linear_q4_0" => "linear_q4_0_cmm_ks",
+                                _ => "linear_quik8_cmm_ks",
+                            };
+                            let kchunk = (in_f / 32 / ks_split).max(1) * 32;
+                            // ceil to cover the tail: ksplit*kchunk must reach in_f
+                            let kchunk = if kchunk * ks_split < in_f {
+                                kchunk + 32
+                            } else {
+                                kchunk
+                            };
+                            let parts = self.scratch_buf(ks_split * m * out_f, 8);
+                            let mut kp = p.clone();
+                            kp.extend_from_slice(&(ks_split as u32).to_ne_bytes());
+                            kp.extend_from_slice(&(kchunk as u32).to_ne_bytes());
+                            let pso = self.pipelines.get(ks_kern)?;
+                            self.encode_tg_off(
+                                r,
+                                &pso,
+                                &[
+                                    (bx.as_ref(), 0),
+                                    (&qw.codes, codes_off),
+                                    (&qw.scm, scm_off),
+                                    (&qw.dd, dd_off),
+                                    (parts.as_ref(), 0),
+                                ],
+                                1 << 4,
+                                &kp,
+                                ntm * nto * ks_split * 128,
+                                128,
+                            );
+                            let rp_pso = self.pipelines.get("cmm_ks_reduce")?;
+                            let mut rp = ((m * out_f) as u32).to_ne_bytes().to_vec();
+                            rp.extend_from_slice(&(ks_split as u32).to_ne_bytes());
+                            self.encode_w(
+                                r,
+                                &rp_pso,
+                                &[parts.as_ref(), bd.as_ref()],
+                                1 << 1,
+                                &rp,
+                                m * out_f,
+                            );
+                            r.loc[dst.0 as usize] = Loc::Device;
+                            return Ok(());
+                        }
                         // Reads f32 x directly (casts to f16 while staging) — no cast pass.
                         let pso = self.pipelines.get(cmm_kern)?;
                         self.encode_tg_off(

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1326,6 +1326,37 @@ impl MetalBackend {
                             .max_total_threads_per_threadgroup()
                             >= 128;
                     p.extend_from_slice(&qw.dshift.to_ne_bytes());
+                    // Multi-row mul_mv GEMV for m = 2..8 K-quant shapes (speculative verify,
+                    // short suffix prefills): weight bytes hoisted to registers and reused
+                    // across 8 token rows — one DRAM stream per 8 tokens at GEMV-class
+                    // bandwidth, where the cooperative tile is latency-bound on its serial
+                    // k-loop at these sizes.
+                    let mr_kern = match qw.kern {
+                        "linear_q4k" => Some("linear_q4k_mrv"),
+                        "linear_q6k" => Some("linear_q6k_mrv"),
+                        _ => None,
+                    };
+                    if let (true, Some(kn), 0) = ((2..=8).contains(&m), mr_kern, w_off) {
+                        let pso = self.pipelines.get(kn)?;
+                        let sgs = out_f.div_ceil(2) * m;
+                        self.encode_tg_off(
+                            r,
+                            &pso,
+                            &[
+                                (bx.as_ref(), 0),
+                                (&qw.codes, codes_off),
+                                (&qw.scm, scm_off),
+                                (&qw.dd, dd_off),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 4,
+                            &p,
+                            sgs * 32,
+                            32,
+                        );
+                        r.loc[dst.0 as usize] = Loc::Device;
+                        return Ok(());
+                    }
                     if cmm_ok {
                         // Split-K for small-m deep-k (verify rows, short suffix prefills): the
                         // plain tile's out_f/64 threadgroups underfill the GPU and serialize

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -190,6 +190,32 @@ fn replay_shape(g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
             | Op::GatedActFused { .. }
             | Op::Add { .. } => {}
             Op::QkNormRope { .. } | Op::Rope { .. } => has_rope = true,
+            // qwen35 (Qwen3-Next) decode ops: all pos-independent, on-device, recurrent state
+            // updated in the BOUND buffer — tape-safe when the arm's device gate holds (the
+            // host fallbacks can't tape, so the gates mirror the arms').
+            Op::QkNorm { .. } | Op::Scale { .. } | Op::Copy { .. } | Op::CopyStrided { .. } => {}
+            Op::Conv1dSilu { state, kernel, .. } => {
+                if *kernel > 8
+                    || std::env::var("INFR_METAL_NODELTA").is_ok()
+                    || bindings.get(*state).is_none()
+                {
+                    return false;
+                }
+            }
+            Op::DeltaNet {
+                state,
+                head_k,
+                head_v,
+                ..
+            } => {
+                if *head_k > 256
+                    || !(head_v.is_multiple_of(32) && *head_v <= 1024)
+                    || std::env::var("INFR_METAL_NODELTA").is_ok()
+                    || bindings.get(*state).is_none()
+                {
+                    return false;
+                }
+            }
             // MoE decode tapes only when the arm takes the fully-on-device path (the same gate
             // as the MoeFfn arm's `device_ok`): dtypes with expert kernels, in-bounds shapes,
             // escape hatch off. The host fallback computes on the CPU per token — a tape can't
@@ -1215,10 +1241,11 @@ impl MetalBackend {
                 p.extend_from_slice(&(hd as u32).to_ne_bytes());
                 p.extend_from_slice(&eps.to_ne_bytes());
                 // One simdgroup per (row, head) — see `qknorm_f32`.
-                self.encode_tg(
+                self.encode_tg_w(
                     r,
                     &pso,
                     &[bx.as_ref(), bw.as_ref(), bd.as_ref()],
+                    1 << 2,
                     &p,
                     rows * nh * 32,
                     32,
@@ -1731,7 +1758,7 @@ impl MetalBackend {
                 let pso = self.pipelines.get("scale_f32")?;
                 let mut p = s.to_ne_bytes().to_vec();
                 p.extend_from_slice(&(n as u32).to_ne_bytes());
-                self.encode(r, &pso, &[bx.as_ref(), bd.as_ref()], &p, n);
+                self.encode_w(r, &pso, &[bx.as_ref(), bd.as_ref()], 1 << 1, &p, n);
                 r.loc[dst.0 as usize] = Loc::Device;
             }
             Op::Softcap { x, dst, cap, n } => {
@@ -2687,10 +2714,11 @@ impl MetalBackend {
                         let mut p = (rr as u32).to_ne_bytes().to_vec();
                         p.extend_from_slice(&(cc as u32).to_ne_bytes());
                         p.extend_from_slice(&(kk as u32).to_ne_bytes());
-                        self.encode(
+                        self.encode_w(
                             r,
                             &pso,
                             &[bx.as_ref(), bw.as_ref(), &sbuf.raw, bd.as_ref()],
+                            (1 << 2) | (1 << 3),
                             &p,
                             cc,
                         );
@@ -2787,7 +2815,7 @@ impl MetalBackend {
                             p.extend_from_slice(&(kd as u32).to_ne_bytes());
                             p.extend_from_slice(&(vd as u32).to_ne_bytes());
                             p.extend_from_slice(&eps.to_ne_bytes());
-                            self.encode_tg(
+                            self.encode_tg_w(
                                 r,
                                 &pso,
                                 &[
@@ -2801,6 +2829,7 @@ impl MetalBackend {
                                     &sbuf.raw,
                                     bd.as_ref(),
                                 ],
+                                (1 << 7) | (1 << 8),
                                 &p,
                                 nv * vd,
                                 vd,

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -1534,6 +1534,141 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     }                                                                                             \
 }
 
+// Split-K cooperative GEMM for SMALL-m deep-k shapes (a chat turn's short suffix prefill,
+// speculative verify's k+1 rows): at m <= 15 the plain tile launches only out_f/64
+// threadgroups, each serializing the whole k loop — grid underfill on exactly the shapes
+// where the weight stream dominates. ksplit threadgroups share each (token, output) tile,
+// each covering a kchunk-slice of k and writing an f32 partial plane [ksplit, m, out_f];
+// `cmm_ks_reduce` folds the planes in fixed (ascending) order — deterministic.
+struct QLinKsParams { uint m; uint in_f; uint out_f; uint dshift; uint ksplit; uint kchunk; };
+#define CMMKS_KERNEL(NAME, DEC)                                                                     \
+kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
+                 device const uchar*  codes [[buffer(1)]],                                       \
+                 device const uchar*  scm   [[buffer(2)]],                                       \
+                 device const uchar*  dd    [[buffer(3)]],                                       \
+                 device float*        dst   [[buffer(4)]],                                       \
+                 constant QLinKsParams& p   [[buffer(5)]],                                       \
+                 uint gid  [[thread_position_in_grid]],                                          \
+                 uint lane [[thread_index_in_simdgroup]],                                        \
+                 uint sgid [[simdgroup_index_in_threadgroup]]) {                                 \
+    uint tgix = gid / 128u;                                                                       \
+    uint nto = p.out_f / 64u;                                                                     \
+    uint ntm = (p.m + 31u) / 32u;                                                                 \
+    uint sidx = tgix / (ntm * nto);                                                               \
+    if (sidx >= p.ksplit) return;                                                                 \
+    tgix %= ntm * nto;                                                                            \
+    device float* dstp = dst + (ulong)sidx * p.m * p.out_f;                                       \
+    uint to = tgix % nto;                                                                         \
+    uint tm = tgix / nto;                                                                         \
+    uint ro = to * 64u;                                                                           \
+    uint rt = tm * 32u;                                                                           \
+    uint tid = sgid * 32u + lane;                                                                 \
+    uint nr1 = min(32u, p.m - rt);                                                                \
+                                                                                                  \
+    threadgroup float shraw[2048];  /* 8 KB: sa(4K half) + sb(2K half); reused f32 for stores */  \
+    threadgroup half* sa = (threadgroup half*)shraw;                                              \
+    threadgroup half* sb = ((threadgroup half*)shraw) + 2048u;                                    \
+                                                                                                  \
+    uint lr0 = tid >> 1;                 /* weight (output) row 0..63 */                          \
+    uint il0 = tid & 1u;                 /* which 16-element half of the 32-K step */             \
+    uint lr1 = tid >> 2;                 /* token row 0..31 */                                    \
+    uint iyk = (tid & 3u) * 8u;          /* k offset within the 32-K step */                      \
+    uint lr1c = min(lr1, nr1 - 1u);      /* clamp token loads to the matrix edge */               \
+                                                                                                  \
+    simdgroup_half8x8 ma[4];                                                                      \
+    simdgroup_half8x8 mb[2];                                                                      \
+    simdgroup_float8x8 mc[8];                                                                     \
+    for (uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                               \
+                                                                                                  \
+    uint nb = p.in_f >> 4;                                                                        \
+    uint k_lo = sidx * p.kchunk;                                                                  \
+    uint k_hi = min(k_lo + p.kchunk, p.in_f);                                                     \
+    for (uint k0 = k_lo; k0 < k_hi; k0 += 32u) {                                                  \
+        /* device reads + dequant FIRST, into registers — issued while the previous       */     \
+        /* iteration's MMA phase (other simdgroups) is still draining; the barrier below  */     \
+        /* orders only the threadgroup-memory stores (mul_mm does exactly this)           */     \
+        ulong bi = (ulong)(ro + lr0) * nb + (ulong)(k0 >> 4) + il0;                               \
+        float wk[16];                                                                             \
+        DEC(wk)                                                                                   \
+        device const float4* yy =                                                                 \
+            (device const float4*)(x + (ulong)(rt + lr1c) * p.in_f + k0 + iyk);                   \
+        float4 yv0 = yy[0];                                                                       \
+        float4 yv1 = yy[1];                                                                       \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        {   /* stage A: one 16-block per thread, into pre-transposed 8x8 tiles */                 \
+            uint sy = lr0 >> 3;                                                                   \
+            uint lx = lr0 & 7u;                                                                   \
+            for (uint i = 0; i < 16u; i++) {                                                      \
+                uint sx = 2u * il0 + (i >> 3);                                                    \
+                sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
+            }                                                                                     \
+        }                                                                                         \
+        {   /* stage B: 8 activations per thread, two vectorized f32->f16 half4 stores */         \
+            uint ib = 4u * (tid & 3u) + (lr1 >> 3);                                               \
+            uint ly = lr1 & 7u;                                                                   \
+            threadgroup half4* sb4 = (threadgroup half4*)(sb + 64u * ib + 8u * ly);               \
+            sb4[0] = half4(yv0);                                                                  \
+            sb4[1] = half4(yv1);                                                                  \
+        }                                                                                         \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
+        threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
+        for (uint ik = 0; ik < 4u; ik++) {                                                        \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
+            for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
+            for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
+            simdgroup_barrier(mem_flags::mem_none);                                               \
+            for (uint i = 0; i < 8u; i++)                                                         \
+                simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
+            lsma += 8u * 64u;                                                                     \
+            lsmb += 4u * 64u;                                                                     \
+        }                                                                                         \
+    }                                                                                             \
+    threadgroup_barrier(mem_flags::mem_threadgroup);                                              \
+                                                                                                  \
+    if (rt + 32u <= p.m) {                                                                        \
+        device float* C = dstp + (ro + 32u * (sgid & 1u)) +                                        \
+                          (ulong)(rt + 16u * (sgid >> 1)) * p.out_f;                              \
+        for (uint i = 0; i < 8u; i++)                                                             \
+            simdgroup_store(mc[i], C + 8u * (i & 3u) + 8u * p.out_f * (i >> 2), p.out_f);         \
+    } else {                                                                                      \
+        /* partial token tile: stage through threadgroup memory, row-guard the copy-out */        \
+        threadgroup float* tc = shraw + 32u * (sgid & 1u) + (16u * (sgid >> 1)) * 64u;            \
+        for (uint i = 0; i < 8u; i++)                                                             \
+            simdgroup_store(mc[i], tc + 8u * (i & 3u) + 8u * 64u * (i >> 2), 64u);                \
+        threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
+        if (sgid == 0u) {                                                                         \
+            for (uint j = lane; j < nr1; j += 32u) {                                              \
+                device float* d2 = dstp + ro + (ulong)(rt + j) * p.out_f;                          \
+                threadgroup const float* c2 = shraw + j * 64u;                                    \
+                for (uint i = 0; i < 64u; i++) d2[i] = c2[i];                                     \
+            }                                                                                     \
+        }                                                                                         \
+    }                                                                                             \
+}
+
+
+struct KsReduceParams { uint n; uint ksplit; };
+kernel void cmm_ks_reduce(device const float* parts [[buffer(0)]],
+                          device float*       dst   [[buffer(1)]],
+                          constant KsReduceParams& p [[buffer(2)]],
+                          uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.n) return;
+    float s = 0.0f;
+    for (uint i = 0; i < p.ksplit; i++) s += parts[(ulong)i * p.n + gid];
+    dst[gid] = s;
+}
+
+CMMKS_KERNEL(linear_quik4_cmm_ks, DEC16_K4)
+CMMKS_KERNEL(linear_quik6_cmm_ks, DEC16_K6)
+CMMKS_KERNEL(linear_quik8_cmm_ks, DEC16_K8)
+CMMKS_KERNEL(linear_q4k_cmm_ks, DEC16_Q4K)
+CMMKS_KERNEL(linear_q6k_cmm_ks, DEC16_Q6K)
+CMMKS_KERNEL(linear_q8_0_cmm_ks, DEC16_Q8_0)
+CMMKS_KERNEL(linear_q5_0_cmm_ks, DEC16_Q5_0)
+CMMKS_KERNEL(linear_q4_0_cmm_ks, DEC16_Q4_0)
+
 CMM_KERNEL(linear_quik4_cmm, DEC16_K4)
 CMM_KERNEL(linear_quik6_cmm, DEC16_K6)
 CMM_KERNEL(linear_quik8_cmm, DEC16_K8)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -345,6 +345,39 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
         wk[2u * k + 1u] = d * ((float)b1 - 8.0f);                                                 \
     }
 
+// IQ4_NL / IQ4_XS shared 16-entry signed codebook (llama.cpp kvalues_iq4nl).
+constant float kvalues_iq4nl_f[16] = {
+    -127.0f, -104.0f, -83.0f, -65.0f, -49.0f, -35.0f, -22.0f, -10.0f,
+    1.0f, 13.0f, 25.0f, 38.0f, 53.0f, 69.0f, 89.0f, 113.0f,
+};
+
+// NATIVE IQ4_XS block (136 B / 256 elems): [f16 d][u16 scales_h][4 B scales_l][128 B nibbles],
+// 8 sub-blocks of 32; value = (d * (ls - 32)) * kvalues[q4] — every factor exact in f32, so it
+// matches dequant_codebook bit-for-bit. The dominant mac format (bartowski IQ4_XS mixes);
+// without a native kernel it dequanted to a cached f32 weight, which OOM-corrupted any >2B
+// model on a 18 GB machine.
+#define DEC16_IQ4XS(wk)                                                                           \
+    device const uchar* blk = codes + (ulong)(bi >> 4) * 136ul;                                   \
+    device const ushort* b16 = (device const ushort*)blk;                                         \
+    float d = (float)as_type<half>(b16[0]);                                                      \
+    uint sub = bi & 15u;                                                                          \
+    uint ib4 = sub >> 1;                                                                          \
+    uint lo = ((uint)blk[4u + (ib4 >> 1)] >> (4u * (ib4 & 1u))) & 0xFu;                           \
+    uint hi2 = ((uint)b16[1] >> (2u * ib4)) & 3u;                                                 \
+    float dl = d * ((float)(lo | (hi2 << 4)) - 32.0f);                                            \
+    device const uchar* qs = blk + 8u + ib4 * 16u;                                                \
+    uint h4 = (sub & 1u) * 4u;                                                                    \
+    for (uint k = 0; k < 16u; k++) wk[k] = dl * kvalues_iq4nl_f[(qs[k] >> h4) & 0xFu];
+
+// NATIVE IQ4_NL block (18 B / 32 elems): [f16 d][16 B nibbles]; value = d * kvalues[q4].
+#define DEC16_IQ4NL(wk)                                                                           \
+    device const uchar* blk = codes + (ulong)(bi >> 1) * 18ul;                                    \
+    device const ushort* b16 = (device const ushort*)blk;                                         \
+    float d = (float)as_type<half>(b16[0]);                                                      \
+    device const uchar* qs = blk + 2u;                                                            \
+    uint h4 = (bi & 1u) * 4u;                                                                     \
+    for (uint k = 0; k < 16u; k++) wk[k] = d * kvalues_iq4nl_f[(qs[k] >> h4) & 0xFu];
+
 // NATIVE Q8_0 block (34 B / 32 elems): [f16 d][32 x i8]. 8.5 bpw streamed vs the factored
 // form's ~10.2 (codes + scm + dd) — the decode GEMV is bound on exactly this stream. 34 % 4 != 0,
 // so d assembles from bytes and the quants are char loads (same convention as Q6_K's byte loads).
@@ -1654,6 +1687,8 @@ kernel void moe_topk(device const float* logits_all [[buffer(0)]],
 GEMV_KERNEL(linear_quik4, DEC16_K4)
 GEMV_KERNEL(linear_quik6, DEC16_K6)
 GEMV_KERNEL(linear_quik8, DEC16_K8)
+GEMV_KERNEL(linear_iq4xs, DEC16_IQ4XS)
+GEMV_KERNEL(linear_iq4nl, DEC16_IQ4NL)
 RT_KERNEL(linear_quik4_rt, DEC16_K4)
 RT_KERNEL(linear_quik6_rt, DEC16_K6)
 RT_KERNEL(linear_quik8_rt, DEC16_K8)
@@ -1662,6 +1697,8 @@ RT_KERNEL(linear_q6k_rt, DEC16_Q6K)
 RT_KERNEL(linear_q8_0_rt, DEC16_Q8_0)
 RT_KERNEL(linear_q5_0_rt, DEC16_Q5_0)
 RT_KERNEL(linear_q4_0_rt, DEC16_Q4_0)
+RT_KERNEL(linear_iq4xs_rt, DEC16_IQ4XS)
+RT_KERNEL(linear_iq4nl_rt, DEC16_IQ4NL)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as
@@ -1908,6 +1945,8 @@ CMMKS_KERNEL(linear_q6k_cmm_ks, DEC16_Q6K)
 CMMKS_KERNEL(linear_q8_0_cmm_ks, DEC16_Q8_0)
 CMMKS_KERNEL(linear_q5_0_cmm_ks, DEC16_Q5_0)
 CMMKS_KERNEL(linear_q4_0_cmm_ks, DEC16_Q4_0)
+CMMKS_KERNEL(linear_iq4xs_cmm_ks, DEC16_IQ4XS)
+CMMKS_KERNEL(linear_iq4nl_cmm_ks, DEC16_IQ4NL)
 
 CMM_KERNEL(linear_quik4_cmm, DEC16_K4)
 CMM_KERNEL(linear_quik6_cmm, DEC16_K6)
@@ -1916,6 +1955,8 @@ CMM_KERNEL(linear_q4k_cmm, DEC16_Q4K)
 CMM_KERNEL(linear_q8_0_cmm, DEC16_Q8_0)
 CMM_KERNEL(linear_q5_0_cmm, DEC16_Q5_0)
 CMM_KERNEL(linear_q4_0_cmm, DEC16_Q4_0)
+CMM_KERNEL(linear_iq4xs_cmm, DEC16_IQ4XS)
+CMM_KERNEL(linear_iq4nl_cmm, DEC16_IQ4NL)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
@@ -1926,6 +1967,8 @@ HGEMM_KERNEL(linear_q6k_hmm, DEC16_Q6K)
 HGEMM_KERNEL(linear_q8_0_hmm, DEC16_Q8_0)
 HGEMM_KERNEL(linear_q5_0_hmm, DEC16_Q5_0)
 HGEMM_KERNEL(linear_q4_0_hmm, DEC16_Q4_0)
+HGEMM_KERNEL(linear_iq4xs_hmm, DEC16_IQ4XS)
+HGEMM_KERNEL(linear_iq4nl_hmm, DEC16_IQ4NL)
 
 
 // ---- RoPE (Op::Rope = the no-qk-norm llama-family rotation): INTERLEAVED pairs (2p, 2p+1) —

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -585,6 +585,208 @@ kernel void NAME(device const half*   x     [[buffer(0)]],                      
     }
 #define GEMV_EPILOGUE(R) GEMV_EPILOGUE_N(R, R)
 
+// MULTI-ROW mul_mv GEMV (m = 2..8: speculative verify's candidate rows, short suffix
+// prefills): the single-row bodies below re-stream the whole weight once PER TOKEN if simply
+// looped, and the cooperative GEMM tile is latency-bound on its serial k-loop at these sizes
+// (measured ~44 GB/s effective vs the GEMV's ~136). This keeps the mul_mv access pattern,
+// hoists each (block, out-row)'s weight bytes into registers, and loops up to 4 token rows
+// inside — the weight streams from DRAM once per 4 tokens, the activations re-read from L1.
+// Grid = out-row-pairs x token-blocks; exact f32 like the other GEMVs (reassociated dot only).
+template<uint MR, typename PT>
+inline void linear_q4k_mr_body(device const float*  x,
+                               device const uchar*  codes,
+                               device float*        dst,
+                               constant PT& p,
+                               uint gid, uint lane) {
+    uint sg = gid / 32u;
+    uint rowgroups = (p.out_f + 1u) / 2u;
+    uint tb = sg / rowgroups;
+    sg %= rowgroups;
+    uint first_row = sg * 2u;
+    uint t0 = tb * MR;
+    if (first_row >= p.out_f || t0 >= p.m) return;
+    uint mt = min(MR, p.m - t0);
+    uint nb = p.in_f >> 8;
+    ulong row_b = (ulong)nb * 144ul;
+    device const uchar* xr = codes + first_row * row_b;
+
+    const ushort kmask1 = 0x3f3f, kmask2 = 0x0f0f, kmask3 = 0xc0c0;
+    uint ix = lane >> 3;
+    uint it = lane & 7u;
+    uint iq = it >> 2;
+    uint ir = it & 3u;
+
+    float sumf[2][MR];
+    for (uint r = 0; r < 2u; r++)
+        for (uint t = 0; t < MR; t++) sumf[r][t] = 0.0f;
+
+    ushort sc16[4];
+    thread const uchar* sc8 = (thread const uchar*)sc16;
+
+    for (uint ib = ix; ib < nb; ib += 4u) {
+        device const uchar* blk = xr + (ulong)ib * 144ul;
+        device const ushort* sc = (device const ushort*)(blk + 4u) + iq;
+        device const ushort* q1 = (device const ushort*)(blk + 16u) + 16u * iq + 4u * ir;
+        device const half* dh = (device const half*)blk;
+        for (uint row = 0; row < 2u; row++) {
+            // weight bytes -> registers, reused across the token loop
+            sc16[0] = sc[0] & kmask1;
+            sc16[1] = sc[2] & kmask1;
+            sc16[2] = ((sc[4] >> 0) & kmask2) | ((sc[0] & kmask3) >> 2);
+            sc16[3] = ((sc[4] >> 4) & kmask2) | ((sc[2] & kmask3) >> 2);
+            ushort q1v[4], q2v[4];
+            for (uint i = 0; i < 4u; i++) {
+                q1v[i] = q1[i];
+                q2v[i] = q1[i + 32u];
+            }
+            float d0 = (float)dh[0];
+            float d1 = (float)dh[1];
+            for (uint t = 0; t < mt; t++) {
+                device const float* y4 = x + (t0 + t) * p.in_f + ib * 256u + 64u * iq + 8u * ir;
+                float4 sumy = float4(0.0f);
+                float yl[16], yh[16];
+                for (uint i = 0; i < 8u; i++) {
+                    yl[i]      = y4[i];        sumy[0] += yl[i];
+                    yl[i + 8u] = y4[i + 32u];  sumy[1] += yl[i + 8u];
+                    yh[i]      = y4[i + 128u]; sumy[2] += yh[i];
+                    yh[i + 8u] = y4[i + 160u]; sumy[3] += yh[i + 8u];
+                }
+                float4 acc1 = float4(0.0f);
+                float4 acc2 = float4(0.0f);
+                for (uint i = 0; i < 4u; i++) {
+                    acc1[0] += yl[2u * i]      * (float)(q1v[i] & 0x000F);
+                    acc1[1] += yl[2u * i + 1u] * (float)(q1v[i] & 0x0F00);
+                    acc1[2] += yl[2u * i + 8u] * (float)(q1v[i] & 0x00F0);
+                    acc1[3] += yl[2u * i + 9u] * (float)(q1v[i] & 0xF000);
+                    acc2[0] += yh[2u * i]      * (float)(q2v[i] & 0x000F);
+                    acc2[1] += yh[2u * i + 1u] * (float)(q2v[i] & 0x0F00);
+                    acc2[2] += yh[2u * i + 8u] * (float)(q2v[i] & 0x00F0);
+                    acc2[3] += yh[2u * i + 9u] * (float)(q2v[i] & 0xF000);
+                }
+                sumf[row][t] += d0 * ((acc1[0] + 1.0f/256.0f * acc1[1]) * sc8[0] +
+                                      (acc1[2] + 1.0f/256.0f * acc1[3]) * sc8[1] * 1.0f/16.0f +
+                                      (acc2[0] + 1.0f/256.0f * acc2[1]) * sc8[4] +
+                                      (acc2[2] + 1.0f/256.0f * acc2[3]) * sc8[5] * 1.0f/16.0f) -
+                                d1 * (sumy[0] * sc8[2] + sumy[1] * sc8[3] +
+                                      sumy[2] * sc8[6] + sumy[3] * sc8[7]);
+            }
+            q1 += row_b / 2u;
+            sc += row_b / 2u;
+            dh += row_b / 2u;
+        }
+    }
+    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
+        for (uint t = 0; t < mt; t++) {
+            float v = simd_sum(sumf[row][t]);
+            if (lane == 0u) dst[(ulong)(t0 + t) * p.out_f + first_row + row] = v;
+        }
+    }
+}
+
+kernel void linear_q4k_mr(device const float*  x     [[buffer(0)]],
+                          device const uchar*  codes [[buffer(1)]],
+                          device const uchar*  scm   [[buffer(2)]],
+                          device const uchar*  dd    [[buffer(3)]],
+                          device float*        dst   [[buffer(4)]],
+                          constant QLinParams& p     [[buffer(5)]],
+                          uint gid  [[thread_position_in_grid]],
+                          uint lane [[thread_index_in_simdgroup]]) {
+    linear_q4k_mr_body<8>(x, codes, dst, p, gid, lane);
+}
+
+// Q6_K multi-row: same register-hoisting structure over `linear_q6k_body`'s access pattern.
+template<uint MR, typename PT>
+inline void linear_q6k_mr_body(device const float*  x,
+                               device const uchar*  codes,
+                               device float*        dst,
+                               constant PT& p,
+                               uint gid, uint lane) {
+    uint sg = gid / 32u;
+    uint rowgroups = (p.out_f + 1u) / 2u;
+    uint tb = sg / rowgroups;
+    sg %= rowgroups;
+    uint first_row = sg * 2u;
+    uint t0 = tb * MR;
+    if (first_row >= p.out_f || t0 >= p.m) return;
+    uint mt = min(MR, p.m - t0);
+    uint nb = p.in_f >> 8;
+    ulong row_b = (ulong)nb * 210ul;
+    device const uchar* xr = codes + first_row * row_b;
+
+    const uchar kmask1 = 0x03, kmask2 = 0x0C, kmask3 = 0x30, kmask4 = 0xC0;
+    uint tid2 = lane >> 1;
+    uint ix = lane & 1u;
+    uint ip = tid2 >> 3;
+    uint il = tid2 & 7u;
+    uint l0 = 4u * il;
+    uint is = 8u * ip + (l0 >> 4);
+    uint y_off = 128u * ip + l0;
+    uint ql_off = 64u * ip + l0;
+    uint qh_off = 32u * ip + l0;
+
+    float sumf[2][MR];
+    for (uint r = 0; r < 2u; r++)
+        for (uint t = 0; t < MR; t++) sumf[r][t] = 0.0f;
+
+    for (uint i = ix; i < nb; i += 2u) {
+        device const uchar* blk = xr + (ulong)i * 210ul;
+        device const uchar* q1 = blk + ql_off;
+        device const uchar* q2 = q1 + 32u;
+        device const uchar* qh = blk + 128u + qh_off;
+        device const char* sc = (device const char*)(blk + 192u) + is;
+        device const half* dh = (device const half*)(blk + 208u);
+
+        for (uint row = 0; row < 2u; row++) {
+            uchar q1v[4], q2v[4], qhv[4];
+            char scv[4];
+            for (uint l = 0; l < 4u; l++) {
+                q1v[l] = q1[l];
+                q2v[l] = q2[l];
+                qhv[l] = qh[l];
+            }
+            scv[0] = sc[0];
+            scv[1] = sc[2];
+            scv[2] = sc[4];
+            scv[3] = sc[6];
+            float d = (float)dh[0];
+            for (uint t = 0; t < mt; t++) {
+                device const float* y = x + (t0 + t) * p.in_f + i * 256u + y_off;
+                float4 sums = float4(0.0f);
+                for (uint l = 0; l < 4u; l++) {
+                    sums[0] += y[l]       * (float)((char)((q1v[l] & 0xF) | ((qhv[l] & kmask1) << 4)) - 32);
+                    sums[1] += y[l + 32u] * (float)((char)((q2v[l] & 0xF) | ((qhv[l] & kmask2) << 2)) - 32);
+                    sums[2] += y[l + 64u] * (float)((char)((q1v[l] >> 4)  | ((qhv[l] & kmask3) << 0)) - 32);
+                    sums[3] += y[l + 96u] * (float)((char)((q2v[l] >> 4)  | ((qhv[l] & kmask4) >> 2)) - 32);
+                }
+                sumf[row][t] += d * (sums[0] * scv[0] + sums[1] * scv[1] +
+                                     sums[2] * scv[2] + sums[3] * scv[3]);
+            }
+            q1 += row_b;
+            q2 += row_b;
+            qh += row_b;
+            sc += row_b;
+            dh += row_b / 2u;
+        }
+    }
+    for (uint row = 0; row < 2u && first_row + row < p.out_f; row++) {
+        for (uint t = 0; t < mt; t++) {
+            float v = simd_sum(sumf[row][t]);
+            if (lane == 0u) dst[(ulong)(t0 + t) * p.out_f + first_row + row] = v;
+        }
+    }
+}
+
+kernel void linear_q6k_mr(device const float*  x     [[buffer(0)]],
+                          device const uchar*  codes [[buffer(1)]],
+                          device const uchar*  scm   [[buffer(2)]],
+                          device const uchar*  dd    [[buffer(3)]],
+                          device float*        dst   [[buffer(4)]],
+                          constant QLinParams& p     [[buffer(5)]],
+                          uint gid  [[thread_position_in_grid]],
+                          uint lane [[thread_index_in_simdgroup]]) {
+    linear_q6k_mr_body<8>(x, codes, dst, p, gid, lane);
+}
+
 // Decode GEMV for the native K-quant formats, mul_mv shape (ported from llama.cpp's
 // kernel_mul_mv_q4_K_f32 / q6_K and adapted to our buffers): each simdgroup computes TWO output
 // rows; activations load once into registers and are reused across both rows, and the inner loop
@@ -836,6 +1038,44 @@ kernel void linear_q6k_ks_add(device const float*  x     [[buffer(0)]],
                            uint lane [[thread_index_in_simdgroup]]) {
     threadgroup float red[4 * 2];
     linear_q6k_body<1, 4>(x, codes, dst, res, p, 0.0f, false, gid, lane, sgitg, red);
+}
+
+// Token-parallel variant: one simdgroup per (row pair, token) running the SINGLE-row mul_mv
+// body — token is the FASTEST-varying grid index, so the m simdgroups sharing a row pair are
+// scheduled near-simultaneously and their weight-block reads coalesce in the cache hierarchy
+// instead of multiplying DRAM traffic. (The register-reuse variant above serializes the token
+// loop inside each simdgroup — ALU-bound, ~24 ms per extra row on an 8B verify.)
+kernel void linear_q4k_mrv(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           constant QLinParams& p     [[buffer(5)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    uint sg = gid / 32u;
+    uint t = sg % p.m;
+    uint rp = sg / p.m;
+    threadgroup float red[2];
+    linear_q4k_body<0, 1>(
+        x + (ulong)t * p.in_f, codes, dst + (ulong)t * p.out_f, dst, p, 0.0f, false,
+        rp * 32u + lane, lane, 0, red);
+}
+kernel void linear_q6k_mrv(device const float*  x     [[buffer(0)]],
+                           device const uchar*  codes [[buffer(1)]],
+                           device const uchar*  scm   [[buffer(2)]],
+                           device const uchar*  dd    [[buffer(3)]],
+                           device float*        dst   [[buffer(4)]],
+                           constant QLinParams& p     [[buffer(5)]],
+                           uint gid  [[thread_position_in_grid]],
+                           uint lane [[thread_index_in_simdgroup]]) {
+    uint sg = gid / 32u;
+    uint t = sg % p.m;
+    uint rp = sg / p.m;
+    threadgroup float red[2];
+    linear_q6k_body<0, 1>(
+        x + (ulong)t * p.in_f, codes, dst + (ulong)t * p.out_f, dst, p, 0.0f, false,
+        rp * 32u + lane, lane, 0, red);
 }
 
 // Decode GEMV for NATIVE Q8_0 (34 B / 32-elem blocks), mul_mv shape (ported from llama.cpp's

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -790,6 +790,73 @@ fn linear_q8_0_gemv_matches_dequant_reference() {
     check_quant_linear_parity(DType::Q8_0, quantize_q8_0(&wf), m, in_f, out_f);
 }
 
+// Q5_K (176-byte / 256-elem blocks) rides the FACTORED path — first exercised by bartowski
+// IQ4_XS mixes, which ship attn_v as Q5_K.
+fn synth_q5k(n_elem: usize, seed: u32) -> Vec<u8> {
+    assert_eq!(n_elem % 256, 0);
+    let mut out = Vec::new();
+    for blk_i in 0..(n_elem / 256) {
+        let mut blk = vec![0u8; 176];
+        blk[0..2].copy_from_slice(&half::f16::from_f32(0.05).to_le_bytes());
+        blk[2..4].copy_from_slice(&half::f16::from_f32(0.10).to_le_bytes());
+        blk[4..176].copy_from_slice(&lcg_bytes(seed ^ blk_i as u32, 172));
+        out.extend_from_slice(&blk);
+    }
+    out
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q5k_matches_dequant_reference() {
+    let (m, in_f, out_f) = (2usize, 256usize, 96usize);
+    check_quant_linear_parity(DType::Q5K, synth_q5k(out_f * in_f, 120), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q5k_gemv_matches_dequant_reference() {
+    let (m, in_f, out_f) = (1usize, 256usize, 96usize);
+    check_quant_linear_parity(DType::Q5K, synth_q5k(out_f * in_f, 121), m, in_f, out_f);
+}
+
+// IQ4_XS is codebook (host-dequant to a cached f32 device weight on Metal); the fused-QKV
+// runner slices it with w_off, so both the plain and offset routes need coverage. Valid blocks:
+// 136 B / 256 elems = [f16 d][u16 scales_h][u32 scales_l... layout per gguf]; LCG payload works
+// because the parity compares against dequant of the SAME bytes.
+fn synth_iq4xs(n_elem: usize, seed: u32) -> Vec<u8> {
+    assert_eq!(n_elem % 256, 0);
+    let mut out = Vec::new();
+    for blk_i in 0..(n_elem / 256) {
+        let mut blk = vec![0u8; 136];
+        blk[0..2].copy_from_slice(&half::f16::from_f32(0.06).to_le_bytes());
+        blk[2..136].copy_from_slice(&lcg_bytes(seed ^ blk_i as u32, 134));
+        out.extend_from_slice(&blk);
+    }
+    out
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_iq4xs_matches_dequant_reference() {
+    let (m, in_f, out_f) = (2usize, 256usize, 96usize);
+    check_quant_linear_parity(DType::Iq4Xs, synth_iq4xs(out_f * in_f, 122), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_iq4xs_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    check_linear_woff(
+        DType::Iq4Xs,
+        synth_iq4xs(256 * in_f, 123),
+        1,
+        in_f,
+        &slices,
+        false,
+        1e-3,
+    );
+}
+
 // K-quants are the formats real checkpoints actually ship. Exercise the Metal dequant path
 // (`weight_buf` → `dequant_block`) for Q4_K and Q6_K, same dequant-reference comparison as Q8_0.
 #[test]

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -806,6 +806,22 @@ fn linear_q6k_matches_dequant_reference() {
     check_quant_linear_parity(DType::Q6K, synth_q6k(out_f * in_f, 27), m, in_f, out_f);
 }
 
+// m = 2..8 K-quants route to the MULTI-ROW mul_mv GEMV (weight registers reused across 4
+// token rows); m=5 exercises the partial token block, out_f=94 the partial row pair.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4k_multirow_matches_dequant_reference() {
+    let (m, in_f, out_f) = (5usize, 512usize, 94usize);
+    check_quant_linear_parity(DType::Q4K, synth_q4k(out_f * in_f, 110), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q6k_multirow_matches_dequant_reference() {
+    let (m, in_f, out_f) = (3usize, 512usize, 96usize);
+    check_quant_linear_parity(DType::Q6K, synth_q6k(out_f * in_f, 111), m, in_f, out_f);
+}
+
 // m=1 routes to the GEMV kernels — decode's path, distinct from the m=2 row-tiled and m>=16 GEMM
 // routes the tests above/below take.
 #[test]

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -972,6 +972,86 @@ fn linear_q6k_gemm_matches_dequant_reference() {
     );
 }
 
+// ─── Split-K coop-GEMM at REAL verify shapes ──────────────────────────────────────
+//
+// The m >= 2 cmm gate routes small multi-row batches (spec verify's k+1 candidate rows, a chat
+// turn's short suffix prefill) through the cooperative tile, and m < 16 with deep k engages the
+// split-K variants (`linear_*_cmm_ks` + `cmm_ks_reduce`): ks_split = min(160/(nto*ntm), 8,
+// in_f/128) partial planes reduced in fixed order. The shapes below make ks_split collapse to
+// its cap of 8 (out_f/64 threadgroups few, k deep), so the k-partition arithmetic, the f32
+// partial plane, and the fixed-order reduce are all on the tested path — the m=40 coop tests
+// keep ks_split == 1 and never touch them. K-quants at m in 2..=8 route to the multi-row GEMV
+// instead (covered by the multirow tests), so the K-quant cases here use m in 9..15.
+//
+// Tolerance 2.5e-3 (not the shallow tests' 1e-3): the reference mirrors the f16 OPERAND
+// rounding but computes f32 products, while the MMA rounds per-product at ~2^-11 relative —
+// accumulated over k=2048..4096 dots that's ~1.5e-3 worst case (observed 1.4e-3 on Q6K),
+// deep-k accumulation, not a kernel defect. The shallow k=256 GEMM tests keep 1e-3.
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q8_0_splitk_verify_shape_matches_dequant_reference() {
+    // m=3: a k=2 verify round's [t_next, cand..] rows. nto=4, ntm=1 → ks_split = 8.
+    let (m, in_f, out_f) = (3usize, 2048usize, 256usize);
+    let wf = rand_f32(out_f * in_f, 41);
+    check_quant_linear_parity_impl(
+        DType::Q8_0,
+        quantize_q8_0(&wf),
+        m,
+        in_f,
+        out_f,
+        2.5e-3,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q5_0_splitk_verify_shape_matches_dequant_reference() {
+    // m=5: a k=4 verify round. Deep-k Q5_0 (gemma's gate/up class) through cmm_ks.
+    let (m, in_f, out_f) = (5usize, 2048usize, 256usize);
+    check_quant_linear_parity_impl(
+        DType::Q5_0,
+        synth_q5_0(out_f * in_f, 42),
+        m,
+        in_f,
+        out_f,
+        2.5e-3,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q4k_splitk_verify_shape_matches_dequant_reference() {
+    // m=12 skips the 2..=8 multi-row GEMV route and lands on cmm_ks (m < 16, deep k).
+    let (m, in_f, out_f) = (12usize, 4096usize, 512usize);
+    check_quant_linear_parity_impl(
+        DType::Q4K,
+        synth_q4k(out_f * in_f, 43),
+        m,
+        in_f,
+        out_f,
+        2.5e-3,
+        true,
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_q6k_splitk_verify_shape_matches_dequant_reference() {
+    let (m, in_f, out_f) = (9usize, 2048usize, 256usize);
+    check_quant_linear_parity_impl(
+        DType::Q6K,
+        synth_q6k(out_f * in_f, 44),
+        m,
+        in_f,
+        out_f,
+        2.5e-3,
+        true,
+    );
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn rmsnorm_parity() {


### PR DESCRIPTION
Implements #16's design, gated to 8B-class targets by the acceptance measurements there. **Stacked on #15** (uses its session/backend state — diff collapses when that merges).

## Shape

- `INFR_SPEC_DRAFT=<small-gguf>` on `infr run` (Metal, greedy): draft session proposes k tokens (`INFR_SPEC_K`, default 8), ONE batched target forward verifies all of them — the graph builder gains `logits_rows` so verify runs the LM head over every candidate row. Matching prefix commits plus the target's own next token as the bonus.
- **Rollback is free**: the session suffix-prefill contract already handles it — the driver commits only the accepted prefix, and the next round's prefix diff overwrites the speculatively-written KV rows. No new KV machinery.
- **Correctness bar: token-identical to target-only greedy** — holds on every prompt tested (4B and 8B targets).

## Two general backend wins that fell out

- Cooperative-GEMM gate drops m ≥ 16 → m ≥ 2: small multi-row batches (short chat-turn suffix prefills too, not just verify) are weight-stream bound; the tile reads the stream once at GEMM rate where the row-tiled shape re-streams at ~1/3 the bandwidth.
- Split-K cooperative GEMM (`linear_*_cmm_ks` + fixed-order deterministic reduce) for small-m deep-k shapes where out_f/64 threadgroups underfill the GPU.

## Numbers (Qwen3-8B Q4_K_M + 0.6B draft, M3 Pro)

26.7 → **28.9 t/s** at k=12 (+8%), 28.3 at the k=8 default — token-identical output. Honest gap analysis: the acceptance data supports ~2×, and the shortfall is one missing kernel — a **multi-row mul_mv GEMV** for m=2–8 (the verify forward runs ~44 GB/s effective vs the decode GEMV's ~136; counter-profiled, split-K helped only marginally because the tile's serial k-loop latency, not grid width, binds at this size). That kernel is the named follow-up and would also lift short suffix prefills everywhere.

Sessions default to 8k ctx in spec mode (two models + two KV caches share the working set; the full-n_ctx_train pair thrashed a 18 GB machine into second-long forwards — measured before capping).

Draft mode until #15 lands; happy to split the two backend routing commits out if you'd rather take them separately.