### PR TITLE
perf(metal): skip inactive MoE tile rows

### DIFF
--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -106,6 +106,8 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     uint lr1c = min(lr1, nr1 - 1u);                                                               \
     uint tident = ids[e * p.cap + tt0 + lr1c];                                                    \
     uint xrow = DIVROW ? (p.row0 + tident / p.n_used) : tident;                                   \
+    /* Preserve the full-band sequence; partial final tiles skip dead 8-row matrix fragments. */ \
+    uint row_base = 16u * (sgid >> 1);                                                            \
                                                                                                   \
     simdgroup_half8x8 ma[4];                                                                      \
     simdgroup_half8x8 mb[2];                                                                      \
@@ -143,12 +145,21 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
         threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
         for (uint ik = 0; ik < 4u; ik++) {                                                        \
             simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
-            simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
-            simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 8u; i++)                                                         \
-                simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
+            if (row_base + 8u < nr1) {                                                            \
+                for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);           \
+                simdgroup_barrier(mem_flags::mem_none);                                           \
+                for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);           \
+                simdgroup_barrier(mem_flags::mem_none);                                           \
+                for (uint i = 0; i < 8u; i++)                                                     \
+                    simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);           \
+            } else if (row_base < nr1) {                                                          \
+                for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);           \
+                simdgroup_barrier(mem_flags::mem_none);                                           \
+                simdgroup_load(mb[0], lsmb, 8);                                                   \
+                simdgroup_barrier(mem_flags::mem_none);                                           \
+                for (uint i = 0; i < 4u; i++)                                                     \
+                    simdgroup_multiply_accumulate(mc[i], mb[0], ma[i], mc[i]);                    \
+            }                                                                                     \
             lsma += 8u * 64u;                                                                     \
             lsmb += 4u * 64u;                                                                     \
         }                                                                                         \

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -48,6 +48,14 @@ fn iq4nl_has_a_native_four_row_decode_body() {
 }
 
 #[test]
