### PR TITLE
feat(spec): conversation slots for speculative serve — 4x on conversation return

### DIFF
--- a/crates/infr-llama/src/cpu_model.rs
+++ b/crates/infr-llama/src/cpu_model.rs
@@ -620,6 +620,16 @@ impl CpuModel {
         let mut committed: Vec<u32> = enc.get_ids().to_vec();
         let n_prompt = committed.len();
 
+        // Conversation slots, like the plain session chat: pick the best-prefix slot in BOTH
+        // sessions from the prompt, once per call (the indices stay stable — LRU recycling only
+        // happens inside pick). A returning conversation suffix-prefills its own slots; a
+        // different conversation forks/seeds instead of clobbering — multi-user spec serve
+        // stops paying a full re-prefill of BOTH models on every conversation switch.
+        let t_slot = session.pool.pick(&session.mtl, &self.cfg, &committed)?;
+        let d_slot = draft_session
+            .pool
+            .pick(&draft_session.mtl, &draft.cfg, &committed)?;
+
         // Initial fill: the target's normal (chunked-prefill) path produces the first token —
         // verify forwards are only for the small k+1 suffixes.
         let t0 = std::time::Instant::now();
@@ -634,7 +644,7 @@ impl CpuModel {
             &committed,
             1,
             |_| {},
-            session.pool.single(),
+            &mut session.pool.slots[t_slot],
             session.max_ctx,
             None,
         )?;
@@ -680,7 +690,7 @@ impl CpuModel {
                 &committed,
                 budget,
                 |_| {},
-                draft_session.pool.single(),
+                &mut draft_session.pool.slots[d_slot],
                 draft_session.max_ctx,
                 None,
             )?;
@@ -700,7 +710,7 @@ impl CpuModel {
                 &self.token_embd,
                 self.per_layer_embd.as_ref(),
                 &feed,
-                session.pool.single(),
+                &mut session.pool.slots[t_slot],
                 session.max_ctx,
             )?;
             if std::env::var("INFR_SPEC_DEBUG").is_ok() {


### PR DESCRIPTION
The spec driver pinned both sessions to slot 0, so every conversation switch on a speculative serve re-prefilled the full history through TWO models. The fix is almost embarrassingly small: pick the best-prefix slot in each session from the prompt (once per call — indices stay stable, LRU recycling only happens inside `pick`) and index the pool instead of `single()`. The existing suffix-prefill, fork, and prefix-seed machinery does everything else.

## Measured (8B + 0.6B spec serve, two alternating conversations, ~1600-token system contexts)

| request | slotted (default 4) | single-slot control (`INFR_KV_SLOTS=1`) |
|---|---|---|
| A cold | 8.2s | 8.1s |
| B cold | 8.9s | 8.9s |
| **A return** | **2.0s** | 8.4s |
| **B return** | **1.9s** | 9.0s |

4.2× on the return path; cold requests unchanged. Control is the same binary with the slot cap at 1, so the comparison isolates exactly the slotting.

Spec ≡ target-only greedy still pinned by `metal_spec_decode_matches_target_only_greedy`. Full matrix + 99 infr-metal tests green.