### PR TITLE
fix(metal): error instead of silent corruption when the f32 weight cache exceeds the working set

### DIFF
--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -896,7 +896,12 @@ impl MetalBackend {
                 }
                 let t0 = std::time::Instant::now();
                 r.cur_op = op_name(op);
-                self.run_op(op, idx, g, bindings, &mut r)?;
+                if let Err(e) = self.run_op(op, idx, g, bindings, &mut r) {
+                    // Seal the open encoder before unwinding — dropping it un-ended is a Metal
+                    // assertion failure that masks the real error.
+                    self.flush(&mut r);
+                    return Err(e);
+                }
                 // Counter mode: seal this op's encoder (the command buffer stays open) so the
                 // next op's dispatches land in their own sampled encoder.
                 if self.counter_set.is_some() {
@@ -925,7 +930,12 @@ impl MetalBackend {
                 if r.skip.contains(&idx) {
                     continue;
                 }
-                self.run_op(op, idx, g, bindings, &mut r)?;
+                if let Err(e) = self.run_op(op, idx, g, bindings, &mut r) {
+                    // Seal the open encoder before unwinding — dropping it un-ended is a Metal
+                    // assertion failure that masks the real error.
+                    self.flush(&mut r);
+                    return Err(e);
+                }
             }
         }
 
@@ -963,12 +973,19 @@ impl MetalBackend {
     }
 
     /// Fetch a dequantized weight as a device f32 buffer, cached by bound-buffer address.
