### PR TITLE
fix(cpu): arch-gate the x86-only repack test import

### DIFF
--- a/crates/infr-cpu/src/kernels.rs
+++ b/crates/infr-cpu/src/kernels.rs
@@ -2906,6 +2906,10 @@ pub(crate) fn act_fn(act: Activation, g: f32) -> f32 {
 mod kernel_tests {
     use super::*;
     use crate::quant::{quantize_q8, quantize_q8_32};
+    // These pack/gemm helpers exist only on x86_64 (AVX2/AVX512-VNNI); the tests that use them
+    // gate their bodies on the same arch, so the import must be gated too or it fails to resolve
+    // on aarch64.
+    #[cfg(target_arch = "x86_64")]
     use crate::repack::{q4k_gemm_group, q4k_pack, q6k_gemm_group, q6k_pack};
     use infr_core::tensor::DType;
     use infr_gguf::dequant::dequant_block;


### PR DESCRIPTION
The `kernel_tests` module in `crates/infr-cpu/src/kernels.rs` imports `q4k_pack`, `q4k_gemm_group`, `q6k_pack`, and `q6k_gemm_group` from `crate::repack` unconditionally, but those helpers are defined only under `#[cfg(target_arch = "x86_64")]` (AVX2/AVX512-VNNI). The two tests that call them (`q6k_pack_gemm_bit_identical_to_batch`, `q4k_pack_gemm_bit_identical_to_scalar`) already gate their bodies on the same arch — only the top-level `use` was missed.

On aarch64 the imported symbols do not exist, so the import fails to resolve and `cargo test -p infr-cpu` does not compile:

```
error[E0432]: unresolved imports `crate::repack::q4k_gemm_group`, `crate::repack::q4k_pack`,
  `crate::repack::q6k_gemm_group`, `crate::repack::q6k_pack`
```

Surfaced building the workspace test suite on an Apple Silicon (M3 Pro) checkout of `main`.

**Fix:** gate the import on `target_arch = "x86_64"`, matching the call sites. No change on x86_64; unbreaks the aarch64 test build — `cargo test -p infr-cpu` compiles and 25 tests pass, with the x86-only pack/gemm tests compiling out as before.

Verified locally on aarch64: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --no-run --locked` all clean.