### PR TITLE
perf(metal): route small IQ4_NL batches to RT

### DIFF
--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -202,6 +202,16 @@ mod tests {
     }
 
     #[test]
+    fn iq4nl_small_multirow_prefers_rt() {
+        assert!(!prefer_iq4nl_rt("linear_iq4nl", 1));
+        for m in 2..=4 {
+            assert!(prefer_iq4nl_rt("linear_iq4nl", m));
+        }
+        assert!(!prefer_iq4nl_rt("linear_iq4nl", 5));
+        assert!(!prefer_iq4nl_rt("linear_q4_0", 2));
+    }
+
+    #[test]
     #[ignore = "requires a Metal GPU"]
     fn replay_gpu_decode_ops_observe_dynamic_inputs() {
         let be = MetalBackend::new().expect("Metal backend");
@@ -648,6 +658,10 @@ fn sample_split_groups(n: usize) -> Option<usize> {
 
 fn sample_split_shape(n: usize, top_k: usize) -> Option<(usize, usize)> {
     sample_split_groups(n).map(|groups| (groups, groups * top_k.min(64)))
+}
+
+fn prefer_iq4nl_rt(kern: &str, m: usize) -> bool {
+    kern == "linear_iq4nl" && (2..=4).contains(&m)
 }
 
 /// Classify the GPU-resident decode tail ops that may appear on an otherwise replayable graph.
@@ -2149,7 +2163,11 @@ impl MetalBackend {
                     // stream ONCE at GEMM rate; the row-tiled shape re-streams at ~1/3 the
                     // bandwidth: 140 ms vs ~45 ms per 8B verify forward). m == 1 keeps the
                     // exact-f32 GEMV (decode's precision contract).
+                    // IQ4_NL is the measured exception at m=2..4: its non-linear codebook keeps
+                    // the mostly-empty CMM tile decode-bound, while RT reuses each decoded block
+                    // across rows. Gemma 6912x1152 measured 39%/25%/8% faster; CMM wins at m=5.
                     let cmm_ok = m >= 2
+                        && !prefer_iq4nl_rt(qw.kern, m)
                         && out_f % 64 == 0
                         && self
                             .pipelines

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -163,30 +163,38 @@ fn synth_iq4nl(n_elem: usize, seed: u32) -> Vec<u8> {
 // Chained bench: K identical GEMVs over K DISTINCT weight copies in ONE graph (one command
 // buffer) — the per-cb commit+wait overhead amortizes away and the number reflects the
 // in-decode-chain cost. Distinct weights so the stream is not cache-resident.
-fn bench_chained(dtype: DType, wbytes: &[u8], in_f: usize, out_f: usize, bpw: f64, label: &str) {
+fn bench_chained_m(
+    dtype: DType,
+    wbytes: &[u8],
+    m: usize,
+    in_f: usize,
+    out_f: usize,
+    bpw: f64,
+    label: &str,
+) {
     let be = MetalBackend::new().unwrap();
     let k = 8usize;
-    let xs: Vec<f32> = (0..in_f).map(|i| (i % 7) as f32 * 0.01).collect();
+    let xs: Vec<f32> = (0..m * in_f).map(|i| (i % 7) as f32 * 0.01).collect();
 
     let mut g = Graph::new();
-    let x = g.input(TensorDesc::new(vec![1, in_f], DType::F32));
+    let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
     let ws: Vec<_> = (0..k)
         .map(|_| g.weight(TensorDesc::new(vec![out_f, in_f], dtype)))
         .collect();
-    let dst = g.output(TensorDesc::new(vec![1, out_f], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
     for w in &ws {
         g.push(Op::Linear {
             x,
             weight: *w,
             dst,
-            m: 1,
+            m: m as u32,
             in_f: in_f as u32,
             out_f: out_f as u32,
             w_off: 0,
         });
     }
 
-    let xb = be.alloc(in_f * 4, BufferUsage::Activations).unwrap();
+    let xb = be.alloc(m * in_f * 4, BufferUsage::Activations).unwrap();
     be.upload(xb.as_ref(), bytemuck::cast_slice(&xs)).unwrap();
     let mut wbs = Vec::new();
     for _ in 0..k {
@@ -194,7 +202,7 @@ fn bench_chained(dtype: DType, wbytes: &[u8], in_f: usize, out_f: usize, bpw: f6
         be.upload(wb.as_ref(), wbytes).unwrap();
         wbs.push(wb);
     }
-    let ob = be.alloc(out_f * 4, BufferUsage::Activations).unwrap();
+    let ob = be.alloc(m * out_f * 4, BufferUsage::Activations).unwrap();
 
     let mut binds = Bindings::new();
     binds.bind(x, xb.as_ref());
@@ -212,11 +220,15 @@ fn bench_chained(dtype: DType, wbytes: &[u8], in_f: usize, out_f: usize, bpw: f6
     let dt = t0.elapsed().as_secs_f64() / (reps * k) as f64;
     let bytes = (out_f * in_f) as f64 * bpw / 8.0;
     println!(
-        "{label}: {out_f}x{in_f} chained -> {:.3} ms/gemv, {:.1} GB/s (stream {:.1} MB)",
+        "{label}: m={m} {out_f}x{in_f} chained -> {:.3} ms/gemv, {:.1} GB/s (stream {:.1} MB)",
         dt * 1e3,
         bytes / dt / 1e9,
         bytes / 1e6
     );
+}
+
+fn bench_chained(dtype: DType, wbytes: &[u8], in_f: usize, out_f: usize, bpw: f64, label: &str) {
+    bench_chained_m(dtype, wbytes, 1, in_f, out_f, bpw, label);
 }
 
 #[test]
@@ -238,6 +250,29 @@ fn gemv_bandwidth_gemma_shapes() {
     bench_chained(DType::Q8_0, &w8, 1152, 65536, 8.5, "q8_0 head/4");
     let wiq4 = synth_iq4nl(6912 * 1152, 15);
     bench_chained(DType::Iq4Nl, &wiq4, 1152, 6912, 4.5, "iq4_nl gate/up");
+    for m in 2..=8 {
+        bench_chained_m(
+            DType::Iq4Nl,
+            &wiq4,
+            m,
+            1152,
+            6912,
+            4.5,
+            "iq4_nl gate/up multirow",
+        );
+    }
+    let wiq4rt = synth_iq4nl(6911 * 1152, 18);
+    for m in 2..=8 {
+        bench_chained_m(
+            DType::Iq4Nl,
+            &wiq4rt,
+            m,
+            1152,
+            6911,
+            4.5,
+            "iq4_nl gate/up multirow rt",
+        );
+    }
     let wiq4d = synth_iq4nl(1152 * 6912, 17);
     bench_chained(DType::Iq4Nl, &wiq4d, 6912, 1152, 4.5, "iq4_nl down");
     let wiq4h = synth_iq4nl(65536 * 1152, 16);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -914,6 +914,20 @@ fn linear_iq4nl_gemv_matches_dequant_reference() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_iq4nl_multirow_matches_dequant_reference() {
+    let (m, in_f, out_f) = (8usize, 256usize, 94usize);
+    check_quant_linear_parity(DType::Iq4Nl, synth_iq4nl(out_f * in_f, 118), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_iq4nl_small_multirow_matches_dequant_reference() {
+    let (m, in_f, out_f) = (4usize, 256usize, 128usize);
+    check_quant_linear_parity(DType::Iq4Nl, synth_iq4nl(out_f * in_f, 117), m, in_f, out_f);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_add_fusion_iq4nl_parity() {
     let (in_f, out_f) = (512usize, 384usize);
     check_linear_add_fusion(DType::Iq4Nl, synth_iq4nl(out_f * in_f, 120), in_f, out_f);


### PR DESCRIPTION
## Summary

- route aligned IQ4_NL matrix multiplies with 2-4 rows through the row-tiled kernel
- retain the cooperative matrix path from 5 rows, where it becomes faster again
- extend the chained Gemma-shape benchmark across 2-8 rows and cover both dispatch paths with parity tests

## Impact

Gemma-shaped 6912x1152 IQ4_NL chained GEMV on M3:

- m=2: 0.160 to 0.097 ms (-39%)
- m=3: 0.158 to 0.119 ms (-25%)
- m=4: 0.162 to 0.149 ms (-8%)
- m=5 keeps CMM (about 0.165 ms vs 0.178 ms through RT)

The row-tiled path reuses each non-linear codebook decode across the small row batch. CMM remains preferable once the tile has enough active rows.

## Validation

- `cargo test -p infr-metal --locked -- --include-ignored` (113/113 parity tests)
- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
