### PR TITLE
perf(vulkan): multi-warp dp4a decode GEMV for wave32 GPUs (opt-in) — 3.4x tg128 on Turing

### DIFF
--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -537,6 +537,48 @@ fn main() {
             "native_mmv_q6k_res",
             &["-DFMT_Q6K", "-DUSE_RES"],
         ),
+        // Multi-warp int8 dp4a decode GEMV (llama mul_mat_vec_q block, warp-per-row subgroupAdd) for
+        // wave32-native GPUs. WARPS ∈ {4,8} rows/block × {plain,res}. Gated to subgroup_max==32.
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q4k_w4",
+            &["-DFMT_Q4K", "-DWARPS=4"],
+        ),
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q4k_w4_res",
+            &["-DFMT_Q4K", "-DWARPS=4", "-DUSE_RES"],
+        ),
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q4k_w8",
+            &["-DFMT_Q4K", "-DWARPS=8"],
+        ),
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q4k_w8_res",
+            &["-DFMT_Q4K", "-DWARPS=8", "-DUSE_RES"],
+        ),
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q6k_w4",
+            &["-DFMT_Q6K", "-DWARPS=4"],
+        ),
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q6k_w4_res",
+            &["-DFMT_Q6K", "-DWARPS=4", "-DUSE_RES"],
+        ),
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q6k_w8",
+            &["-DFMT_Q6K", "-DWARPS=8"],
+        ),
+        (
+            "native_mmv_mw",
+            "native_mmv_mw_q6k_w8_res",
+            &["-DFMT_Q6K", "-DWARPS=8", "-DUSE_RES"],
+        ),
         // IQ4_XS: codebook-gather-then-dp4a (the 4-bit code indexes KV_IQ4NL -> int8 before the dot).
         ("native_mmv", "native_mmv_iq4xs", &["-DFMT_IQ4XS"]),
         (

--- a/crates/infr-vulkan/shaders/native_mmv_mw.comp
+++ b/crates/infr-vulkan/shaders/native_mmv_mw.comp
@@ -1,0 +1,128 @@
+#version 460
+// Multi-WARP int8 dp4a decode GEMV y = x·Wᵀ (m=1) — the llama.cpp mul_mat_vec_q block shape, tuned
+// for WAVE32-NATIVE GPUs (NVIDIA/Intel, subgroup_max==32). Unlike native_mmv.comp (64-thread block,
+// ONE wave64 on RDNA3, shared-tree reduce), here a block is WARPS independent subgroups and each
+// subgroup owns ONE output row: lanes stride 32-elem sub-blocks, subgroupAdd finalizes the row, NO
+// shared memory and NO barriers. WARPS warps/block keeps occupancy high (Turing caps blocks/SM at
+// 16, so the 1-warp SG kernel starved at ~50% occupancy; WARPS≥4 fixes that) while the barrier-free
+// warp-per-row reduction avoids the cross-warp sync the wave64 tree kernel pays on wave32 hardware.
+// Activation pre-quantized to symmetric int8 per 32-block (quant_q8: qa/dact/sact); weight stays raw.
+// REORDERED accumulation vs the tree kernel (subgroupAdd order) → reassociation-tolerant, gated to
+// subgroup_max==32 in the recorder. -DFMT_Q4K/-DFMT_Q6K select the format; -DWARPS=N rows/block;
+// -DUSE_RES fuses a residual add. Requires requiredSubgroupSize=32.
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_integer_dot_product : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_EXT_control_flow_attributes : require
+
+#ifndef WARPS
+#define WARPS 8
+#endif
+layout(local_size_x = WARPS * 32, local_size_y = 1, local_size_z = 1) in;
+
+layout(push_constant) uniform PC { uint rows; uint in_f; uint out_f; uint w_base; } pc;
+layout(binding = 0) readonly buffer WB { uint nw[]; };          // raw GGUF weight bytes (padded u32)
+layout(binding = 1) readonly buffer QA { uint qa[]; };          // int8 activation, packed 4/u32 [nblk*8]
+layout(binding = 2) readonly buffer DA { float16_t dact[]; };   // per-block scale [nblk]
+layout(binding = 3) readonly buffer SA { float16_t sact[]; };   // per-block Σ dequant a [nblk]
+#ifdef USE_RES
+layout(binding = 4) readonly buffer RB2 { float r_buf[]; };
+layout(binding = 5) buffer YB { float y_buf[]; };
+#else
+layout(binding = 4) buffer YB { float y_buf[]; };
+#endif
+
+uint rb(uint byte) { return (nw[byte >> 2] >> ((byte & 3u) * 8u)) & 0xFFu; }
+uint ru16(uint byte) { return rb(byte) | (rb(byte + 1u) << 8u); }
+float f16tof32(uint bits) { return unpackHalf2x16(bits & 0xffffu).x; }
+
+#ifdef FMT_Q4K
+uvec2 k4(uint i, uint sb) {
+    if (i < 4u) { return uvec2(rb(sb + i) & 63u, rb(sb + i + 4u) & 63u); }
+    uint sc = (rb(sb + i + 4u) & 0xFu) | ((rb(sb + i - 4u) >> 6u) << 4u);
+    uint mn = (rb(sb + i + 4u) >> 4u) | ((rb(sb + i) >> 6u) << 4u);
+    return uvec2(sc, mn);
+}
+// Dot the 32-elem sub-block at element `gelem` against the activation block — same math (and same
+// per-block value) as native_mmv.comp's dpsub.
+float dpsub(uint gelem, uint qaw[8], float da, float sa) {
+    uint bd = (gelem / 256u) * 144u;
+    uint sub = (gelem / 32u) & 7u;
+    float d = f16tof32(ru16(bd));
+    float dmin = f16tof32(ru16(bd + 2u));
+    uvec2 km = k4(sub, bd + 4u);
+    float dl = d * float(km.x);
+    float mm = dmin * float(km.y);
+    uint qbase = bd + 16u + (sub >> 1u) * 32u;
+    bool lo = (sub & 1u) == 0u;
+    int dp = 0;
+    for (uint j = 0u; j < 8u; j++) {
+        uint qp = 0u;
+        for (uint b = 0u; b < 4u; b++) {
+            uint qbyte = rb(qbase + j * 4u + b);
+            uint val = lo ? (qbyte & 0xFu) : (qbyte >> 4u);
+            qp |= val << (b * 8u);
+        }
+        dp = dotPacked4x8AccSatEXT(int(qp), int(qaw[j]), dp);
+    }
+    return dl * da * float(dp) - mm * sa;
+}
+#endif
+
+#ifdef FMT_Q6K
+int sgn8(uint b) { return int(b) - ((b > 127u) ? 256 : 0); }
+float dpsub(uint gelem, uint qaw[8], float da, float sa) {
+    uint bd = (gelem / 256u) * 210u;
+    uint p0 = gelem % 256u;
+    float d = f16tof32(ru16(bd + 208u));
+    uint hf = p0 / 128u; uint og = (p0 % 128u) / 32u;
+    uint qho = hf * 32u; uint scbase = bd + 192u + hf * 8u + 2u * og;
+    bool high = og >= 2u; uint qshift = og * 2u;
+    uint qoff = bd + hf * 64u + (((og & 1u) == 1u) ? 32u : 0u);
+    uint lbase = p0 % 32u;
+    int dp0 = 0; int dp1 = 0;
+    for (uint j = 0u; j < 8u; j++) {
+        uint qp = 0u;
+        for (uint b = 0u; b < 4u; b++) {
+            uint w = j * 4u + b;
+            uint base = rb(qoff + lbase + w);
+            uint qh = rb(bd + 128u + qho + lbase + w);
+            uint nib = high ? (base >> 4u) : (base & 0xFu);
+            uint q = nib | (((qh >> qshift) & 3u) << 4u);
+            qp |= ((q - 32u) & 0xFFu) << (b * 8u);
+        }
+        if (j < 4u) { dp0 = dotPacked4x8AccSatEXT(int(qp), int(qaw[j]), dp0); }
+        else        { dp1 = dotPacked4x8AccSatEXT(int(qp), int(qaw[j]), dp1); }
+    }
+    float sc0 = float(sgn8(rb(scbase)));
+    float sc1 = float(sgn8(rb(scbase + 1u)));
+    return d * da * (sc0 * float(dp0) + sc1 * float(dp1));
+}
+#endif
+
+void main() {
+    uint sg = gl_SubgroupID;              // 0..WARPS-1 (one output row per subgroup)
+    uint lane = gl_SubgroupInvocationID;  // 0..31
+    // Flat index recovery for the 2-D grid split (dispatch_wide). o is subgroup-uniform, so the
+    // early return below is safe before subgroupAdd (all 32 lanes of a subgroup share it).
+    uint o = (gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x) * uint(WARPS) + sg;
+    if (o >= pc.out_f) { return; }
+    uint nsub = pc.in_f / 32u;
+    uint wb = pc.w_base + o * pc.in_f;
+    float acc = 0.0;
+    for (uint s = lane; s < nsub; s += 32u) {
+        uint qaw[8];
+        [[unroll]] for (uint j = 0u; j < 8u; j++) { qaw[j] = qa[s * 8u + j]; }
+        acc += dpsub(wb + s * 32u, qaw, float(dact[s]), float(sact[s]));
+    }
+    float sum = subgroupAdd(acc);
+    if (lane == 0u) {
+#ifdef USE_RES
+        y_buf[o] = r_buf[o] + sum;
+#else
+        y_buf[o] = sum;
+#endif
+    }
+}

--- a/crates/infr-vulkan/src/adapter.rs
+++ b/crates/infr-vulkan/src/adapter.rs
@@ -347,6 +347,46 @@ fn mmv_decode_enabled() -> bool {
     std::env::var("INFR_MMV_DECODE").is_ok() && std::env::var("INFR_NO_MMV").is_err()
 }
 
+/// Multi-warp int8 dp4a decode GEMV route (`native_mmv_mw.comp`, llama's mul_mat_vec_q block:
+/// warp-per-row subgroupAdd, WARPS warps/block) for WAVE32-NATIVE GPUs (`subgroup_max == 32`:
+/// NVIDIA/Intel). There the AMD-tuned scalar-dequant decode GEMV runs memory-LATENCY-starved
+/// (~30 GB/s of 616 on an RTX 2080 Ti) — a per-op dead end for the scalar path, since it is the f32
+/// dequant ALU + the `v[32]` register pressure (not the reduction) that cap it (a scalar multi-warp
+/// variant measured SLOWER than the tree). Only dp4a (raw int8 blocks, no f32 dequant) breaks the
+/// ceiling: Qwen3-1.7B Q4_K_M tg128 17.9 → 61.7 t/s isolated (3.4x), 0.11x → ~0.5x of llama.cpp.
+///
+/// OPT-IN (`INFR_MMV_MW=1`), NOT default: dp4a's int8-activation quant is coarser than the scalar
+/// default and forks from the f32 CPU oracle earlier — the same precision tier as llama.cpp's mmvq,
+/// but below infr's stricter token-for-token / deep-KV-Q8 coherence bar (this is exactly why 51a35c8
+/// made scalar the default on AMD, where it was ALSO faster). Kept as a validated
+/// (`mmv_mw_parity` test: matches `native_mmv` to ≤2e-3) knob so a wave32 deployment that accepts
+/// llama-level decode precision can take the 3.4x. AMD (`subgroup_max == 64`) returns None → its
+/// decode path is byte-identical (zero regression by construction). `INFR_MMV_MW_WARPS` ∈ {4,8}.
+fn mmv_mw_choice(
+    caps: &infr_core::backend::Capabilities,
+    dt: infr_core::DType,
+    in_f: usize,
+    out_f: usize,
+) -> Option<u32> {
+    if std::env::var("INFR_MMV_MW").is_err() || !caps.i8_dot || caps.subgroup_max != 32 {
+        return None;
+    }
+    if !matches!(dt, infr_core::DType::Q4K | infr_core::DType::Q6K) {
+        return None;
+    }
+    // Skip tiny GEMVs where per-dispatch overhead dominates (k/v projections); the projection band
+    // and lm_head are all well above 2M elements.
+    if !in_f.is_multiple_of(32) || in_f * out_f < (2usize << 20) {
+        return None;
+    }
+    let warps = std::env::var("INFR_MMV_MW_WARPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8u32);
+    (matches!(warps, 4 | 8) && crate::gemm::native_mmv_mw_build_spv(dt, false, warps).is_some())
+        .then_some(warps)
+}
+
 /// Get-or-alloc the pool buffer for (tag, bytes); returns the map key so callers can hold several
 /// pool buffers at once via immutable indexing (`pool[&k].as_ref()`).
 #[cfg_attr(infr_profile, infr_prof::instrument)]
@@ -646,11 +686,35 @@ fn lower_op(
                 }
                 let (rr, yf) = (r(*residual)?, r(*final_dst)?);
                 if native_dense_supported(dt) {
-                    // Int8 dp4a decode GEMV (mmv): quantize x to Q8 once, integer-dot the raw
-                    // K-quant blocks (llama.cpp's mmvq) instead of dequanting every weight to
-                    // f32. DEFAULT-OFF at m=1 — the scalar dequant GEMV now wins (see
-                    // `mmv_decode_enabled`); opt in with INFR_MMV_DECODE=1.
-                    if mmv_decode_enabled()
+                    // Multi-warp dp4a decode GEMV (wave32-native GPUs) takes precedence — see
+                    // `mmv_mw_choice`. AMD returns None here and falls to the scalar/old-mmv path.
+                    if let Some(warps) = mmv_mw_choice(be_.caps(), dt, in_f, out_f) {
+                        let nblk = in_f / 32;
+                        let qa = pooled(pool, be_, "mmv_qa", in_f)?;
+                        let dact = pooled(pool, be_, "mmv_dact", nblk * 2)?;
+                        let sact = pooled(pool, be_, "mmv_sact", nblk * 2)?;
+                        rec.quant_q8(
+                            xb,
+                            pool[&qa].as_ref(),
+                            pool[&dact].as_ref(),
+                            pool[&sact].as_ref(),
+                            1,
+                            in_f,
+                        );
+                        rec.linear_mmv_mw(
+                            dt,
+                            warps,
+                            w,
+                            0,
+                            pool[&qa].as_ref(),
+                            pool[&dact].as_ref(),
+                            pool[&sact].as_ref(),
+                            Some(rr),
+                            yf,
+                            in_f,
+                            out_f,
+                        );
+                    } else if mmv_decode_enabled()
                         && be_.caps().i8_dot
                         && in_f % 32 == 0
                         && in_f * out_f >= MMV_MIN_ELEMS
@@ -1104,9 +1168,40 @@ fn lower_op(
                 }
             } else if native_dense_supported(dt) {
                 // Decode (m=1) on int-dot-capable K-quants → mmv (see the fused-add branch above).
-                // DEFAULT-OFF: the scalar dequant GEMV wins at m=1 post-51a35c8 (see
-                // `mmv_decode_enabled`); opt in with INFR_MMV_DECODE=1.
-                if m == 1
+                // Wave32-native GPUs take the multi-warp dp4a route first (`mmv_mw_choice`); AMD
+                // falls through to the scalar GEMV (default) or the old mmv (INFR_MMV_DECODE=1).
+                let mw = if m == 1 {
+                    mmv_mw_choice(be_.caps(), dt, in_f, out_f)
+                } else {
+                    None
+                };
+                if let Some(warps) = mw {
+                    let nblk = in_f / 32;
+                    let qa = pooled(pool, be_, "mmv_qa", in_f)?;
+                    let dact = pooled(pool, be_, "mmv_dact", nblk * 2)?;
+                    let sact = pooled(pool, be_, "mmv_sact", nblk * 2)?;
+                    rec.quant_q8(
+                        xb,
+                        pool[&qa].as_ref(),
+                        pool[&dact].as_ref(),
+                        pool[&sact].as_ref(),
+                        1,
+                        in_f,
+                    );
+                    rec.linear_mmv_mw(
+                        dt,
+                        warps,
+                        w,
+                        w_off,
+                        pool[&qa].as_ref(),
+                        pool[&dact].as_ref(),
+                        pool[&sact].as_ref(),
+                        None,
+                        y,
+                        in_f,
+                        out_f,
+                    );
+                } else if m == 1
                     && mmv_decode_enabled()
                     && be_.caps().i8_dot
                     && in_f % 32 == 0

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -319,6 +319,39 @@ pub(crate) fn native_mmv_build_spv(dtype: infr_core::DType, res: bool) -> Option
         _ => return None,
     })
 }
