### PR TITLE
fix(metal): invalidate the decode-replay tape on compile — stale replay corrupted repeated forwards

### DIFF
--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -292,6 +292,16 @@ impl Backend for MetalBackend {
     }
 
     fn compile(&self, graph: &Graph) -> Result<Box<dyn Plan>> {
+        // Invalidate any recorded decode-replay tape: it belongs to the PREVIOUSLY compiled
+        // plan, and the tape only matches on a (op-sequence, bound-buffer-address) fingerprint —
+        // which can COLLIDE across independent compile+execute calls once the allocator reuses a
+        // freed buffer's address, replaying a structurally-stale tape (observed: the MTP head
+        // forward, which recompiles a decode-shaped graph every draft step with fresh IO buffers,
+        // intermittently got a garbage/zeroed replay of an earlier forward). The seam's decode
+        // loop — the ONLY intended replay user — compiles its plan ONCE and executes it per
+        // token, so its tape survives and still replays; anything that recompiles gets a clean
+        // slate and records afresh.
+        *self.replay.lock().unwrap() = None;
         Ok(GraphPlan::boxed(graph))
     }
 

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -1213,6 +1213,43 @@ fn qknormrope_parity() {
     assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
 }
 
+// The qwen35 MTP head's exact QkNormRope shape: head_dim=256 with a PARTIAL rope_dim=64 (dims
+// 64..256 pass through unrotated) and a high freq_base (1e7). The `qknormrope_parity` above only
+// exercises head_dim==rope_dim==128 at theta 1e4, so partial rope at hd=256 was uncovered — the
+// one caller is the MTP head, whose per-draft decode diverged from CPU starting at position 2
+// (position 0's rotation is identity, so a rotation bug only shows once the angle is non-trivial).
+// rows here span positions 0..6 explicitly so the ≥2 positions are on the tested path.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn qknormrope_hd256_partial_parity() {
+    let (rows, nh, hd, rd) = (6usize, 16usize, 256usize, 64usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![hd], DType::F32));
+    let pos = g.input(TensorDesc::new(vec![rows], DType::I32));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::QkNormRope {
+        x,
+        weight: w,
+        positions: pos,
+        dst,
+        rows: rows as u32,
+        n_head: nh as u32,
+        head_dim: hd as u32,
+        rope_dim: rd as u32,
+        theta: 1.0e7,
+        eps: 1e-6,
+        freq_factors: None,
+    });
+    let positions: Vec<i32> = (0..rows as i32).collect(); // 0,1,2,3,4,5 — includes pos >= 2
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(rows * nh * hd, 34))),
+        (w, f32_bytes(&rand_f32(hd, 35))),
+        (pos, i32_bytes(&positions)),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn writekv_f16_parity() {
@@ -1566,6 +1603,52 @@ fn attention_gqa_causal_parity() {
         (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 43))),
     ];
     assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+}
+
+// rows==1 decode at hd=256 with a SHORT kv_len (< 128): rows*n_head < 128 so it's not a wide
+// launch, and kv_len < 128 so neither the vec nor split32 tier applies (split32 is hd<=128
+// only) — it routes to the 8-way `attnsplit_f16kv`. Every other hd=256 decode in the engine is
+// TAPED (attnvec_dyn_hd256), so this attnsplit path is otherwise unexercised; the MTP head's
+// per-draft-step decode is the one real caller (kv_len grows 1,2,3,… as the head accumulates
+// its own KV), and it diverged there from kv_len 3 on. GQA (nkv=4) like the qwen35 head.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_decode_hd256_short_kv_parity() {
+    for kv_len in [1usize, 2, 3, 5, 8] {
+        let (rows, nh, nkv, hd) = (1usize, 16usize, 4usize, 256usize);
+        let pos = kv_len - 1;
+        let mut g = Graph::new();
+        let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+        let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+        let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+        let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+        g.push(Op::Attention {
+            q,
+            k_cache: kc,
+            v_cache: vc,
+            dst,
+            rows: rows as u32,
+            kv_len: kv_len as u32,
+            n_head: nh as u32,
+            n_kv: nkv as u32,
+            head_dim: hd as u32,
+            scale: 1.0 / (hd as f32).sqrt(),
+            mask: infr_core::graph::AttnMask::Causal,
+            pos: pos as u32,
+        });
+        let bound = vec![
+            (q, f32_bytes(&rand_f32(rows * nh * hd, 71 + kv_len as u64))),
+            (
+                kc,
+                f16_bytes(&rand_f32(kv_len * nkv * hd, 72 + kv_len as u64)),
+            ),
+            (
+                vc,
+                f16_bytes(&rand_f32(kv_len * nkv * hd, 73 + kv_len as u64)),
+            ),
+        ];
+        assert_parity(&g, &bound, dst, rows * nh * hd, 1e-4);
+    }
 }
 
 // Wide launch, short context (rows*n_head >= 128, kv_len < 128): routes to the lean unsplit


### PR DESCRIPTION
A latent correctness bug in the decode-replay tape, found while validating MTP on Metal (#36) — turned out **not** to be MTP head numerics at all.

## The bug

The tape (`Capabilities::decode_replay`) is stored per-backend and matched purely on a fingerprint of `(op sequence, bound-buffer addresses)`. That's sound for its one intended user — the seam's decode loop, which compiles a plan ONCE and executes it per token with stable bindings. It is **unsound** for any code that recompiles a decode-shaped graph with fresh IO buffers: once the allocator reuses a freed buffer's address, the new forward's fingerprint collides with an earlier recording and replays a **structurally-stale tape**.

## How it surfaced

The MTP head rebuilds a `rows==1` rope+attention graph every draft step with fresh e/h/pos/logits buffers. Intermittently it got an **all-zeroed replay** of a previous step's tape, which sporadically won the argmax at the last vocab row (248319 of 248320) → ~random draft rejections → acceptance rate 0.26 vs the CPU/f32 oracle's 0.96.

The isolation chain (all in this PR's new tests or ruled out):
- hd=256 short-kv attention: **parity-correct** (new test).
- hd=256 partial rope @ freq_base 1e7: **parity-correct** (new test).
- KV accumulation across executes, single head forward: correct.
- `INFR_METAL_PROFILE=3` (tape disabled): divergence **vanishes**.
- With the fix: head MTP acceptance **0.26 → 0.82**.

## The fix

Clear the tape in `compile()`. The seam decode loop compiles once and keeps replaying (0.6B tg128 **145.6 t/s, unchanged** — full replay speedup intact); anything that recompiles records afresh instead of replaying a stale tape. General fix, not MTP-specific — any repeated-compile decode-shaped workload was exposed.

## Verified

Spec-decode still token-identical; dense replay-on/off identity holds across models; 94 GPU parity (incl. the 2 new coverage cases); full matrix green. Independent of #36 — that MTP PR now rebases on this and becomes correct (still perf-bound by the huge-vocab lm_head, same as the Vulkan path).