+fn moe_cmm_masks_inactive_matrix_row_fragments() {
+    let src = include_str!("../shaders/moe.metal");
+    assert!(src.contains("uint row_base = 16u * (sgid >> 1);"));
+    assert!(src.contains("if (row_base + 8u < nr1) {"));
+    assert!(src.contains("else if (row_base < nr1) {"));
+}
+
+#[test]
 #[ignore = "requires a Metal GPU"]
 fn every_dispatchable_kernel_exists_in_the_library() {
     let src = include_str!("../src/exec.rs");

--- a/crates/infr-metal/tests/moe_bw.rs
+++ b/crates/infr-metal/tests/moe_bw.rs
@@ -35,13 +35,18 @@ fn synth_q4k(n_elem: usize, seed: u32) -> Vec<u8> {
 fn moe_layer_wall() {
     // Qwen3-30B-A3B MoE layer: ne=2048, n_ff_exp=768, 128 experts, 8 used.
     let (ne, n_expert, n_used, nff) = (2048usize, 128usize, 8usize, 768usize);
+    let rows = std::env::var("INFR_METAL_MOE_ROWS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1usize);
     let be = MetalBackend::new().unwrap();
 
     // CHAIN of layers in one graph (dst feeds the next op's x), so the timing reports the
     // MARGINAL per-layer cost inside a batched forward, not the fixed per-execute overhead.
-    let nlayers = 8usize;
+    let nlayers = if rows == 1 { 8usize } else { 1usize };
+    let shape = if rows == 1 { vec![ne] } else { vec![rows, ne] };
     let mut g = Graph::new();
-    let x = g.input(TensorDesc::new(vec![ne], DType::F32));
+    let x = g.input(TensorDesc::new(shape.clone(), DType::F32));
     let router = g.weight(TensorDesc::new(vec![n_expert, ne], DType::F32));
     let gate = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::Q4K));
     let up = g.weight(TensorDesc::new(vec![n_expert, nff, ne], DType::Q4K));
@@ -50,9 +55,9 @@ fn moe_layer_wall() {
     let mut dst = x;
     for l in 0..nlayers {
         dst = if l + 1 == nlayers {
-            g.output(TensorDesc::new(vec![ne], DType::F32))
+            g.output(TensorDesc::new(shape.clone(), DType::F32))
         } else {
-            g.internal(TensorDesc::new(vec![ne], DType::F32))
+            g.internal(TensorDesc::new(shape.clone(), DType::F32))
         };
         g.push(Op::MoeFfn {
             x: cur,
@@ -77,10 +82,20 @@ fn moe_layer_wall() {
         cur = dst;
     }
 
-    let xs: Vec<f32> = (0..ne).map(|i| (i % 13) as f32 * 0.01 - 0.06).collect();
-    let rw: Vec<f32> = (0..n_expert * ne)
-        .map(|i| (i % 17) as f32 * 0.001)
-        .collect();
+    // Identity router plus eight positive expert coordinates per row gives deterministic,
+    // balanced top-8 routing. At rows=256 every expert receives 16 live rows, exposing the
+    // grouped kernel's half-full 32-row tile without relying on random routing distribution.
+    let mut xs = vec![0.0f32; rows * ne];
+    for r in 0..rows {
+        for u in 0..n_used {
+            let e = (r * 17 + u * 37) % n_expert;
+            xs[r * ne + e] = 2.0 - u as f32 * 0.05;
+        }
+    }
+    let mut rw = vec![0.0f32; n_expert * ne];
+    for e in 0..n_expert {
+        rw[e * ne + e] = 1.0;
+    }
     let bound: Vec<(infr_core::tensor::TensorId, Vec<u8>)> = vec![
         (x, bytemuck::cast_slice(&xs).to_vec()),
         (router, bytemuck::cast_slice(&rw).to_vec()),
@@ -95,7 +110,7 @@ fn moe_layer_wall() {
         be.upload(b.as_ref(), bytes).unwrap();
         bufs.push((*id, b));
     }
-    let ob = be.alloc(ne * 4, BufferUsage::Activations).unwrap();
+    let ob = be.alloc(rows * ne * 4, BufferUsage::Activations).unwrap();
     bufs.push((dst, ob));
     let mut binds = Bindings::new();
     for (id, b) in &bufs {
@@ -108,7 +123,10 @@ fn moe_layer_wall() {
         be.execute(plan.as_ref(), &binds).unwrap();
     }
     be.sync().unwrap();
-    let reps = 50;
+    let reps = std::env::var("INFR_METAL_MOE_REPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(if rows == 1 { 50 } else { 5 });
     let t0 = std::time::Instant::now();
     for _ in 0..reps {
         be.execute(plan.as_ref(), &binds).unwrap();
@@ -120,11 +138,12 @@ fn moe_layer_wall() {
     } else {
         "device"
     };
-    // Active bytes per token: 3 matmuls x n_used experts (q4k = 4.5 bpw -> 0.5625 B/elem).
+    // Dense-equivalent bytes: grouped GEMM reuses each expert's weights across routed rows.
     let mb = (3 * n_used * nff * ne) as f64 * 0.5625 / 1e6;
     println!(
-        "moe layer ({path}, marginal of {nlayers}-chain): {:.3} ms/op, active expert stream {mb:.1} MB -> {:.1} GB/s",
+        "moe layer ({path}, rows={rows}, marginal of {nlayers}-chain): {:.3} ms/op, dense-equivalent expert bytes {:.1} MB -> {:.1} effective GB/s",
         per * 1e3,
-        mb / 1e3 / per
+        mb * rows as f64,
+        mb * rows as f64 / 1e3 / per
     );
 }


### PR DESCRIPTION
## Summary

- skip inactive 8-row matrix fragments in partial Metal MoE expert tiles
- preserve the original load, barrier, and MMA sequence for fully live bands
- extend the Qwen3-30B-A3B probe to deterministic balanced multi-row routing

## Impact

Qwen3-30B-A3B-shaped Q4_K MoE layer on M3, balanced top-8 routing:

- rows=128: 9.652 to 6.064 ms (-37.2%)
- rows=256: 10.640 to 7.982 ms (-25.0%)

At the production 256-row chunk size, 128 experts receive an average of 16 routed rows each. The previous kernel executed a full 32-row matrix tile and discarded the inactive half.

A separate 128-column shallow-down tile was measured and rejected: rows=256 improved only 0.8%, while rows=128 regressed 0.7%. No code from that experiment remains.

## Validation

- `cargo test -p infr-metal --locked -- --include-ignored` (111/111 parity tests)
- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