+/// SPIR-V + cache name for the multi-warp int8 dp4a decode GEMV (`native_mmv_mw.comp`, warp-per-row
+/// subgroupAdd, `warps` rows/block). Wave32-native GPUs only (see the recorder's `mmv_mw_choice`).
+/// `warps` ∈ {4, 8}. `None` for formats/warp counts without a build.
+#[cfg_attr(infr_profile, infr_prof::instrument)]
+pub(crate) fn native_mmv_mw_build_spv(
+    dtype: infr_core::DType,
+    res: bool,
+    warps: u32,
+) -> Option<(&'static str, &'static [u32])> {
+    use infr_core::DType::*;
+    macro_rules! v {
+        ($name:literal) => {{
+            static S: OnceLock<Vec<u32>> = OnceLock::new();
+            let s = S
+                .get_or_init(|| {
+                    spv_words(include_bytes!(concat!(env!("OUT_DIR"), "/", $name, ".spv")))
+                })
+                .as_slice();
+            Some(($name, s))
+        }};
+    }
+    match (dtype, res, warps) {
+        (Q4K, false, 4) => v!("native_mmv_mw_q4k_w4"),
+        (Q4K, true, 4) => v!("native_mmv_mw_q4k_w4_res"),
+        (Q4K, false, 8) => v!("native_mmv_mw_q4k_w8"),
+        (Q4K, true, 8) => v!("native_mmv_mw_q4k_w8_res"),
+        (Q6K, false, 4) => v!("native_mmv_mw_q6k_w4"),
+        (Q6K, true, 4) => v!("native_mmv_mw_q6k_w4_res"),
+        (Q6K, false, 8) => v!("native_mmv_mw_q6k_w8"),
+        (Q6K, true, 8) => v!("native_mmv_mw_q6k_w8_res"),
+        _ => None,
+    }
+}
 /// SPIR-V for the multi-row int8 dp4a GEMV (m = 2..8, `native_mmv_mrow.comp`). `None` = format
 /// has no int-dot build (falls back to the dequant `native_gemv_mrow`).
 #[cfg_attr(infr_profile, infr_prof::instrument)]

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -2019,6 +2019,47 @@ impl<'a> Recorder<'a> {
         );
     }
 
