### PR TITLE
feat(serve): speculative decoding on Metal serve — one selection funnel for run and serve

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -431,40 +431,7 @@ fn cmd_run(model: &str, message: Option<&str>) -> anyhow::Result<()> {
             );
             #[cfg(target_os = "macos")]
             {
-                // INFR_SPEC_DRAFT=<gguf>: speculative decoding — a small same-tokenizer draft
-                // proposes k tokens (INFR_SPEC_K, default 4), one batched target forward
-                // verifies. Greedy-only; pays off for ~8B-class targets (issue #16).
-                if let Ok(draft_path) = std::env::var("INFR_SPEC_DRAFT") {
-                    let target = infr_llama::CpuModel::load(&gguf, tok.as_deref())?;
-                    let draft =
-                        infr_llama::CpuModel::load(std::path::Path::new(&draft_path), None)?;
-                    // Upper bound on the draft length; the driver adapts the actual k per
-                    // round to recent acceptance (verify cost scales with rows on this
-                    // hardware, so over-drafting low-acceptance text costs real time).
-                    let k = std::env::var("INFR_SPEC_K")
-                        .ok()
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(6);
-                    let (tb, db) = (
-                        std::fs::metadata(&gguf).map(|m| m.len()).unwrap_or(0),
-                        std::fs::metadata(&draft_path).map(|m| m.len()).unwrap_or(0),
-                    );
-                    if db * 4 > tb {
-                        eprintln!(
-                            "[spec] warning: draft is more than 1/4 the target's size — \
-                             speculation only pays when the target is much larger (see #16)"
-                        );
-                    }
-                    std::env::set_var("INFR_TEMP", "0");
-                    eprintln!(
-                        "[metal spec — target + {k}-token draft verify, greedy (INFR_TEMP=0)]"
-                    );
-                    Box::new(infr_llama::model::SpecMetalChat::new(target, draft, k))
-                } else {
-                    Box::new(infr_llama::model::MetalSeamChat::new(
-                        infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
-                    ))
-                }
+                metal_chat_model(&gguf, tok.as_deref())?
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -548,6 +515,48 @@ fn run_chat_turn(
         rate(stats.n_gen, stats.decode_secs),
     );
     Ok(())
+}
+
+/// The Metal dense/MoE [`ChatModel`] for run AND serve: the persistent-session seam chat, or —
+/// with `INFR_SPEC_DRAFT=<gguf>` — speculative decoding (a small same-tokenizer draft proposes up
+/// to `INFR_SPEC_K` tokens per round, default 6; one batched target forward verifies; greedy-only,
+/// pays off for ~8B-class targets — issue #16). One selection funnel so run and serve can never
+/// disagree on how the Metal model is built.
+#[cfg(target_os = "macos")]
+fn metal_chat_model(
+    gguf: &Path,
+    tok: Option<&Path>,
+) -> anyhow::Result<Box<dyn infr_llama::model::ChatModel + Send>> {
+    if let Ok(draft_path) = std::env::var("INFR_SPEC_DRAFT") {
+        let target = infr_llama::CpuModel::load(gguf, tok)?;
+        let draft = infr_llama::CpuModel::load(std::path::Path::new(&draft_path), None)?;
+        // Upper bound on the draft length; the driver adapts the actual k per round to recent
+        // acceptance (verify cost scales with rows on this hardware, so over-drafting
+        // low-acceptance text costs real time).
+        let k = std::env::var("INFR_SPEC_K")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6);
+        let (tb, db) = (
+            std::fs::metadata(gguf).map(|m| m.len()).unwrap_or(0),
+            std::fs::metadata(&draft_path).map(|m| m.len()).unwrap_or(0),
+        );
+        if db * 4 > tb {
+            eprintln!(
+                "[spec] warning: draft is more than 1/4 the target's size — \
+                 speculation only pays when the target is much larger (see #16)"
+            );
+        }
+        std::env::set_var("INFR_TEMP", "0");
+        eprintln!("[metal spec — target + {k}-token draft verify, greedy (INFR_TEMP=0)]");
+        Ok(Box::new(infr_llama::model::SpecMetalChat::new(
+            target, draft, k,
+        )))
+    } else {
+        Ok(Box::new(infr_llama::model::MetalSeamChat::new(
+            infr_llama::CpuModel::load(gguf, tok)?,
+        )))
+    }
 }
 
 /// Serve adapter for the seam-backed [`ChatModel`]s (qwen35 on any backend, dense/MoE on the
@@ -1291,13 +1300,13 @@ fn cmd_serve(model: &str, addr: &str) -> anyhow::Result<()> {
             infr_llama::model::Qwen35Chat::new(gguf.clone())
         })
     } else if std::env::var("INFR_METAL").is_ok() {
-        // Metal: the persistent-session seam chat on macOS (the Vulkan session's Apple twin);
-        // the stateless reference wrapper elsewhere (the arm is unreachable off-macOS anyway).
+        // Metal: the SAME selection funnel as `infr run` — persistent-session seam chat, or
+        // speculative decoding with INFR_SPEC_DRAFT (serve requests then decode through the
+        // draft-verify driver; greedy-only). Stateless reference wrapper elsewhere (the arm is
+        // unreachable off-macOS anyway).
         #[cfg(target_os = "macos")]
         {
-            Box::new(infr_llama::model::MetalSeamChat::new(
-                infr_llama::CpuModel::load(&gguf, tok.as_deref())?,
-            ))
+            metal_chat_model(&gguf, tok.as_deref())?
         }
         #[cfg(not(target_os = "macos"))]
         {

--- a/crates/infr-llama/src/model.rs
+++ b/crates/infr-llama/src/model.rs
@@ -527,6 +527,20 @@ impl ChatModel for SpecMetalChat {
         self.target.render_chat_messages(messages)
     }
 
+    fn warmup(&mut self) -> Result<()> {
+        // Compile BOTH models' pipelines now (a spec round drives target prefill, draft decode,
+        // and the batched verify) so serve's first request doesn't pay two cold starts.
+        self.generate("Hi", 2, &mut |_| {})?;
+        // Drop the warmup tokens so the first real prompt prefills clean slots from row 0.
+        if let Some(s) = &mut self.target_session {
+            s.reset_cache();
+        }
+        if let Some(s) = &mut self.draft_session {
+            s.reset_cache();
+        }
+        Ok(())
+    }
+
     fn generate(
         &mut self,
         prompt: &str,


### PR DESCRIPTION
`infr run` honored `INFR_SPEC_DRAFT`; `infr serve` silently ignored it and always built the plain session chat — so the +12–16% draft-verify win on 8B-class targets (#17) never reached the OpenAI endpoint.

## Change

- The Metal model selection (spec pair with size-ratio warning + greedy clamp, or plain persistent-session chat) moves into one helper, `metal_chat_model()`, used by BOTH commands — run and serve can no longer drift on how the model is built.
- `SpecMetalChat` gains the `warmup` override serve relies on: one tiny spec round compiles both models' pipelines (target prefill, draft decode, batched verify) before the first request, then resets both sessions so the first real prompt prefills clean slots instead of forking off the warmup prefix.

## Verified

Live serve, 8B Q4_K_M target + 0.6B Q8_0 draft on an M3 Pro: dual-model warmup 9.0s, code-shaped completion decodes in the spec class (~29 t/s vs ~27 plain 8B), consecutive different-conversation requests coherent. Spec ≡ target-only greedy is already pinned end-to-end by `metal_spec_decode_matches_target_only_greedy`; serve funnels through the same `generate`. Full matrix + 89 GPU parity green.

Independent of #23/#24 — applies directly on main.