### PR TITLE
test(metal): kernel-name tripwire — missing kernels fail red instead of silently degrading

### DIFF
--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -34,6 +34,7 @@ use metal::{Buffer as MtlBuffer, CommandQueue, Device};
 mod exec;
 mod profile;
 mod shaders;
+pub use shaders::msl_source;
 
 fn be(msg: impl std::fmt::Display) -> Error {
     Error::backend(msg)

--- a/crates/infr-metal/src/shaders.rs
+++ b/crates/infr-metal/src/shaders.rs
@@ -20,6 +20,14 @@ pub struct Pipelines {
 unsafe impl Send for Pipelines {}
 unsafe impl Sync for Pipelines {}
 
+/// The complete assembled MSL source — the ONE string the backend compiles. Public so the
+/// kernel-name tripwire test resolves names against exactly what the runtime compiles (a
+/// separately-maintained file list in the test would drift the same way a duplicated source
+/// copy once did).
+pub fn msl_source() -> String {
+    MSL_PARTS.concat()
+}
+
 impl Pipelines {
     pub fn build(device: &Device) -> Result<Self> {
         let opts = metal::CompileOptions::new();
@@ -27,7 +35,7 @@ impl Pipelines {
         // results stay in tight numeric parity with the CPU interpreter.
         opts.set_fast_math_enabled(false);
         let library = device
-            .new_library_with_source(&MSL_PARTS.concat(), &opts)
+            .new_library_with_source(&msl_source(), &opts)
             .map_err(|e| be(format!("compile MSL library: {e}")))?;
         Ok(Self {
             device: device.clone(),

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -1,0 +1,81 @@
+//! Tripwire for the silent-missing-kernel class: every kernel name the executor can dispatch
+//! must exist in the compiled MSL library.
+//!
+//! Why this exists: the executor's pipeline cap-checks treat a missing function as "capability
+//! absent" and fall back gracefully — correct behavior for genuinely capped devices, but it
+//! also means a kernel that silently VANISHES from the library (e.g. a rebase restoring a stale
+//! copy of the shader source, as happened once: the native-read KV kernels disappeared and
+//! q4_0 decode at depth ran 3x slower with zero errors anywhere) degrades performance invisibly
+//! instead of failing. This test turns that class red: it scrapes every kernel-shaped string
+//! literal out of exec.rs and asserts each one resolves in the library.
+
+/// A string literal in exec.rs is "kernel-shaped" when it starts with one of the kernel-family
+/// prefixes. Names are scraped from the SOURCE (include_str! at compile time), so a new dispatch
+/// site is covered automatically — no list to maintain. If a literal matches a prefix but is
+/// not meant to be a kernel, extend the exclusion below with a comment.
+const KERNEL_PREFIXES: &[&str] = &[
+    "add_",
+    "argmax",
+    "attention",
+    "attnflash",
+    "attnvec",
+    "cast_",
+    "cmm_",
+    "conv1d_",
+    "copy_",
+    "deltanet_",
+    "dequant_",
+    "gatedact",
+    "linear_",
+    "moe_",
+    "qknorm",
+    "rmsnorm",
+    "rope_",
+    "scale_f32",
+    "softcap",
+    "writekv_",
+];
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn every_dispatchable_kernel_exists_in_the_library() {
+    let src = include_str!("../src/exec.rs");
+    // Scrape "..." literals. exec.rs kernel names are plain [a-z0-9_] identifiers.
+    let mut names: Vec<String> = Vec::new();
+    let mut rest = src;
+    while let Some(q) = rest.find('"') {
+        rest = &rest[q + 1..];
+        let Some(end) = rest.find('"') else { break };
+        let lit = &rest[..end];
+        rest = &rest[end + 1..];
+        if !lit.is_empty()
+            && lit
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            && KERNEL_PREFIXES.iter().any(|p| lit.starts_with(p))
+            && !names.iter().any(|n| n == lit)
+        {
+            names.push(lit.to_string());
+        }
+    }
+    assert!(
+        names.len() > 40,
+        "kernel-name scrape looks broken: only {} names found",
+        names.len()
+    );
+
+    let dev = metal::Device::system_default().expect("no Metal device");
+    // Resolve each name against EXACTLY the source the runtime compiles (infr_metal::msl_source
+    // is the backend's own assembly — no separately-maintained file list to drift).
+    let lib = dev
+        .new_library_with_source(&infr_metal::msl_source(), &metal::CompileOptions::new())
+        .expect("MSL library compile");
+    let have: std::collections::HashSet<String> = lib.function_names().into_iter().collect();
+
+    let missing: Vec<&String> = names.iter().filter(|n| !have.contains(*n)).collect();
+    assert!(
+        missing.is_empty(),
+        "exec.rs dispatches kernels that do NOT exist in the compiled MSL library \
+         (the runtime would silently treat them as capability-absent and fall back): {missing:?}"
+    );
+}

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "macos")] // like the lib: empty on other targets (metal dep is cfg-gated)
+
 //! Tripwire for the silent-missing-kernel class: every kernel name the executor can dispatch
 //! must exist in the compiled MSL library.
 //!


### PR DESCRIPTION
The follow-up offered in #27. The cap-check fallback that made the f89dcef regression invisible (missing function → "capability absent" → graceful fallback → 3× decode loss, zero errors) is correct runtime behavior for capped devices — so the guard belongs in CI instead.

The test scrapes every kernel-shaped string literal from exec.rs (prefix families, no hand-maintained list — new dispatch sites are covered automatically) and asserts each resolves in the compiled library. It resolves against `infr_metal::msl_source()` — the backend's own source assembly, newly public — so the test can't drift from what the runtime compiles (a duplicated file list in the test would rot exactly the way the duplicated source copy did).

Verified in both directions: green on main; renaming a single kernel in a shader file fails it with the missing name listed. Runs in the macOS CI job through its existing `--include-ignored`. Full matrix green.