+    ///
+    /// GUARDED against silent OOM corruption: this cache stores the weight at 4 bytes/element,
+    /// ballooning a quant tensor 4-8x. Formats without native kernels (IQ2*/IQ3*/TQ*/fp4 — every
+    /// Linear falls here) can push a model that FITS in its quantized form past the GPU working
+    /// set, and Metal shared-storage allocation doesn't fail there — it silently corrupts under
+    /// pressure (observed: a 4B IQ4_XS ballooned to 16 GB on a 12.9 GB working set and generated
+    /// garbage with no error). Exceeding the budget is now a hard error naming the fix.
     fn weight_buf(
         &self,
         id: TensorId,
         g: &infr_core::graph::Graph,
         bindings: &Bindings,
-    ) -> Arc<MtlBuffer> {
+    ) -> Result<Arc<MtlBuffer>> {
         let buf = metal_buf(bindings.get(id).expect("metal backend: unbound Weight"));
         // Key on the UNDERLYING MTLBuffer (unified-memory contents pointer), not the wrapper
         // address: the runner rebuilds its bindings map per prefill graph, so wrapper addresses
@@ -977,13 +994,30 @@ impl MetalBackend {
         // uploaded weight, so its contents pointer is stable and unique.
         let key = buf.raw.contents() as usize;
         if let Some(w) = self.weight_cache.lock().unwrap().get(&key) {
-            return w.clone();
+            return Ok(w.clone());
+        }
+        let dt = g.desc(id).dtype;
+        let want = (g.desc(id).numel() * 4) as u64;
+        let used = self.device.current_allocated_size();
+        let budget = self.device.recommended_max_working_set_size();
+        if budget > 0 && used + want > budget {
+            return Err(Error::Backend(format!(
+                "dequant-cached f32 weight would exceed the GPU working set: \
+                 {:.2} GiB allocated + {:.2} GiB for this {dt:?} tensor > {:.2} GiB budget. \
+                 {dt:?} has no native Metal kernel, so its weights are cached at f32 (4-8x the \
+                 quantized size) and the total no longer fits — proceeding would corrupt \
+                 silently. Use a natively-supported quantization (Q4_K_M / Q6_K / Q8_0 / Q5_0 / \
+                 Q4_0) or run this checkpoint on the CPU backend (INFR_CPU=1).",
+                used as f64 / (1u64 << 30) as f64,
+                want as f64 / (1u64 << 30) as f64,
+                budget as f64 / (1u64 << 30) as f64,
+            )));
         }
         let bytes = Self::read_bytes(buf);
-        let f = bytes_to_f32(&bytes, g.desc(id).dtype);
+        let f = bytes_to_f32(&bytes, dt);
         let w = Arc::new(self.f32_buf(&f));
         self.weight_cache.lock().unwrap().insert(key, w.clone());
-        w
+        Ok(w)
     }
 
     /// A device buffer initialized from a raw byte slice.
@@ -1165,7 +1199,7 @@ impl MetalBackend {
             } => {
                 let (rows, dim) = (rows as usize, dim as usize);
                 let bx = self.ensure_device(r, x);
-                let bw = self.weight_buf(weight, g, bindings);
+                let bw = self.weight_buf(weight, g, bindings)?;
                 let bd = self.dev_dst(r, dst, rows * dim);
                 // Decode (few rows): the WIDE kernel — 8 simdgroups per row; the 32-lane form
                 // is latency-bound on dim/32 serial loads (~20 us/launch at dim 1152). Prefill
@@ -1207,7 +1241,7 @@ impl MetalBackend {
             } => {
                 let (rows, nh, hd) = (rows as usize, n_head as usize, head_dim as usize);
                 let bx = self.ensure_device(r, x);
-                let bw = self.weight_buf(weight, g, bindings);
+                let bw = self.weight_buf(weight, g, bindings)?;
                 let bd = self.dev_dst(r, dst, rows * nh * hd);
                 let pso = self.pipelines.get("qknorm_f32")?;
                 let mut p = (rows as u32).to_ne_bytes().to_vec();
@@ -1479,7 +1513,7 @@ impl MetalBackend {
                     }
                 } else {
                     // f16/f32/bf16 weight: dequant-to-f32 device buffer, cached.
-                    let bw = self.weight_buf(weight, g, bindings);
+                    let bw = self.weight_buf(weight, g, bindings)?;
                     let pso = self.pipelines.get("linear_f32")?;
                     self.encode_tg_off(
                         r,
@@ -1550,7 +1584,7 @@ impl MetalBackend {
             } => {
                 let (rows, nh, hd) = (rows as usize, n_head as usize, head_dim as usize);
                 let bx = self.ensure_device(r, x);
-                let bw = self.weight_buf(weight, g, bindings);
+                let bw = self.weight_buf(weight, g, bindings)?;
                 // The kernel reads the bound i32 positions buffer directly (exact widening in
                 // the shader) — no host round-trip, and the decode-replay tape stays valid when
                 // the engine rewrites the position between replays.
@@ -2230,7 +2264,7 @@ impl MetalBackend {
                     // Router logits for ALL rows (one GEMV-per-(row, expert) dispatch over the
                     // dequant-cached router weight), then per-row top-k into the [rows, 32]
                     // expert table (idx in slots 0..16, f32 weights in 16..32).
-                    let rw = self.weight_buf(router, g, bindings);
+                    let rw = self.weight_buf(router, g, bindings)?;
                     let logits = self.scratch_buf(rows * n_expert, 0);
                     let pso = self.pipelines.get("linear_f32")?;
                     let mut p = (rows as u32).to_ne_bytes().to_vec();
@@ -2576,7 +2610,7 @@ impl MetalBackend {
                 if kk <= 8 && std::env::var("INFR_METAL_NODELTA").is_err() {
                     if let Some(sb) = bindings.get(state) {
                         let bx = self.ensure_device(r, x);
-                        let bw = self.weight_buf(weight, g, bindings);
+                        let bw = self.weight_buf(weight, g, bindings)?;
                         let bd = self.dev_dst(r, dst, rr * cc);
                         let sbuf = metal_buf(sb);
                         let i = state.0 as usize;
@@ -2672,8 +2706,8 @@ impl MetalBackend {
                             let bv = self.ensure_device(r, v);
                             let bb = self.ensure_device(r, b);
                             let ba = self.ensure_device(r, a);
-                            let bac = self.weight_buf(a_coef, g, bindings);
-                            let bdt = self.weight_buf(dt_bias, g, bindings);
+                            let bac = self.weight_buf(a_coef, g, bindings)?;
+                            let bdt = self.weight_buf(dt_bias, g, bindings)?;
                             let bd = self.dev_dst(r, dst, rr * nv * vd);
                             let sbuf = metal_buf(sb);
                             let i = state.0 as usize;


### PR DESCRIPTION
Closes the last open item from the IQ4_XS corruption class (#17's IQ4 arc fixed the two formats users actually ship; this guards every format still on the fallback path).

## The failure mode

Formats without native Metal kernels (IQ2*/IQ3*/TQ*/MXFP4 today) fall to the dequant-cached f32 weight path — every tensor cached at 4 bytes/element, 4-8x its quantized size. A checkpoint that fits fine in quantized form can push the cumulative cache past the device working set, and Metal shared-storage allocation **does not fail** there — it silently corrupts under pressure. The concrete repro: a 4B IQ4_XS (2.3 GB file) balloons to ~16 GB against a 12.9 GB working set and generates garbage at 1.9 t/s with zero indication anything is wrong.

## The fix

`weight_buf` checks `current_allocated_size + tensor_f32_size > recommended_max_working_set_size` before allocating and returns a hard error naming both exits (natively-supported quantization, or `INFR_CPU=1`):

```
Error: backend: dequant-cached f32 weight would exceed the GPU working set: 11.86 GiB allocated
+ 0.19 GiB for this Iq4Xs tensor > 12.00 GiB budget. ...
```

Fixing the error path surfaced a second latent bug: an op arm bailing mid-forward dropped the batch encoder without `endEncoding`, so ANY encode error died as a Metal assertion (`Command encoder released without endEncoding`) that masked the real message. `run_graph` now seals the encoder before unwinding — that fix applies to every error path through the walk, not just this guard.

## Verified

- 4B IQ4_XS on an 18 GB box: garbage → clean error (the original repro).
- 0.6B IQ4_XS (fits): still runs correctly through the same cached path.
- fmt / clippy `-D warnings` / workspace tests / 78 GPU parity green.

Independent of the open PR stack — applies directly on main. (After #17 lands its native IQ4 kernels, IQ4_XS/IQ4_NL leave this path entirely and the guard keeps covering the remaining exotic formats.)