### PR TITLE
fix(metal): propagate request context

### DIFF
--- a/crates/infr-llama/src/chat/metal.rs
+++ b/crates/infr-llama/src/chat/metal.rs
@@ -82,7 +82,7 @@ impl ChatModel for MetalSeamChat {
         // (No INFR_METAL_PROFILE suppression: the Metal backend reads it at CONSTRUCTION —
         // which happens inside this first generate — so unsetting it here would disable
         // profiling for the whole session, not just the warmup.)
-        self.generate("Hi", 2, &mut |_| {})?;
+        self.generate("Hi", 2, None, &mut |_| {})?;
         // Drop the warmup tokens so the first real prompt prefills clean slots from row 0
         // instead of forking off a garbage prefix.
         if let Some(s) = &mut self.session {
@@ -95,6 +95,7 @@ impl ChatModel for MetalSeamChat {
         &mut self,
         prompt: &str,
         max_new: usize,
+        req: Option<&crate::sampling::RequestCtx>,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
         // MTP (INFR_MTP=1 on a qwen35 head-bearing GGUF): the draft-verify-catchup loop over the
@@ -108,10 +109,13 @@ impl ChatModel for MetalSeamChat {
             });
         }
         self.ensure_session()?;
-        self.model
-            .generate_metal_session(self.session.as_mut().unwrap(), prompt, max_new, |p| {
-                on_piece(p)
-            })
+        self.model.generate_metal_session(
+            self.session.as_mut().unwrap(),
+            prompt,
+            max_new,
+            req,
+            |p| on_piece(p),
+        )
     }
 
     fn generate_constrained(
@@ -119,6 +123,7 @@ impl ChatModel for MetalSeamChat {
         prompt: &str,
         max_new: usize,
         constraint: &mut crate::grammar::Constraint,
+        req: Option<&crate::sampling::RequestCtx>,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
         self.ensure_session()?;
@@ -127,6 +132,7 @@ impl ChatModel for MetalSeamChat {
             prompt,
             max_new,
             Some(constraint),
+            req,
             |p| on_piece(p),
         )
     }
@@ -187,7 +193,7 @@ impl ChatModel for SpecMetalChat {
     fn warmup(&mut self) -> Result<()> {
         // Compile BOTH models' pipelines now (a spec round drives target prefill, draft decode,
         // and the batched verify) so serve's first request doesn't pay two cold starts.
-        self.generate("Hi", 2, &mut |_| {})?;
+        self.generate("Hi", 2, None, &mut |_| {})?;
         // Drop the warmup tokens so the first real prompt prefills clean slots from row 0.
         if let Some(s) = &mut self.target_session {
             s.reset_cache();
@@ -202,6 +208,7 @@ impl ChatModel for SpecMetalChat {
         &mut self,
         prompt: &str,
         max_new: usize,
+        _req: Option<&crate::sampling::RequestCtx>,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
         self.ensure_sessions()?;

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -1127,6 +1127,7 @@ pub(crate) fn generate_dense_metal(
     ple: Option<&PerLayerEmbd>,
     prompt: &[u32],
     max_new: usize,
+    req: Option<&crate::sampling::RequestCtx>,
     on_token: impl FnMut(u32),
 ) -> AResult<(Vec<u32>, GenStats)> {
     generate_dense_metal_session(
@@ -1141,6 +1142,7 @@ pub(crate) fn generate_dense_metal(
         &mut None,
         prompt.len() + max_new + 1,
         None,
+        req,
     )
 }
 
@@ -1162,6 +1164,7 @@ pub(crate) fn generate_dense_metal_session(
     state: &mut Option<SeamKv>,
     want_ctx: usize,
     constraint: Option<&mut crate::grammar::Constraint>,
+    req: Option<&crate::sampling::RequestCtx>,
 ) -> AResult<(Vec<u32>, GenStats)> {
     generate_dense_backend(
         mtl,
@@ -1187,7 +1190,7 @@ pub(crate) fn generate_dense_metal_session(
         None,
         None,
         None,
-        None,
+        req,
     )
 }
 

--- a/crates/infr-llama/src/seam/model.rs
+++ b/crates/infr-llama/src/seam/model.rs
@@ -946,9 +946,10 @@ impl SeamModel {
         session: &mut DenseMetalSession,
         prompt: &str,
         max_new: usize,
+        req: Option<&crate::sampling::RequestCtx>,
         on_piece: impl FnMut(&str),
     ) -> Result<crate::GenStats> {
-        self.generate_metal_session_constrained(session, prompt, max_new, None, on_piece)
+        self.generate_metal_session_constrained(session, prompt, max_new, None, req, on_piece)
     }
 
     /// [`generate_metal_session`](Self::generate_metal_session) with an optional llguidance
@@ -960,6 +961,7 @@ impl SeamModel {
         prompt: &str,
         max_new: usize,
         constraint: Option<&mut crate::grammar::Constraint>,
+        req: Option<&crate::sampling::RequestCtx>,
         mut on_piece: impl FnMut(&str),
     ) -> Result<crate::GenStats> {
         let enc = self
@@ -982,6 +984,7 @@ impl SeamModel {
             &mut session.pool.slots[slot],
             session.max_ctx,
             constraint,
+            req,
         )?;
         Ok(stats)
     }
@@ -995,6 +998,7 @@ impl SeamModel {
         &self,
         prompt: &str,
         max_new: usize,
+        req: Option<&crate::sampling::RequestCtx>,
         mut on_piece: impl FnMut(&str),
     ) -> Result<crate::GenStats> {
         let enc = self
@@ -1013,6 +1017,7 @@ impl SeamModel {
             self.per_layer_embd.as_ref(),
             &prompt_tokens,
             max_new,
+            req,
             |id| stream_token(&self.tokenizer, &mut acc, &mut printed, id, &mut on_piece),
         )?;
         Ok(stats)
@@ -1092,6 +1097,7 @@ impl SeamModel {
             &mut session.pool.slots[t_slot],
             session.max_ctx,
             None,
+            None,
         )?;
         let prompt_secs = t0.elapsed().as_secs_f64();
         let mut t_next = *first.first().ok_or_else(|| anyhow!("empty first token"))?;
@@ -1137,6 +1143,7 @@ impl SeamModel {
                 |_| {},
                 &mut draft_session.pool.slots[d_slot],
                 draft_session.max_ctx,
+                None,
                 None,
             )?;
             // Verify: one batched target forward over [t_next, cand..]; row i's argmax is the
@@ -1241,6 +1248,7 @@ impl SeamModel {
             |_| {},
             session.pool.single(),
             session.max_ctx,
+            None,
             None,
         )?;
         Ok(stats)

--- a/crates/infr-llama/tests/cpu_backend.rs
+++ b/crates/infr-llama/tests/cpu_backend.rs
@@ -721,7 +721,7 @@ fn metal_spec_decode_matches_target_only_greedy() {
     {
         let mut sess = target.metal_session(1024).expect("target-only session");
         target
-            .generate_metal_session(&mut sess, &prompt, 64, |p| plain.push_str(p))
+            .generate_metal_session(&mut sess, &prompt, 64, None, |p| plain.push_str(p))
             .expect("target-only greedy");
     }
 
@@ -756,13 +756,13 @@ fn metal_decode_chain_matches_per_token_greedy() {
     std::env::set_var("INFR_DECODE_CHAIN", "1");
     let mut per_token = String::new();
     model
-        .generate_metal(&prompt, 32, |p| per_token.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| per_token.push_str(p))
         .expect("per-token greedy");
 
     std::env::set_var("INFR_DECODE_CHAIN", "8");
     let mut chained = String::new();
     model
-        .generate_metal(&prompt, 32, |p| chained.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| chained.push_str(p))
         .expect("chained greedy");
 
     std::env::remove_var("INFR_DECODE_CHAIN");
@@ -787,13 +787,13 @@ fn metal_decode_chain_matches_per_token_sampling() {
     std::env::set_var("INFR_DECODE_CHAIN", "1");
     let mut per_token = String::new();
     model
-        .generate_metal(&prompt, 32, |p| per_token.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| per_token.push_str(p))
         .expect("per-token sampling");
 
     std::env::set_var("INFR_DECODE_CHAIN", "8");
     let mut chained = String::new();
     model
-        .generate_metal(&prompt, 32, |p| chained.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| chained.push_str(p))
         .expect("chained sampling");
 
     for var in [
@@ -828,18 +828,18 @@ fn metal_seam_multi_slot_prefix_sharing() {
 
     let mut ta = String::new();
     let sa = model
-        .generate_metal_session(&mut sess, &pa, 8, |p| ta.push_str(p))
+        .generate_metal_session(&mut sess, &pa, 8, None, |p| ta.push_str(p))
         .expect("conv A");
     assert!(sa.n_prompt > 0);
 
     // Conversation B: different question, same system prefix → new slot seeded from A's.
     let mut tb = String::new();
     let sb = model
-        .generate_metal_session(&mut sess, &pb, 8, |p| tb.push_str(p))
+        .generate_metal_session(&mut sess, &pb, 8, None, |p| tb.push_str(p))
         .expect("conv B");
     let mut fresh_b = String::new();
     model
-        .generate_metal(&pb, 8, |p| fresh_b.push_str(p))
+        .generate_metal(&pb, 8, None, |p| fresh_b.push_str(p))
         .expect("fresh B");
     assert_eq!(
         tb.trim(),
@@ -858,11 +858,11 @@ fn metal_seam_multi_slot_prefix_sharing() {
     let pa2 = format!("{pa}{ta} And the capital of Spain is");
     let mut ta2 = String::new();
     let sa2 = model
-        .generate_metal_session(&mut sess, &pa2, 8, |p| ta2.push_str(p))
+        .generate_metal_session(&mut sess, &pa2, 8, None, |p| ta2.push_str(p))
         .expect("conv A turn 2");
     let mut fresh_a2 = String::new();
     model
-        .generate_metal(&pa2, 8, |p| fresh_a2.push_str(p))
+        .generate_metal(&pa2, 8, None, |p| fresh_a2.push_str(p))
         .expect("fresh A2");
     assert_eq!(
         ta2.trim(),


### PR DESCRIPTION
## Summary

- update macOS Metal chat implementations for the request-aware `ChatModel` API
- propagate per-request sampling, abort, and GPU gate state through regular Metal generation
- keep non-server Metal test and speculative call sites explicit with `None`

## Root cause

The parallel server change added `RequestCtx` to `ChatModel` and the shared seam runner, but the macOS-only Metal wrappers were not updated. Linux CI could not compile those paths, while the macOS workspace build failed with trait signature and argument-count errors.

## Validation

- `cargo fmt --check`
- `cargo check -p infr-llama`
- `cargo test -p infr-llama --lib` (26 passed)
- `cargo build --workspace --locked`
- `cargo test -p infr-metal --locked -- --include-ignored` (113 Metal parity tests passed; all Metal unit/integration tests passed)
