### PR TITLE
fix(serve): honor the request's max_tokens

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -550,6 +550,7 @@ impl infr_server::ChatGenerator for SeamGenerator {
         messages: &[infr_engine::ChatMessage],
         tools_json: Option<&str>,
         tool_choice: Option<&str>,
+        max_tokens: Option<u32>,
         on_delta: &mut dyn FnMut(infr_engine::Delta),
     ) -> anyhow::Result<()> {
         let tools: Option<serde_json::Value> = tools_json
@@ -557,10 +558,14 @@ impl infr_server::ChatGenerator for SeamGenerator {
             .transpose()
             .context("parsing request `tools`")?;
         let prompt = self.renderer.render(messages, tools.as_ref())?;
-        let max_new = std::env::var("INFR_MAX_NEW")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(2048usize);
+        // The request's `max_tokens` wins; INFR_MAX_NEW (default 2048) is the server-side
+        // default for requests that don't set one.
+        let max_new = max_tokens.map(|v| v as usize).unwrap_or_else(|| {
+            std::env::var("INFR_MAX_NEW")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(2048usize)
+        });
         // Forced tool_choice ("required"/named): grammar-constrain the call body (the same
         // llguidance machinery as the bespoke path — grammar::constrained_step runs inside the
         // seam decode). Prime the assistant turn with the <tool_call> opener and parse the

--- a/crates/infr-server/src/lib.rs
+++ b/crates/infr-server/src/lib.rs
@@ -36,12 +36,15 @@ use tokio::sync::Mutex;
 
 /// Generation backend the server drives — it never knows the model/GPU underneath.
 /// Implemented by `Engine` (below) and by CLI adapters (e.g. a Llama runner).
+/// `max_tokens` is the request's generation budget (OpenAI `max_tokens`); `None` leaves the
+/// generator's own default in charge.
 pub trait ChatGenerator: Send {
     fn chat(
         &mut self,
         messages: &[ChatMessage],
         tools_json: Option<&str>,
         tool_choice: Option<&str>,
+        max_tokens: Option<u32>,
         on_delta: &mut dyn FnMut(Delta),
     ) -> anyhow::Result<()>;
 }
@@ -52,6 +55,7 @@ impl ChatGenerator for Engine {
         messages: &[ChatMessage],
         tools_json: Option<&str>,
         _tool_choice: Option<&str>,
+        _max_tokens: Option<u32>,
         on_delta: &mut dyn FnMut(Delta),
     ) -> anyhow::Result<()> {
         Engine::chat(self, messages, tools_json, on_delta).map_err(|e| anyhow::anyhow!("{e}"))
@@ -313,6 +317,7 @@ async fn chat_completions_handler(
             messages,
             tools_json,
             tool_choice,
+            req.max_tokens,
             cid,
             model_id,
             created,
@@ -324,6 +329,7 @@ async fn chat_completions_handler(
             messages,
             tools_json,
             tool_choice,
+            req.max_tokens,
             cid,
             model_id,
             created,
@@ -336,11 +342,13 @@ async fn chat_completions_handler(
 // Non-streaming path
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 async fn non_streaming(
     state: AppState,
     messages: Vec<ChatMessage>,
     tools_json: Option<String>,
     tool_choice: Option<String>,
+    max_tokens: Option<u32>,
     cid: String,
     model_id: String,
     created: i64,
@@ -365,6 +373,7 @@ async fn non_streaming(
                 &messages,
                 tools_json.as_deref(),
                 tool_choice.as_deref(),
+                max_tokens,
                 &mut |delta| match delta {
                     Delta::Reasoning(t) => reasoning.push_str(&t),
                     Delta::Content(t) => content.push_str(&t),
@@ -437,11 +446,13 @@ async fn non_streaming(
 // Streaming path (SSE)
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 async fn streaming(
     state: AppState,
     messages: Vec<ChatMessage>,
     tools_json: Option<String>,
     tool_choice: Option<String>,
+    max_tokens: Option<u32>,
     cid: String,
     model_id: String,
     created: i64,
@@ -485,6 +496,7 @@ async fn streaming(
             &messages,
             tools_json.as_deref(),
             tool_choice.as_deref(),
+            max_tokens,
             &mut |delta| {
                 let payload = match delta {
                     Delta::Reasoning(t) => DeltaPayload {


### PR DESCRIPTION
## What

The OpenAI handler parsed `max_tokens` into `ChatRequest` and then dropped it — `ChatGenerator::chat` had no parameter for it, so `SeamGenerator` always generated `INFR_MAX_NEW` (default 2048) tokens regardless of what the client asked for.

Two user-visible consequences:
- Any request whose own `max_tokens` fit the context still failed with `prompt N + gen 2048 exceeds the session KV capacity` whenever the env default exceeded the KV headroom.
- No client could bound its completion length at all.

## Fix

Plumb `max_tokens: Option<u32>` through the `ChatGenerator` trait and both handler paths. Semantics: the request's `max_tokens` wins; `INFR_MAX_NEW` remains the server-side default for requests that don't set one (unchanged behavior). The bespoke `Engine` impl ignores it — its `chat` is still the `todo!()` stub.

## Verified

Against a live Metal serve (`INFR_MAX_CTX=2048`, no `INFR_MAX_NEW`):
- `max_tokens: 40` → completes on both the non-streaming and SSE paths (both returned the capacity error before).
- No `max_tokens` → today's behavior exactly (default 2048, honest capacity error when it doesn't fit).
- fmt / clippy `-D warnings` / workspace tests green.

Independent of the open Metal PRs — applies directly on main.