### PR TITLE
feat(cli): measure Metal MTP self-speculation in bench

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -1023,9 +1023,29 @@ fn bench_mtp_tg(
     let prompt = sentence.repeat(want.div_ceil(10));
     let mut samples = Vec::with_capacity(reps.max(1));
     let mut timing = infr_llama::mtp::MtpTiming::default();
+    // Backend selection mirrors the rest of the CLI: INFR_METAL routes the MTP driver onto the
+    // Apple-GPU trunk+head (issue #39 — measuring Metal's accept rate needs the Metal timed path,
+    // not Vulkan's), everything else stays on Vulkan. The two timed fns share a signature.
+    let use_metal = std::env::var("INFR_METAL").is_ok();
     for _ in 0..reps.max(1) {
-        let (stats, t) =
-            infr_llama::mtp::generate_mtp_spec_vulkan_timed(model, &head, &prompt, n_gen, |_| {})?;
+        let (stats, t) = if use_metal {
+            #[cfg(target_os = "macos")]
+            {
+                infr_llama::mtp::generate_mtp_spec_metal_timed(
+                    model,
+                    &head,
+                    &prompt,
+                    n_gen,
+                    |_| {},
+                )?
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                anyhow::bail!("INFR_METAL MTP bench requires macOS");
+            }
+        } else {
+            infr_llama::mtp::generate_mtp_spec_vulkan_timed(model, &head, &prompt, n_gen, |_| {})?
+        };
         samples.push(stats.n_gen as f64 / stats.decode_secs.max(1e-9));
         timing.add(&t);
     }
@@ -1154,7 +1174,16 @@ fn cmd_bench_metal(
         } else {
             format!("pp{n_prompt}")
         };
-        print_bench_avg(&samples, &label, depth, " [metal]", reps, json);
+        // MTP arm (issue #33/#39): twin of the Vulkan path's arm — a model shipping an MTP head
+        // gets its self-speculative Metal decode (accept rate + phase split) measured alongside the
+        // baseline tg above. `bench_mtp_tg` reads INFR_METAL (set here) to route onto the Metal
+        // timed driver. Models without a head keep `mtp = None` → byte-identical to the old output.
+        let mtp = if pg.is_none() && n_gen > 0 && model.config().n_layer_nextn > 0 {
+            Some(bench_mtp_tg(&model, n_prompt, depth, n_gen, reps)?)
+        } else {
+            None
+        };
+        print_bench_avg_mtp(&samples, &label, depth, reps, json, mtp.as_ref());
         Ok(())
     }
 }


### PR DESCRIPTION
The bench MTP arm (issue #33) only drove the Vulkan timed path, so `INFR_METAL=1 infr bench` on an MTP-head GGUF reported the baseline tg rate but no accept rate / phase split for Metal: `cmd_bench_metal` early-returns before the arm, and `bench_mtp_tg` hard-coded `generate_mtp_spec_vulkan_timed`.

**Change:** route `bench_mtp_tg` onto `generate_mtp_spec_metal_timed` under `INFR_METAL`, and add the same MTP arm to `cmd_bench_metal`. Non-MTP models and the Vulkan path are unchanged (`mtp = None` falls straight through to `print_bench_avg` — byte-identical output).

## Why — this closes out #39

Measuring the Metal accept rate is what #39 needed. On **Qwen3.5-4B-MTP UD-Q4_K_XL, M3 Pro**, current `main`:

```
tg128: 32.7 t/s | mtp128: 42.4 t/s (1.30x, alpha=0.95, draft 23% verify 64% catchup 12%)
tg256: 33.2 t/s | mtp256: 44.2 t/s (1.33x, alpha=0.97, draft 23% verify 64% catchup 13%)
tg128: 32.8 t/s | mtp128: 39.6 t/s (1.21x, alpha=0.95, draft 21% verify 68% catchup 11%)
```

Metal **alpha = 0.95–0.97**, matching Vulkan (0.95) and the CPU f32 oracle (0.96) — up from the **0.26** #39 tracked. The gap was the decode-replay tape fingerprint collision fixed in **#38**, not head numerics. MTP is now **net-positive on Metal (1.2–1.3×)** where it used to be net-negative, and stays **token-identical to greedy** (verified: `INFR_MTP=1` vs plain greedy at temp 0, byte-identical 200-token output).

I will post the same numbers to #39 and suggest closing it.

Verified locally on aarch64 (M3 Pro): `cargo fmt --all -- --check`, `cargo clippy -p infr-cli --all-targets --locked -- -D warnings`, and `RUSTFLAGS="-D warnings" cargo test -p infr-cli --no-run` all clean.