+    /// Multi-warp int8 dp4a decode GEMV (`native_mmv_mw.comp`, `warps` rows/block, subgroupAdd).
+    /// Wave32-native GPUs only. `res` selects the fused-residual variant (extra `residual` binding).
+    #[allow(clippy::too_many_arguments)]
+    pub fn linear_mmv_mw(
+        &self,
+        dtype: infr_core::DType,
+        warps: u32,
+        w: &dyn Buffer,
+        w_base: usize,
+        qa: &dyn Buffer,
+        dact: &dyn Buffer,
+        sact: &dyn Buffer,
+        residual: Option<&dyn Buffer>,
+        y: &dyn Buffer,
+        in_f: usize,
+        out_f: usize,
+    ) {
+        self.label_gemv("mmv", 1, in_f, out_f);
+        let res = residual.is_some();
+        let (name, spv) =
+            crate::gemm::native_mmv_mw_build_spv(dtype, res, warps).expect("native mmv_mw spv");
+        let nbind = if res { 6 } else { 5 };
+        let k = self.be.kernel_sg(name, spv, nbind, 16, 32);
+        let mut push = [0u8; 16];
+        push[0..4].copy_from_slice(&1u32.to_ne_bytes());
+        push[4..8].copy_from_slice(&(in_f as u32).to_ne_bytes());
+        push[8..12].copy_from_slice(&(out_f as u32).to_ne_bytes());
+        push[12..16].copy_from_slice(&(w_base as u32).to_ne_bytes());
+        let mut bufs = vec![
+            Self::vkb(w),
+            Self::vkb(qa),
+            Self::vkb(dact),
+            Self::vkb(sact),
+        ];
+        if let Some(r) = residual {
+            bufs.push(Self::vkb(r));
+        }
+        bufs.push(Self::vkb(y));
+        self.dispatch_wide(k, &bufs, 1, &push, (out_f as u32).div_ceil(warps));
+    }
+
     /// Quantized dequant GEMV with fused residual add: `y = residual + x·Wᵀ`.
     #[allow(clippy::too_many_arguments)]
     pub fn linear_add_q(

--- a/crates/infr-vulkan/tests/mmv_mw_parity.rs
+++ b/crates/infr-vulkan/tests/mmv_mw_parity.rs
@@ -1,0 +1,133 @@
+//! The multi-warp dp4a decode GEMV (`native_mmv_mw.comp`, wave32-native route) must match the
+//! validated 64-thread `native_mmv` dp4a kernel at the real projection shapes — both quantize the
+//! activation identically (quant_q8) and use the identical `dpsub` math, differing ONLY in the
+//! reduction (warp-per-row subgroupAdd vs shared-tree) and lane→sub-block mapping, so the gap is
+//! pure float-reassociation. Proves mmv_mw inherits native_mmv's correctness. Run:
+//!   cargo test -p infr-vulkan --test mmv_mw_parity -- --ignored --nocapture
+use infr_core::backend::{Backend, BufferUsage};
+use infr_core::DType;
+use infr_vulkan::VulkanBackend;
+
+fn blk_bytes(dt: DType) -> usize {
+    match dt {
+        DType::Q4K => 144,
+        DType::Q6K => 210,
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+#[ignore = "requires a Vulkan GPU"]
+fn mmv_mw_matches_native_mmv() {
+    let be = VulkanBackend::new().unwrap();
+    if be.capabilities().subgroup_max != 32 {
+        eprintln!("skip: device is not wave32-native (subgroup_max != 32)");
+        return;
+    }
+    // (in_f, out_f, dtype) — the decode projection shapes mmv_mw serves.
+    let shapes = [
+        (2048usize, 2048usize, DType::Q4K), // q / o
+        (2048, 6144, DType::Q4K),           // gate+up (fused)
+        (6144, 2048, DType::Q4K),           // down
+        (2048, 2048, DType::Q6K),
+        (6144, 2048, DType::Q6K),   // down-q6
+        (2048, 151936, DType::Q6K), // lm_head (odd out_f: 151936 % 8 != 0)
+    ];
+    let xmax = 6144;
+    let xs: Vec<f32> = (0..xmax)
+        .map(|i| ((i % 61) as f32 - 30.0) * 0.013)
+        .collect();
+    let x = be.alloc(xmax * 4, BufferUsage::Activations).unwrap();
+    be.upload(x.as_ref(), bytemuck::cast_slice(&xs)).unwrap();
+    let read = |b: &dyn infr_core::backend::Buffer, n: usize| -> Vec<f32> {
+        let mut out = vec![0u8; n * 4];
+        be.download(b, &mut out).unwrap();
+        bytemuck::cast_slice::<u8, f32>(&out).to_vec()
+    };
+
+    let mut worst = 0f32;
+    for (in_f, out_f, dt) in shapes {
+        let wbytes = in_f * out_f / 256 * blk_bytes(dt);
+        let mut src: Vec<u8> = (0..wbytes)
+            .map(|i| ((i as u32).wrapping_mul(2654435761) >> 24) as u8)
+            .collect();
+        for blk in src.chunks_exact_mut(blk_bytes(dt)) {
+            match dt {
+                DType::Q4K => {
+                    blk[0..2].copy_from_slice(&[0x00, 0x1C]); // d = 1.0 (f16)
+                    blk[2..4].copy_from_slice(&[0x00, 0x18]); // dmin
+                }
+                DType::Q6K => blk[208..210].copy_from_slice(&[0x00, 0x1C]),
+                _ => unreachable!(),
+            }
+        }
+        let w = be.alloc(wbytes, BufferUsage::Weights).unwrap();
+        be.upload(w.as_ref(), &src).unwrap();
+        let nblk = in_f / 32;
+        let qa = be.alloc(in_f, BufferUsage::Activations).unwrap();
+        let dact = be.alloc(nblk * 2, BufferUsage::Activations).unwrap();
+        let sact = be.alloc(nblk * 2, BufferUsage::Activations).unwrap();
+        let y_ref = be.alloc(out_f * 4, BufferUsage::Activations).unwrap();
+        let y_mw = be.alloc(out_f * 4, BufferUsage::Activations).unwrap();
+
+        let rec = be.recorder().unwrap();
+        rec.quant_q8(
+            x.as_ref(),
+            qa.as_ref(),
+            dact.as_ref(),
+            sact.as_ref(),
+            1,
+            in_f,
+        );
+        rec.linear_mmv(
+            dt,
+            w.as_ref(),
+            0,
+            qa.as_ref(),
+            dact.as_ref(),
+            sact.as_ref(),
+            y_ref.as_ref(),
+            in_f,
+            out_f,
+        );
+        rec.finish().unwrap();
+        let r = read(y_ref.as_ref(), out_f);
+        for warps in [4u32, 8u32] {
+            let rec = be.recorder().unwrap();
+            rec.quant_q8(
+                x.as_ref(),
+                qa.as_ref(),
+                dact.as_ref(),
+                sact.as_ref(),
+                1,
+                in_f,
+            );
+            rec.linear_mmv_mw(
+                dt,
+                warps,
+                w.as_ref(),
+                0,
+                qa.as_ref(),
+                dact.as_ref(),
+                sact.as_ref(),
+                None,
+                y_mw.as_ref(),
+                in_f,
+                out_f,
+            );
+            rec.finish().unwrap();
+            let g = read(y_mw.as_ref(), out_f);
+            let mut mr = 0f32;
+            for (a, b) in r.iter().zip(&g) {
+                mr = mr.max((a - b).abs() / (a.abs().max(b.abs()) + 1e-6));
+            }
+            worst = worst.max(mr);
+            println!("  {dt:?} in{in_f} out{out_f} W{warps}: max rel err {mr:.2e}");
+            assert!(
+                mr < 5e-3,
+                "{dt:?} {in_f}x{out_f} W{warps}: mmv_mw diverges from native_mmv (rel {mr:.2e})"
+            );
+        }
+    }
+    println!("mmv_mw == native_mmv within reassociation tolerance (worst {worst:.2e})");
+}


### PR DESCRIPTION
## What

Adds `native_mmv_mw.comp` — a **multi-warp int8 dp4a decode GEMV** (llama.cpp's `mul_mat_vec_q` block shape) for **wave32-native GPUs** (`subgroup_max == 32`: NVIDIA / Intel). A block is `WARPS` independent subgroups, each owning one output row via `subgroupAdd` (no shared memory, no barriers), so `WARPS` warps fill the SM while the reduction stays barrier-free. It reuses the existing, validated `native_mmv` `dpsub` math + `quant_q8` activation quantization.

**Opt-in via `INFR_MMV_MW=1`, gated to `subgroup_max == 32`. Not default.**

## Why

infr's decode is very slow on NVIDIA wave32 hardware. On an **RTX 2080 Ti**, Qwen3-1.7B Q4_K_M `tg128` runs **17.9 t/s vs llama.cpp's ~150 (0.11×)** — measured interleaved (alternating infr/llama per round) to cancel thermal drift.

Root cause (profiled): decode is GPU-bound (`replay_n` = 78% of wall), and **every scalar decode GEMV variant — tree / RM / subgroup — clusters at ~30 GB/s of the 616 GB/s DRAM**. The bottleneck is the f32-dequant ALU + the `v[32]` per-sub-block register pressure capping occupancy, **not** the reduction:

- A scalar **multi-warp** variant (same block shape, scalar dequant) measured **slower** than the tree.
- The wave32 **subgroup** kernel regressed because its 1-warp blocks halve occupancy under Turing's 16-blocks/SM limit.

Only **dp4a** breaks the ceiling — integer-dot the raw K-quant blocks instead of dequanting every weight to f32.

## Result (RTX 2080 Ti, Qwen3-1.7B Q4_K_M, interleaved vs `llama-bench`)

| metric | before | after (`INFR_MMV_MW=1`) | vs llama.cpp |
|---|---|---|---|
| tg128 (isolated, r=3) | 17.9 t/s | **61.7 t/s** (3.4×) | 0.11× → ~0.4× |
| tg128 (interleaved median) | 16 t/s | **82.5 t/s** | 0.11× → **~0.5×** |
| pp512 | unchanged | unchanged | decode-only change |

## Why opt-in, not default

dp4a's int8-activation quant is the **same precision tier as llama.cpp's decode**, but coarser than infr's scalar default: it forks from the f32 CPU oracle earlier, below infr's stricter token-for-token / deep-KV-Q8 coherence bar. This is exactly why 51a35c8 chose scalar as the default on AMD (where scalar is *also* faster, so dp4a had no upside). On wave32 the tradeoff is live — a deployment that accepts llama-level decode precision opts in for the 3.4×. Flipping it to default is a maintainer call (needs the precision judgment + AMD review).

**AMD (`subgroup_max == 64`) returns `None` from `mmv_mw_choice` → its decode path is byte-identical. Zero regression by construction.** I have no AMD/Metal hardware to test on, so the device gate is the non-regression guarantee.

## Correctness

- New `mmv_mw_parity` test proves `native_mmv_mw` matches the validated `native_mmv` dp4a kernel to **≤ 2e-3** (pure `subgroupAdd` reassociation) across the projection shapes, including odd `out_f`.
- All 12 `gpu_seam_matches_cpu_*` token-for-token tests pass with `INFR_MMV_MW=1` (llama, qwen2/3, gemma3/4, diffusion-gemma, qwen35moe; Q4K/Q6K/IQ4XS/Q2K/Q8_0).
- Default-path `cpu_backend` suite unchanged: **40 pass / 4 fail identical to clean HEAD on this box** — the 4 failures are pre-existing (GPU goldens blessed on the AMD reference GPU don't match Turing's f16 accumulation).
- `clippy --workspace --all-targets` + `fmt` clean.

> Note: validated only on an RTX 2080 Ti (Turing, wave32). The gate is `subgroup_max == 32`, so Intel Xe would also opt in — untested there. AMD/Metal are untouched by construction but I couldn't run their suites.