### PR TITLE
feat(mtp): Metal + CPU MTP drivers — correct on both, Metal head-numerics gap flagged

### DIFF
--- a/crates/infr-llama/src/model.rs
+++ b/crates/infr-llama/src/model.rs
@@ -452,6 +452,8 @@ impl ChatModel for DenseSeamChat {
 pub struct MetalSeamChat {
     model: CpuModel,
     session: Option<crate::cpu_model::DenseMetalSession>,
+    mtp_head: Option<crate::mtp::MtpHeadWeights>,
+    mtp_checked: bool,
 }
 
 #[cfg(target_os = "macos")]
@@ -460,7 +462,32 @@ impl MetalSeamChat {
         Self {
             model,
             session: None,
+            mtp_head: None,
+            mtp_checked: false,
         }
+    }
+
+    /// MTP mode is opt-in (`INFR_MTP=1`) and only for a qwen35 GGUF that ships an MTP head — the
+    /// Metal twin of [`DenseSeamChat::wants_mtp`]. Memoized so a non-MTP GGUF doesn't re-parse
+    /// its `Config` every turn.
+    fn wants_mtp(&mut self) -> Result<bool> {
+        if self.mtp_head.is_some() {
+            return Ok(true);
+        }
+        if self.mtp_checked {
+            return Ok(false);
+        }
+        self.mtp_checked = true;
+        if std::env::var("INFR_MTP").ok().as_deref() != Some("1")
+            || self.model.config().n_layer_nextn == 0
+        {
+            return Ok(false);
+        }
+        self.mtp_head = Some(crate::mtp::load_mtp_head(
+            self.model.gguf(),
+            self.model.config(),
+        )?);
+        Ok(true)
     }
 
     fn ensure_session(&mut self) -> Result<()> {
@@ -500,6 +527,16 @@ impl ChatModel for MetalSeamChat {
         max_new: usize,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
+        // MTP (INFR_MTP=1 on a qwen35 head-bearing GGUF): the draft-verify-catchup loop over the
+        // Metal trunk + head, instead of the plain session decode. The committed stream is the
+        // target's greedy stream (the same invariant Vulkan MTP holds), so the two are
+        // token-identical — pinned by the greedy-equivalence check in the CLI validation.
+        if self.wants_mtp()? {
+            let head = self.mtp_head.as_ref().expect("wants_mtp loaded it");
+            return crate::mtp::generate_mtp_spec_metal(&self.model, head, prompt, max_new, |p| {
+                on_piece(p)
+            });
+        }
         self.ensure_session()?;
         self.model
             .generate_metal_session(self.session.as_mut().unwrap(), prompt, max_new, |p| {
@@ -652,6 +689,22 @@ impl ChatModel for CpuDenseChat {
             return Err(anyhow::anyhow!(
                 "the Metal backend is only available on macOS"
             ));
+        }
+        // CPU MTP (INFR_MTP=1 on a head-bearing qwen35 GGUF): the exact-f32 reference for the
+        // draft-verify loop — its acceptance rate is the oracle a GPU backend's alpha is judged
+        // against (a backend whose head numerics drift from its trunk shows a lower alpha here).
+        if std::env::var("INFR_MTP").ok().as_deref() == Some("1")
+            && self.model.config().n_layer_nextn > 0
+        {
+            let head = crate::mtp::load_mtp_head(self.model.gguf(), self.model.config())?;
+            return crate::mtp::generate_mtp_spec_cpu_timed(
+                &self.model,
+                &head,
+                prompt,
+                max_new,
+                |p| on_piece(p),
+            )
+            .map(|(stats, _)| stats);
         }
         self.model.generate_cpu(prompt, max_new, |p| on_piece(p))
     }

--- a/crates/infr-llama/src/mtp.rs
+++ b/crates/infr-llama/src/mtp.rs
@@ -771,6 +771,34 @@ impl<'a> MtpHeadSession<'a> {
         )
     }
 
+    /// Construct over the Metal backend (raw native-dtype upload — mirrors
+    /// `cpu_backend.rs`'s `generate_dense_metal_session` weight closure).
+    #[cfg(target_os = "macos")]
+    pub fn new_metal(
+        mtl: &'a infr_metal::MetalBackend,
+        g: &Gguf,
+        cfg: &crate::Config,
+        head: &MtpHeadWeights,
+        embed_table: &'a [f32],
+        max_ctx: usize,
+    ) -> Result<Self> {
+        Self::build(
+            mtl,
+            &|_name, tb, dt, _n| {
+                let buf = mtl
+                    .alloc(tb.len().max(1), BufferUsage::Weights)
+                    .map_err(|e| anyhow!("{e}"))?;
+                mtl.upload(buf.as_ref(), &tb).map_err(|e| anyhow!("{e}"))?;
+                Ok((buf, dt))
+            },
+            g,
+            cfg,
+            head,
+            embed_table,
+            max_ctx,
+        )
+    }
+
     fn build(
         be: &'a dyn Backend,
         bind_weight: &BindWeightFn,
@@ -1002,8 +1030,13 @@ pub const DEFAULT_N_MAX: usize = 6;
 /// self-speculative decoding). Returns `(logits [m*vocab], h [m*n_embd])`, `m = tokens.len() -
 /// (tokens already cached in `state`)`.
 #[allow(clippy::too_many_arguments)]
+/// One TARGET-trunk verify forward over `tokens`, returning (all-row logits, all-row hidden
+/// states) — the hidden rows are the extra tap the MTP head consumes. Backend-generic: the
+/// trunk graph is `generate_dense_backend` (which already takes `be` + a bind closure), so this
+/// drives Vulkan, Metal, or CPU by the caller's binder.
 fn run_verify(
-    vk: &infr_vulkan::VulkanBackend,
+    be: &dyn Backend,
+    bind: &BindWeightFn,
     g: &Gguf,
     cfg: &crate::Config,
     token_embd: &[f32],
@@ -1014,16 +1047,8 @@ fn run_verify(
     let mut logits = Vec::new();
     let mut h = Vec::new();
     crate::cpu_backend::generate_dense_backend(
-        vk,
-        &|_name, tb, dt, _n| {
-            let padded = infr_vulkan::linear::pad_to_u32_align(&tb);
-            let buf = vk
-                .alloc(padded.len(), BufferUsage::Weights)
-                .map_err(|e| anyhow!("{e}"))?;
-            vk.upload(buf.as_ref(), &padded)
-                .map_err(|e| anyhow!("{e}"))?;
-            Ok((buf, dt))
-        },
+        be,
+        bind,
         g,
         cfg,
         token_embd,
@@ -1190,6 +1215,130 @@ pub fn generate_mtp_spec_vulkan_timed(
     head: &MtpHeadWeights,
     prompt: &str,
     max_new: usize,
+    on_piece: impl FnMut(&str),
+) -> Result<(crate::GenStats, MtpTiming)> {
+    let cfg = model.config();
+    let max_ctx = model.encode(prompt)?.len() + max_new + DEFAULT_N_MAX + 8;
+    let vk = infr_vulkan::VulkanBackend::new().map_err(|e| anyhow!("vulkan init: {e}"))?;
+    let bind: &BindWeightFn = &|_name, tb, dt, _n| {
+        let padded = infr_vulkan::linear::pad_to_u32_align(&tb);
+        let buf = vk
+            .alloc(padded.len(), BufferUsage::Weights)
+            .map_err(|e| anyhow!("{e}"))?;
+        vk.upload(buf.as_ref(), &padded)
+            .map_err(|e| anyhow!("{e}"))?;
+        Ok((buf, dt))
+    };
+    let mut head_sess =
+        MtpHeadSession::new_vulkan(&vk, model.gguf(), cfg, head, model.token_embd(), max_ctx)?;
+    generate_mtp_spec_core(
+        &vk,
+        bind,
+        model,
+        &mut head_sess,
+        max_ctx,
+        prompt,
+        max_new,
+        on_piece,
+    )
+}
+
+/// Metal twin of [`generate_mtp_spec_vulkan_timed`] — the SAME draft-verify-catchup driver over
+/// the Apple-GPU trunk + head (raw native-dtype weight upload, `MtpHeadSession::new_metal`).
+#[cfg(target_os = "macos")]
+pub fn generate_mtp_spec_metal_timed(
+    model: &crate::CpuModel,
+    head: &MtpHeadWeights,
+    prompt: &str,
+    max_new: usize,
+    on_piece: impl FnMut(&str),
+) -> Result<(crate::GenStats, MtpTiming)> {
+    let cfg = model.config();
+    let max_ctx = model.encode(prompt)?.len() + max_new + DEFAULT_N_MAX + 8;
+    let mtl = infr_metal::MetalBackend::new().map_err(|e| anyhow!("metal init: {e}"))?;
+    let bind: &BindWeightFn = &|_name, tb, dt, _n| {
+        let buf = mtl
+            .alloc(tb.len().max(1), BufferUsage::Weights)
+            .map_err(|e| anyhow!("{e}"))?;
+        mtl.upload(buf.as_ref(), &tb).map_err(|e| anyhow!("{e}"))?;
+        Ok((buf, dt))
+    };
+    let mut head_sess =
+        MtpHeadSession::new_metal(&mtl, model.gguf(), cfg, head, model.token_embd(), max_ctx)?;
+    generate_mtp_spec_core(
+        &mtl,
+        bind,
+        model,
+        &mut head_sess,
+        max_ctx,
+        prompt,
+        max_new,
+        on_piece,
+    )
+}
+
+/// CPU MTP driver — the exact-f32 reference (no GPU). Same draft-verify-catchup loop; used to
+/// establish the acceptance-rate oracle (a backend whose head numerics differ from the trunk's
+/// shows up as a lower alpha here vs on a GPU backend).
+pub fn generate_mtp_spec_cpu_timed(
+    model: &crate::CpuModel,
+    head: &MtpHeadWeights,
+    prompt: &str,
+    max_new: usize,
+    on_piece: impl FnMut(&str),
+) -> Result<(crate::GenStats, MtpTiming)> {
+    let cfg = model.config();
+    let max_ctx = model.encode(prompt)?.len() + max_new + DEFAULT_N_MAX + 8;
+    let cpu = infr_cpu::CpuBackend::new();
+    let bind: &BindWeightFn = &|_name, tb, dt, _n| match tb {
+        crate::cpu_backend::WBytes::Mmap(tb) => Ok((cpu.map_weight(tb), dt)),
+        crate::cpu_backend::WBytes::Owned(v) => {
+            let buf = cpu
+                .alloc(v.len().max(1), BufferUsage::Weights)
+                .map_err(|e| anyhow!("{e}"))?;
+            cpu.upload(buf.as_ref(), &v).map_err(|e| anyhow!("{e}"))?;
+            Ok((buf, dt))
+        }
+    };
+    let mut head_sess =
+        MtpHeadSession::new_cpu(&cpu, model.gguf(), cfg, head, model.token_embd(), max_ctx)?;
+    generate_mtp_spec_core(
+        &cpu,
+        bind,
+        model,
+        &mut head_sess,
+        max_ctx,
+        prompt,
+        max_new,
+        on_piece,
+    )
+}
+
+/// Non-timed Metal MTP driver (drops the [`MtpTiming`]) — the `ChatModel::generate` entry.
+#[cfg(target_os = "macos")]
+pub fn generate_mtp_spec_metal(
+    model: &crate::CpuModel,
+    head: &MtpHeadWeights,
+    prompt: &str,
+    max_new: usize,
+    on_piece: impl FnMut(&str),
+) -> Result<crate::GenStats> {
+    generate_mtp_spec_metal_timed(model, head, prompt, max_new, on_piece).map(|(stats, _)| stats)
+}
+
+/// The backend-generic MTP draft-verify-catchup loop — the shared body of the `_vulkan`/`_metal`
+/// drivers. The trunk verify runs through `run_verify(be, bind, …)`; the draft head is the
+/// caller-built [`MtpHeadSession`] (bound to the same `be`). Everything between — draft, accept,
+/// catch-up, streaming — is backend-agnostic.
+#[allow(clippy::too_many_arguments)]
+fn generate_mtp_spec_core(
+    be: &dyn Backend,
+    bind: &BindWeightFn,
+    model: &crate::CpuModel,
+    head_sess: &mut MtpHeadSession,
+    max_ctx: usize,
+    prompt: &str,
+    max_new: usize,
     mut on_piece: impl FnMut(&str),
 ) -> Result<(crate::GenStats, MtpTiming)> {
     let cfg = model.config();
@@ -1201,22 +1350,16 @@ pub fn generate_mtp_spec_vulkan_timed(
     let hit_eos = |t: u32| !ignore_eos && (cfg.eos_ids.contains(&t) || t == cfg.eos);
 
     let prompt_tokens = model.encode(prompt)?;
-    anyhow::ensure!(
-        !prompt_tokens.is_empty(),
-        "generate_mtp_spec_vulkan: empty prompt"
-    );
+    anyhow::ensure!(!prompt_tokens.is_empty(), "generate_mtp_spec: empty prompt");
     let p = prompt_tokens.len();
-    let max_ctx = p + max_new + n_max + 8;
 
-    let vk = infr_vulkan::VulkanBackend::new().map_err(|e| anyhow!("vulkan init: {e}"))?;
     let mut trunk_state: Option<crate::cpu_backend::SeamKv> = None;
-    let mut head_sess =
-        MtpHeadSession::new_vulkan(&vk, model.gguf(), cfg, head, model.token_embd(), max_ctx)?;
 
     // ── prime: one VERIFY over the whole prompt, then catch the head up over it ──────────────
     let t_prime = std::time::Instant::now();
     let (logits0, h_rows0) = run_verify(
-        &vk,
+        be,
+        bind,
         model.gguf(),
         cfg,
         model.token_embd(),
@@ -1235,7 +1378,7 @@ pub fn generate_mtp_spec_vulkan_timed(
     if p > 1 {
         shifted_h[ne..].copy_from_slice(&h_rows0[..(p - 1) * ne]);
     }
-    catch_up(&mut head_sess, &prompt_tokens, &shifted_h, 0)?;
+    catch_up(head_sess, &prompt_tokens, &shifted_h, 0)?;
 
     let mut committed = prompt_tokens.clone();
     let mut id_last = prompt_tokens[p - 1];
@@ -1268,7 +1411,7 @@ pub fn generate_mtp_spec_vulkan_timed(
 
         let t_draft = std::time::Instant::now();
         let drafted = draft(
-            &mut head_sess,
+            head_sess,
             id_last,
             &pending_h,
             n_past,
@@ -1282,7 +1425,8 @@ pub fn generate_mtp_spec_vulkan_timed(
         feed.extend_from_slice(&cand);
         let t_verify = std::time::Instant::now();
         let (logits, h_rows) = run_verify(
-            &vk,
+            be,
+            bind,
             model.gguf(),
             cfg,
             model.token_embd(),
@@ -1326,7 +1470,7 @@ pub fn generate_mtp_spec_vulkan_timed(
         let catchup_h = &catchup_h_all[..(accepted + 1) * ne];
 
         let t_catchup = std::time::Instant::now();
-        catch_up(&mut head_sess, &catchup_tokens, catchup_h, n_past + 1)?;
+        catch_up(head_sess, &catchup_tokens, catchup_h, n_past + 1)?;
         let catchup_secs = t_catchup.elapsed().as_secs_f64();
         pending_h = catchup_h[accepted * ne..].to_vec();
         sum_draft_secs += draft_secs;

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -292,6 +292,16 @@ impl Backend for MetalBackend {
     }
 
     fn compile(&self, graph: &Graph) -> Result<Box<dyn Plan>> {
+        // Invalidate any recorded decode-replay tape: it belongs to the PREVIOUSLY compiled
+        // plan, and the tape only matches on a (op-sequence, bound-buffer-address) fingerprint —
+        // which can COLLIDE across independent compile+execute calls once the allocator reuses a
+        // freed buffer's address, replaying a structurally-stale tape (observed: the MTP head
+        // forward, which recompiles a decode-shaped graph every draft step with fresh IO buffers,
+        // intermittently got a garbage/zeroed replay of an earlier forward). The seam's decode
+        // loop — the ONLY intended replay user — compiles its plan ONCE and executes it per
+        // token, so its tape survives and still replays; anything that recompiles gets a clean
+        // slate and records afresh.
+        *self.replay.lock().unwrap() = None;
         Ok(GraphPlan::boxed(graph))
     }
 

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1213,6 +1213,43 @@ fn qknormrope_parity() {
     assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
 }
 
+// The qwen35 MTP head's exact QkNormRope shape: head_dim=256 with a PARTIAL rope_dim=64 (dims
+// 64..256 pass through unrotated) and a high freq_base (1e7). The `qknormrope_parity` above only
+// exercises head_dim==rope_dim==128 at theta 1e4, so partial rope at hd=256 was uncovered — the
+// one caller is the MTP head, whose per-draft decode diverged from CPU starting at position 2
+// (position 0's rotation is identity, so a rotation bug only shows once the angle is non-trivial).
+// rows here span positions 0..6 explicitly so the ≥2 positions are on the tested path.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn qknormrope_hd256_partial_parity() {
+    let (rows, nh, hd, rd) = (6usize, 16usize, 256usize, 64usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![hd], DType::F32));
+    let pos = g.input(TensorDesc::new(vec![rows], DType::I32));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::QkNormRope {
+        x,
+        weight: w,
+        positions: pos,
+        dst,
+        rows: rows as u32,
+        n_head: nh as u32,
+        head_dim: hd as u32,
+        rope_dim: rd as u32,
+        theta: 1.0e7,
+        eps: 1e-6,
+        freq_factors: None,
+    });
+    let positions: Vec<i32> = (0..rows as i32).collect(); // 0,1,2,3,4,5 — includes pos >= 2
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * nh * hd, 34))),
+        (w, f32_bytes(&rand_f32(hd, 35))),
+        (pos, i32_bytes(&positions)),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn writekv_f16_parity() {
@@ -1566,6 +1603,52 @@ fn attention_gqa_causal_parity() {
         (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 43))),
     ];
     assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+// rows==1 decode at hd=256 with a SHORT kv_len (< 128): rows*n_head < 128 so it's not a wide
+// launch, and kv_len < 128 so neither the vec nor split32 tier applies (split32 is hd<=128
+// only) — it routes to the 8-way `attnsplit_f16kv`. Every other hd=256 decode in the engine is
+// TAPED (attnvec_dyn_hd256), so this attnsplit path is otherwise unexercised; the MTP head's
+// per-draft-step decode is the one real caller (kv_len grows 1,2,3,… as the head accumulates
+// its own KV), and it diverged there from kv_len 3 on. GQA (nkv=4) like the qwen35 head.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_decode_hd256_short_kv_parity() {
+    for kv_len in [1usize, 2, 3, 5, 8] {
+        let (rows, nh, nkv, hd) = (1usize, 16usize, 4usize, 256usize);
+        let pos = kv_len - 1;
+        let mut g = Graph::new();
+        let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+        let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+        let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+        let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+        g.push(Op::Attention {
+            q,
+            k_cache: kc,
+            v_cache: vc,
+            dst,
+            rows: rows as u32,
+            kv_len: kv_len as u32,
+            n_head: nh as u32,
+            n_kv: nkv as u32,
+            head_dim: hd as u32,
+            scale: 1.0 / (hd as f32).sqrt(),
+            mask: infr_core::graph::AttnMask::Causal,
+            pos: pos as u32,
+        });
+        let bound = vec![
+            (q, f32_bytes(&rand_f32(rows * nh * hd, 71 + kv_len as u64))),
+            (
+                kc,
+                f16_bytes(&rand_f32(kv_len * nkv * hd, 72 + kv_len as u64)),
+            ),
+            (
+                vc,
+                f16_bytes(&rand_f32(kv_len * nkv * hd, 73 + kv_len as u64)),
+            ),
+        ];
+        assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+    }
 }
 
 // Wide launch, short context (rows*n_head >= 128, kv_len < 128): routes to the lean unsplit


### PR DESCRIPTION
Extends the MTP arc (issue #33) off the Vulkan-only path. The head session + the whole draft-verify-catchup loop were already backend-generic (`MtpHeadSession` holds a `&dyn Backend`; `run_verify` is just `generate_dense_backend`), so only three spots hardcoded Vulkan. Refactored those into a backend-generic core (`generate_mtp_spec_core`) with thin `_vulkan`/`_metal`/`_cpu` wrappers, added `MtpHeadSession::new_metal`, and wired `INFR_MTP` into `MetalSeamChat` + `CpuDenseChat`.

## Validation (Qwen3.5-4B-MTP UD-Q4_K_XL, M3 Pro)

**Correctness — solid on both new backends.** MTP output is token-identical to target-only greedy, every prompt tried (the same invariant the Vulkan path is pinned on). Verified on Metal and CPU.

**Perf — a Metal-specific gap, and the reason this lands "correct" not "fast":**

| backend | precision | alpha (accept rate) |
|---|---|---|
| CPU | exact f32 | **0.96** |
| Vulkan (reference) | f16 | ~0.95 |
| **Metal** | f16 | **0.26** |

CPU's 0.96 matches the Vulkan reference, so the **port logic is correct**. Metal's 0.26 is far lower — and since Vulkan f16 also hits ~0.95, it's **Metal-specific, not generic f16 rounding**. The trunk verify on Metal is already proven correct (spec-decode is token-identical there), so the divergence is in the **head forward's Metal execution**. At alpha 0.26 every reject triggers a full reprefill (qwen35 no-rewind), so MTP is currently **net-negative on Metal** — it needs the head numerics pinned before it's a win.

The `generate_mtp_spec_cpu_timed` driver is the exact-f32 acceptance oracle that made that diagnosis possible; it stays as the reference for the head-numerics follow-up (and is useful on its own).

## How to read this PR

Two things bundled: (1) the backend-generic refactor + CPU/Metal wiring (mergeable — correct, non-MTP paths untouched, `INFR_MTP` unset is a no-op), and (2) a precisely-localized Metal head-numerics bug handed back with an isolating experiment. If you'd rather I keep digging the head's per-op Metal numerics before this lands, say the word — I have the model cached and the CPU oracle to A/B against. Happy to split the refactor from the Metal path if you want the CPU oracle in now and the Metal path held.

Non-MTP models/paths untouched. Full matrix + 92 GPU parity green.

(Separate, noticed while validating: `DiffusionSess` trips clippy's `large_enum_variant` on macOS — the `#[cfg(macos)]` Metal variant makes the size spread — but the Linux clippy CI job never compiles that variant, so it's invisible there. Filing that separately.)