### PR TITLE
perf(metal): route the wide lm_head off mrv onto cmm at m=2..8 (#35)

### DIFF
--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1474,6 +1474,20 @@ impl MetalBackend {
                         "linear_q6k" => Some("linear_q6k_mrv"),
                         _ => None,
                     };
+                    // mrv's edge (weight bytes hoisted to registers, reused across the 2..8 rows)
+                    // was tuned on the per-layer projections (out_f <= 9216). The tied lm_head is
+                    // out_f = 248320 — 27x wider — where mrv spawns out_f/2 * m (~870k) simdgroups
+                    // and loses to the cmm GEMM tile, which streams the weight once at GEMM rate.
+                    // Measured on qwen3.5-4B-MTP verify (m=7): routing the lm_head to cmm is +8% on
+                    // the MTP cycle (1.30x -> 1.39x), token-identical to greedy. Gate at 65536 —
+                    // comfortably above every per-layer out_f, below any real lm_head/vocab width.
+                    // INFR_METAL_LMHEAD_MRV forces the old mrv path (A/B + escape hatch).
+                    let mr_kern =
+                        if out_f >= 65536 && std::env::var("INFR_METAL_LMHEAD_MRV").is_err() {
+                            None
+                        } else {
+                            mr_kern
+                        };
                     if let (true, Some(kn), 0) = ((2..=8).contains(&m), mr_kern, w_off) {
                         let pso = self.pipelines.get(kn)?;
                         let sgs = out_f.div_ceil(2) * m;


### PR DESCRIPTION
One of #35's candidates: *"lm_head at 51% of verify GPU time — check whether the batched GEMM tier beats mrow at m=7 for out_f this wide."* Answer on Metal: **yes.**

The multi-row GEMV (`mrv`) path for m=2..8 K-quant Linears — speculative VERIFY's k+1 candidate rows, short suffix prefills — hoists weight bytes to registers and reuses them across the rows. It was tuned on the per-layer projections, whose `out_f` is ≤ 9216. The tied lm_head is `out_f = 248320` (vocab), 27× wider, where `mrv` spawns `out_f/2 * m` (~870k) simdgroups and loses to the `cmm` GEMM tile that streams the weight once at GEMM rate.

**Change:** gate the `mrv` path to `out_f < 65536` (comfortably above every per-layer projection, below any real vocab width), so the lm_head verify GEMV takes `cmm`. `INFR_METAL_LMHEAD_MRV` forces the old path (A/B + escape hatch).

## Measured (M3 Pro)

qwen3.5-4B-MTP UD-Q4_K_XL, MTP self-speculation (`INFR_METAL=1 infr bench -n 128`, needs the arm from #42), 3 clean alternating reps:

```
cmm (new): 46.1 / 46.0 / 45.9 t/s
mrv (old): 42.5 / 42.5 / 42.4 t/s     → +8.3% on the MTP cycle
```

Qwen3-0.6B self-speculation (vocab 151936, also ≥ 65536 → same reroute):

```
cmm (new): 127.7 / 127.8 tok/s
mrv (old): 124.4 / 124.1 tok/s        → +2.8%
```

So it generalizes to any large-`out_f` m=2..8 verify, not just qwen3.5.

## Correctness

Token-identical to plain greedy **and** to the old mrv path — verified `INFR_MTP=1` (default cmm) vs greedy and vs `INFR_METAL_LMHEAD_MRV=1` across four diverse prompts (prose, code, lists, haiku), byte-identical. Full `infr-metal` parity suite 94/94 on the M3. Alpha unchanged (0.95).

Verified locally on aarch64: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test -p infr-metal --no-run`, parity `--include-ignored` 94/94.

Note: the MTP bench numbers use the Metal MTP arm from #42 (open); the change itself is independent and also measurable via the spec-decode path above.