### PR TITLE
perf(metal): run f16 linear natively

### DIFF
--- a/crates/infr-metal/shaders/linear.metal
+++ b/crates/infr-metal/shaders/linear.metal
@@ -22,6 +22,26 @@ kernel void linear_f32(device const float* x   [[buffer(0)]],
     if (lane == 0u) dst[sg] = acc;
 }
 
+// Native f16-weight twin of linear_f32. Activations and accumulation stay f32; only the bound
+// weight stream is half-width, matching the GGUF value exactly without a host f16->f32 cache.
+kernel void linear_f16(device const float* x   [[buffer(0)]],
+                       device const half*  w   [[buffer(1)]],
+                       device float*       dst [[buffer(2)]],
+                       constant LinearParams& p [[buffer(3)]],
+                       uint gid [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    uint sg = gid / 32u;
+    if (sg >= p.m * p.out_f) return;
+    uint r = sg / p.out_f;
+    uint o = sg % p.out_f;
+    device const float* xr = x + (ulong)r * p.in_f;
+    device const half* wo = w + (ulong)o * p.in_f;
+    float acc = 0.0f;
+    for (uint i = lane; i < p.in_f; i += 32u) acc += xr[i] * (float)wo[i];
+    acc = simd_sum(acc);
+    if (lane == 0u) dst[sg] = acc;
+}
+
 // ---- Linear over a NATIVE quantized weight. Two on-device forms:
 //
 // * FACTORED (`dequant_factored`): bit-packed 4/6/8-bit codes + one (sc, m) i16 pair per

--- a/crates/infr-metal/shaders/linear.metal
+++ b/crates/infr-metal/shaders/linear.metal
@@ -61,6 +61,13 @@ kernel void linear_f16(device const float* x   [[buffer(0)]],
 // prefill).
 struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
 
+// Native f16 weights for the cooperative multi-row tile. `codes` is the raw half buffer;
+// scm/dd/dshift are unused so this decoder can share the quantized CMM template unchanged.
+#define DEC16_F16(wk)                                                                             \
+    device const half* hp = (device const half*)codes + (ulong)bi * 16ul;                         \
+    _Pragma("clang loop unroll(full)")                                                            \
+    for (uint i = 0; i < 16u; i++) wk[i] = (float)hp[i];
+
 // factored, 4-bit codes: one uint2 = 8 bytes = one 16-element block, code k at bits 4k.
 #define DEC16_K4(wk)                                                                              \
     short2 s = ((device const short2*)scm)[bi];                                                   \

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -291,6 +291,7 @@ RT_KERNEL(linear_iq2xs_rt, DEC16_IQ2XS)
 // accumulators; a partial token tile stages through threadgroup memory and row-guards the copy,
 // so every tile takes the MMA path. Requires out_f % 64 == 0 and in_f % 32 == 0; other shapes
 // fall back to the per-simdgroup HGEMM.
+#define CMM_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
 #define CMM_KERNEL(NAME, DEC)                                                                     \
 kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
                  device const uchar*  codes [[buffer(1)]],                                       \
@@ -325,7 +326,7 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     simdgroup_half8x8 ma[4];                                                                      \
     simdgroup_half8x8 mb[2];                                                                      \
     simdgroup_float8x8 mc[8];                                                                     \
-    for (uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                               \
+    CMM_UNROLL(uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                         \
                                                                                                   \
     uint nb = p.in_f >> 4;                                                                        \
     for (uint k0 = 0; k0 < p.in_f; k0 += 32u) {                                                   \
@@ -343,7 +344,7 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
         {   /* stage A: one 16-block per thread, into pre-transposed 8x8 tiles */                 \
             uint sy = lr0 >> 3;                                                                   \
             uint lx = lr0 & 7u;                                                                   \
-            for (uint i = 0; i < 16u; i++) {                                                      \
+            CMM_UNROLL(uint i = 0; i < 16u; i++) {                                                \
                 uint sx = 2u * il0 + (i >> 3);                                                    \
                 sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
             }                                                                                     \
@@ -358,13 +359,13 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
         threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
         threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
         threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
-        for (uint ik = 0; ik < 4u; ik++) {                                                        \
+        CMM_UNROLL(uint ik = 0; ik < 4u; ik++) {                                                  \
             simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
+            CMM_UNROLL(uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);         \
             simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
+            CMM_UNROLL(uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);         \
             simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 8u; i++)                                                         \
+            CMM_UNROLL(uint i = 0; i < 8u; i++)                                                   \
                 simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
             lsma += 8u * 64u;                                                                     \
             lsmb += 4u * 64u;                                                                     \
@@ -375,12 +376,12 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     if (rt + 32u <= p.m) {                                                                        \
         device float* C = dst + (ro + 32u * (sgid & 1u)) +                                        \
                           (ulong)(rt + 16u * (sgid >> 1)) * p.out_f;                              \
-        for (uint i = 0; i < 8u; i++)                                                             \
+        CMM_UNROLL(uint i = 0; i < 8u; i++)                                                       \
             simdgroup_store(mc[i], C + 8u * (i & 3u) + 8u * p.out_f * (i >> 2), p.out_f);         \
     } else {                                                                                      \
         /* partial token tile: stage through threadgroup memory, row-guard the copy-out */        \
         threadgroup float* tc = shraw + 32u * (sgid & 1u) + (16u * (sgid >> 1)) * 64u;            \
-        for (uint i = 0; i < 8u; i++)                                                             \
+        CMM_UNROLL(uint i = 0; i < 8u; i++)                                                       \
             simdgroup_store(mc[i], tc + 8u * (i & 3u) + 8u * 64u * (i >> 2), 64u);                \
         threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
         if (sgid == 0u) {                                                                         \

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -553,6 +553,7 @@ CMM_KERNEL(linear_iq3s_cmm, DEC16_IQ3S)
 CMM_KERNEL(linear_iq2s_cmm, DEC16_IQ2S)
 CMM_KERNEL(linear_iq2xs_cmm, DEC16_IQ2XS)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
+CMM_KERNEL(linear_f16_cmm, DEC16_F16)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
 HGEMM_KERNEL(linear_quik6_hmm, DEC16_K6)

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -281,6 +281,7 @@ RT_KERNEL(linear_iq3xxs_rt, DEC16_IQ3XXS)
 RT_KERNEL(linear_iq3s_rt, DEC16_IQ3S)
 RT_KERNEL(linear_iq2s_rt, DEC16_IQ2S)
 RT_KERNEL(linear_iq2xs_rt, DEC16_IQ2XS)
+RT_KERNEL(linear_f16_rt, DEC16_F16)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2514,27 +2514,51 @@ impl MetalBackend {
                         );
                     }
                 } else {
-                    // f16/f32/bf16 weight: dequant-to-f32 device buffer, cached.
-                    let bw = self.weight_buf(weight, g, bindings)?;
-                    let pso = self.pipelines.get("linear_f32")?;
-                    if let Some(label) =
-                        counter_linear_label(self.counter_set.is_some(), "linear_f32")
-                    {
+                    let f16_native =
+                        wdt == DType::F16 && std::env::var("INFR_METAL_NO_F16_NATIVE").is_err();
+                    let (kern, elem_bytes) = match wdt {
+                        DType::F16 if f16_native => ("linear_f16", 2u64),
+                        _ => ("linear_f32", 4u64),
+                    };
+                    let pso = self.pipelines.get(kern)?;
+                    if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern) {
                         r.cur_op = label;
                     }
-                    self.encode_tg_off(
-                        r,
-                        &pso,
-                        &[
-                            (bx.as_ref(), 0),
-                            (bw.as_ref(), w_off as u64 * 4),
-                            (bd.as_ref(), 0),
-                        ],
-                        1 << 2,
-                        &p,
-                        m * out_f * 32,
-                        32,
-                    );
+                    if f16_native {
+                        // Read the uploaded GGUF half buffer directly. Besides halving the weight
+                        // stream, this avoids a same-size host read plus a 2x f32 cache allocation.
+                        let bw =
+                            metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        self.encode_tg_off(
+                            r,
+                            &pso,
+                            &[
+                                (bx.as_ref(), 0),
+                                (&bw.raw, w_off as u64 * elem_bytes),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 2,
+                            &p,
+                            m * out_f * 32,
+                            32,
+                        );
+                    } else {
+                        // f32/bf16 weight: dequant-to-f32 device buffer, cached.
+                        let bw = self.weight_buf(weight, g, bindings)?;
+                        self.encode_tg_off(
+                            r,
+                            &pso,
+                            &[
+                                (bx.as_ref(), 0),
+                                (bw.as_ref(), w_off as u64 * elem_bytes),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 2,
+                            &p,
+                            m * out_f * 32,
+                            32,
+                        );
+                    }
                 }
                 r.loc[dst.0 as usize] = Loc::Device;
             }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2516,19 +2516,56 @@ impl MetalBackend {
                 } else {
                     let f16_native =
                         wdt == DType::F16 && std::env::var("INFR_METAL_NO_F16_NATIVE").is_err();
+                    let f16_cmm = f16_native
+                        && m >= 16
+                        && out_f % 64 == 0
+                        && std::env::var("INFR_METAL_NO_F16_CMM").is_err()
+                        && self
+                            .pipelines
+                            .get("linear_f16_cmm")?
+                            .max_total_threads_per_threadgroup()
+                            >= 128;
                     let (kern, elem_bytes) = match wdt {
                         DType::F16 if f16_native => ("linear_f16", 2u64),
                         _ => ("linear_f32", 4u64),
                     };
-                    let pso = self.pipelines.get(kern)?;
-                    if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern) {
-                        r.cur_op = label;
-                    }
-                    if f16_native {
+                    if f16_cmm {
+                        let cmm = self.pipelines.get("linear_f16_cmm")?;
+                        if let Some(label) =
+                            counter_linear_label(self.counter_set.is_some(), "linear_f16_cmm")
+                        {
+                            r.cur_op = label;
+                        }
+                        let bw =
+                            metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        let dummy = self.scratch_buf(1, 14);
+                        let mut cp = p.clone();
+                        cp.extend_from_slice(&0u32.to_ne_bytes());
+                        self.encode_tg_off(
+                            r,
+                            &cmm,
+                            &[
+                                (bx.as_ref(), 0),
+                                (&bw.raw, w_off as u64 * elem_bytes),
+                                (dummy.as_ref(), 0),
+                                (dummy.as_ref(), 0),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 4,
+                            &cp,
+                            m.div_ceil(32) * (out_f / 64) * 128,
+                            128,
+                        );
+                    } else if f16_native {
                         // Read the uploaded GGUF half buffer directly. Besides halving the weight
                         // stream, this avoids a same-size host read plus a 2x f32 cache allocation.
                         let bw =
                             metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        let pso = self.pipelines.get(kern)?;
+                        if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern)
+                        {
+                            r.cur_op = label;
+                        }
                         self.encode_tg_off(
                             r,
                             &pso,
@@ -2545,6 +2582,11 @@ impl MetalBackend {
                     } else {
                         // f32/bf16 weight: dequant-to-f32 device buffer, cached.
                         let bw = self.weight_buf(weight, g, bindings)?;
+                        let pso = self.pipelines.get(kern)?;
+                        if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern)
+                        {
+                            r.cur_op = label;
+                        }
                         self.encode_tg_off(
                             r,
                             &pso,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2525,6 +2525,9 @@ impl MetalBackend {
                             .get("linear_f16_cmm")?
                             .max_total_threads_per_threadgroup()
                             >= 128;
+                    let f16_rt = f16_native
+                        && (2..16).contains(&m)
+                        && std::env::var("INFR_METAL_NO_F16_RT").is_err();
                     let (kern, elem_bytes) = match wdt {
                         DType::F16 if f16_native => ("linear_f16", 2u64),
                         _ => ("linear_f32", 4u64),
@@ -2555,6 +2558,33 @@ impl MetalBackend {
                             &cp,
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,
+                        );
+                    } else if f16_rt {
+                        let rt = self.pipelines.get("linear_f16_rt")?;
+                        if let Some(label) =
+                            counter_linear_label(self.counter_set.is_some(), "linear_f16_rt")
+                        {
+                            r.cur_op = label;
+                        }
+                        let bw =
+                            metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        let dummy = self.scratch_buf(1, 14);
+                        let mut rp = p.clone();
+                        rp.extend_from_slice(&0u32.to_ne_bytes());
+                        self.encode_tg_off(
+                            r,
+                            &rt,
+                            &[
+                                (bx.as_ref(), 0),
+                                (&bw.raw, w_off as u64 * elem_bytes),
+                                (dummy.as_ref(), 0),
+                                (dummy.as_ref(), 0),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 4,
+                            &rp,
+                            m.div_ceil(8) * out_f * 32,
+                            32,
                         );
                     } else if f16_native {
                         // Read the uploaded GGUF half buffer directly. Besides halving the weight

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -140,6 +140,22 @@ fn q5k_swar_probe() {
     bench_chained(DType::Q5K, &wq5k, 1152, 65536, 5.5, "q5k head");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f16_native_probe() {
+    let (in_f, out_f) = (1152usize, 65536usize);
+    let wf: Vec<f32> = (0..out_f * in_f).map(|i| (i % 13) as f32 * 0.01).collect();
+    let w16: Vec<u8> = wf
+        .into_iter()
+        .flat_map(|v| half::f16::from_f32(v).to_le_bytes())
+        .collect();
+
+    std::env::set_var("INFR_METAL_NO_F16_NATIVE", "1");
+    bench_chained(DType::F16, &w16, in_f, out_f, 32.0, "f16 cached-f32");
+    std::env::remove_var("INFR_METAL_NO_F16_NATIVE");
+    bench_chained(DType::F16, &w16, in_f, out_f, 16.0, "f16 native");
+}
+
 fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
     let mut out = Vec::new();
     for blk_i in 0..(n_elem / 32) {

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -156,6 +156,28 @@ fn f16_native_probe() {
     bench_chained(DType::F16, &w16, in_f, out_f, 16.0, "f16 native");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f16_cmm_probe() {
+    let (m, in_f, out_f) = (32usize, 1152usize, 8192usize);
+    let w16: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| half::f16::from_f32((i % 13) as f32 * 0.01).to_le_bytes())
+        .collect();
+
+    std::env::set_var("INFR_METAL_NO_F16_CMM", "1");
+    bench_chained_m(
+        DType::F16,
+        &w16,
+        m,
+        in_f,
+        out_f,
+        16.0 * m as f64,
+        "f16 native-gemv",
+    );
+    std::env::remove_var("INFR_METAL_NO_F16_CMM");
+    bench_chained_m(DType::F16, &w16, m, in_f, out_f, 16.0, "f16 cmm");
+}
+
 fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
     let mut out = Vec::new();
     for blk_i in 0..(n_elem / 32) {

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -178,6 +178,30 @@ fn f16_cmm_probe() {
     bench_chained_m(DType::F16, &w16, m, in_f, out_f, 16.0, "f16 cmm");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f16_rt_probe() {
+    let (in_f, out_f) = (1152usize, 8192usize);
+    let w16: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| half::f16::from_f32((i % 13) as f32 * 0.01).to_le_bytes())
+        .collect();
+
+    for m in [2usize, 4, 8] {
+        std::env::set_var("INFR_METAL_NO_F16_RT", "1");
+        bench_chained_m(
+            DType::F16,
+            &w16,
+            m,
+            in_f,
+            out_f,
+            16.0 * m as f64,
+            "f16 native-gemv",
+        );
+        std::env::remove_var("INFR_METAL_NO_F16_RT");
+        bench_chained_m(DType::F16, &w16, m, in_f, out_f, 16.0, "f16 rt");
+    }
+}
+
 fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
     let mut out = Vec::new();
     for blk_i in 0..(n_elem / 32) {

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -66,7 +66,7 @@ fn asserts_token_seq(src: &str, needle: &str) {
     );
 }
 
-// The three tripwires below guard OPTIMIZATIONS, not correctness. The parity tests pass whether
+// The four tripwires below guard OPTIMIZATIONS, not correctness. The parity tests pass whether
 // or not these are present (a reverted optimization is still numerically right, just slower), so
 // nothing else in the suite would notice if one silently vanished — the exact failure mode this
 // file's header describes. That is why they assert on shader source at all.
@@ -97,6 +97,24 @@ fn q5k_reconstructs_four_codes_per_word() {
     asserts_token_seq(src, "uint packed = (q & 0x0F0F0F0Fu)");
     asserts_token_seq(src, "(h & 0x01010101u) << 4u");
     asserts_token_seq(src, "packed >> 24u");
+}
+
+#[test]
+fn regular_cmm_unrolls_its_fixed_tile_loops() {
+    let src = include_str!("../shaders/moe.metal");
+    asserts_token_seq(
+        src,
+        "#define CMM_UNROLL(x) _Pragma(\"clang loop unroll(full)\") for (x)",
+    );
+    let compact = despace(src);
+    let cmm = compact
+        .split_once(&despace("#define CMM_KERNEL(NAME, DEC)"))
+        .unwrap()
+        .1
+        .split_once(&despace("#define CMMKS_KERNEL(NAME, DEC)"))
+        .unwrap()
+        .0;
+    assert!(cmm.matches("CMM_UNROLL").count() >= 8);
 }
 
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -136,6 +136,16 @@ fn f16_multirow_linear_uses_the_cooperative_tile() {
     asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_cmm\")");
 }
 
+#[test]
+fn f16_small_multirow_linear_uses_the_exact_row_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "RT_KERNEL(linear_f16_rt, DEC16_F16)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let f16_rt = f16_native && (2..16).contains(&m)");
+    asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_rt\")");
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -126,6 +126,16 @@ fn f16_linear_reads_the_bound_weight_directly() {
     asserts_token_seq(exec, "DType::F16 if f16_native => (\"linear_f16\", 2u64)");
 }
 
+#[test]
+fn f16_multirow_linear_uses_the_cooperative_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "CMM_KERNEL(linear_f16_cmm, DEC16_F16)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let f16_cmm = f16_native && m >= 16");
+    asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_cmm\")");
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -117,6 +117,15 @@ fn regular_cmm_unrolls_its_fixed_tile_loops() {
     assert!(cmm.matches("CMM_UNROLL").count() >= 8);
 }
 
+#[test]
+fn f16_linear_reads_the_bound_weight_directly() {
+    let shader = include_str!("../shaders/linear.metal");
+    asserts_token_seq(shader, "kernel void linear_f16");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "DType::F16 if f16_native => (\"linear_f16\", 2u64)");
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -560,6 +560,14 @@ fn linear_woff_f16_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f16_rt() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 352);
+    check_linear_woff(DType::F16, f16_bytes(&wf), 8, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_f16_cmm() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 351);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -560,6 +560,14 @@ fn linear_woff_f16_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f16_cmm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 351);
+    check_linear_woff(DType::F16, f16_bytes(&wf), 40, in_f, &slices, true, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_q8_0_coop_gemm() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 36);
@@ -665,6 +673,14 @@ fn linear_f16_parity() {
         (w, f16_bytes(&rand_f32(out_f * in_f, 23))),
     ];
     assert_parity(&g, &bound, dst, m * out_f, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_f16_cmm_parity() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    let wf = rand_f32(out_f * in_f, 230);
+    check_quant_linear_parity_impl(DType::F16, f16_bytes(&wf), m, in_f, out_f, 1e-3, true);
 }
 
 // Quantized Linear: Metal dequants the weight to f32 (via infr_gguf) and matmuls. Compare to a

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -552,6 +552,14 @@ fn linear_woff_q8_0_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f16_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 350);
+    check_linear_woff(DType::F16, f16_bytes(&wf), 1, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_q8_0_coop_gemm() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 36);


### PR DESCRIPTION
## Summary

- read F16 Linear weights directly from their uploaded half buffer instead of host-converting and caching them as f32
- reuse the cooperative 64x32 tile for F16 matrices at `m >= 16`
- reuse the exact-f32 row tile for F16 matrices at `m=2..15`
- preserve direct native GEMV for `m=1`

This is stacked on #54. After #54 merges, its cooperative-loop unroll commit will disappear from this PR's diff. The inherited macOS CI failure on #54 is fixed by the fully green #55.

## Performance

M3 Pro release probes:

- `m=1`, `65536x1152`: `2.370 -> 1.168 ms` (2.03x)
- `m=2`, `8192x1152`: `0.354 -> 0.179 ms` (1.98x)
- `m=4`, `8192x1152`: `0.633 -> 0.192 ms` (3.30x)
- `m=8`, `8192x1152`: `1.221 -> 0.302 ms` (4.04x)
- `m=32`, `8192x1152`: `4.746 -> 0.235 ms` (20.2x)

The native path also removes the one-time host F16-to-f32 conversion and the 2x device-side weight cache. This directly addresses DiffusionGemma's large F16 `sc_embT` Linear path.

## Correctness

- native F16 whole-weight parity
- F16 nonzero-`w_off` parity for GEMV, row-tiled, and cooperative routes
- kernel-name and route tripwires
- `cargo fmt --check`
- `cargo clippy -p infr-metal --all-targets --locked -- -D warnings`
- `cargo test -p infr-metal --locked -- --include-ignored` (117 Metal parity tests passed; all Metal unit/integration tests passed)

## Rejected probe

Routing `m=2` through cooperative MMA was rejected because half-rounding f32 activations exceeded the existing `1e-3` Linear parity contract. The exact row tile is used below `m=16` instead.
