### PR TITLE
perf(metal): tile small-row f32 linear

### DIFF
--- a/crates/infr-metal/shaders/linear.metal
+++ b/crates/infr-metal/shaders/linear.metal
@@ -90,6 +90,11 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
     _Pragma("clang loop unroll(full)")                                                            \
     for (uint i = 0; i < 16u; i++) wk[i] = (float)hp[i];
 
+#define DEC16_BF16(wk)                                                                            \
+    device const ushort* bp = (device const ushort*)codes + (ulong)bi * 16ul;                     \
+    _Pragma("clang loop unroll(full)")                                                            \
+    for (uint i = 0; i < 16u; i++) wk[i] = as_type<float>((uint)bp[i] << 16u);
+
 // factored, 4-bit codes: one uint2 = 8 bytes = one 16-element block, code k at bits 4k.
 #define DEC16_K4(wk)                                                                              \
     short2 s = ((device const short2*)scm)[bi];                                                   \

--- a/crates/infr-metal/shaders/linear.metal
+++ b/crates/infr-metal/shaders/linear.metal
@@ -95,6 +95,11 @@ struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
     _Pragma("clang loop unroll(full)")                                                            \
     for (uint i = 0; i < 16u; i++) wk[i] = as_type<float>((uint)bp[i] << 16u);
 
+#define DEC16_F32(wk)                                                                             \
+    device const float* fp = (device const float*)codes + (ulong)bi * 16ul;                       \
+    _Pragma("clang loop unroll(full)")                                                            \
+    for (uint i = 0; i < 16u; i++) wk[i] = fp[i];
+
 // factored, 4-bit codes: one uint2 = 8 bytes = one 16-element block, code k at bits 4k.
 #define DEC16_K4(wk)                                                                              \
     short2 s = ((device const short2*)scm)[bi];                                                   \

--- a/crates/infr-metal/shaders/linear.metal
+++ b/crates/infr-metal/shaders/linear.metal
@@ -22,6 +22,26 @@ kernel void linear_f32(device const float* x   [[buffer(0)]],
     if (lane == 0u) dst[sg] = acc;
 }
 
+// Native f16-weight twin of linear_f32. Activations and accumulation stay f32; only the bound
+// weight stream is half-width, matching the GGUF value exactly without a host f16->f32 cache.
+kernel void linear_f16(device const float* x   [[buffer(0)]],
+                       device const half*  w   [[buffer(1)]],
+                       device float*       dst [[buffer(2)]],
+                       constant LinearParams& p [[buffer(3)]],
+                       uint gid [[thread_position_in_grid]],
+                       uint lane [[thread_index_in_simdgroup]]) {
+    uint sg = gid / 32u;
+    if (sg >= p.m * p.out_f) return;
+    uint r = sg / p.out_f;
+    uint o = sg % p.out_f;
+    device const float* xr = x + (ulong)r * p.in_f;
+    device const half* wo = w + (ulong)o * p.in_f;
+    float acc = 0.0f;
+    for (uint i = lane; i < p.in_f; i += 32u) acc += xr[i] * (float)wo[i];
+    acc = simd_sum(acc);
+    if (lane == 0u) dst[sg] = acc;
+}
+
 // ---- Linear over a NATIVE quantized weight. Two on-device forms:
 //
 // * FACTORED (`dequant_factored`): bit-packed 4/6/8-bit codes + one (sc, m) i16 pair per

--- a/crates/infr-metal/shaders/linear.metal
+++ b/crates/infr-metal/shaders/linear.metal
@@ -42,6 +42,28 @@ kernel void linear_f16(device const float* x   [[buffer(0)]],
     if (lane == 0u) dst[sg] = acc;
 }
 
+// Native bf16-weight GEMV without requiring Metal bfloat support: GGUF BF16 stores the top 16
+// bits of each f32, so widening is the exact integer shift used by the CPU and gather kernels.
+kernel void linear_bf16(device const float*  x   [[buffer(0)]],
+                        device const ushort* w   [[buffer(1)]],
+                        device float*        dst [[buffer(2)]],
+                        constant LinearParams& p [[buffer(3)]],
+                        uint gid [[thread_position_in_grid]],
+                        uint lane [[thread_index_in_simdgroup]]) {
+    uint sg = gid / 32u;
+    if (sg >= p.m * p.out_f) return;
+    uint r = sg / p.out_f;
+    uint o = sg % p.out_f;
+    device const float* xr = x + (ulong)r * p.in_f;
+    device const ushort* wo = w + (ulong)o * p.in_f;
+    float acc = 0.0f;
+    for (uint i = lane; i < p.in_f; i += 32u) {
+        acc += xr[i] * as_type<float>((uint)wo[i] << 16u);
+    }
+    acc = simd_sum(acc);
+    if (lane == 0u) dst[sg] = acc;
+}
+
 // ---- Linear over a NATIVE quantized weight. Two on-device forms:
 //
 // * FACTORED (`dequant_factored`): bit-packed 4/6/8-bit codes + one (sc, m) i16 pair per

--- a/crates/infr-metal/shaders/linear.metal
+++ b/crates/infr-metal/shaders/linear.metal
@@ -61,6 +61,13 @@ kernel void linear_f16(device const float* x   [[buffer(0)]],
 // prefill).
 struct QLinParams { uint m; uint in_f; uint out_f; uint dshift; };
 
+// Native f16 weights for the cooperative multi-row tile. `codes` is the raw half buffer;
+// scm/dd/dshift are unused so this decoder can share the quantized CMM template unchanged.
+#define DEC16_F16(wk)                                                                             \
+    device const half* hp = (device const half*)codes + (ulong)bi * 16ul;                         \
+    _Pragma("clang loop unroll(full)")                                                            \
+    for (uint i = 0; i < 16u; i++) wk[i] = (float)hp[i];
+
 // factored, 4-bit codes: one uint2 = 8 bytes = one 16-element block, code k at bits 4k.
 #define DEC16_K4(wk)                                                                              \
     short2 s = ((device const short2*)scm)[bi];                                                   \

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -291,6 +291,7 @@ RT_KERNEL(linear_iq2xs_rt, DEC16_IQ2XS)
 // accumulators; a partial token tile stages through threadgroup memory and row-guards the copy,
 // so every tile takes the MMA path. Requires out_f % 64 == 0 and in_f % 32 == 0; other shapes
 // fall back to the per-simdgroup HGEMM.
+#define CMM_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
 #define CMM_KERNEL(NAME, DEC)                                                                     \
 kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
                  device const uchar*  codes [[buffer(1)]],                                       \
@@ -325,7 +326,7 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     simdgroup_half8x8 ma[4];                                                                      \
     simdgroup_half8x8 mb[2];                                                                      \
     simdgroup_float8x8 mc[8];                                                                     \
-    for (uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                               \
+    CMM_UNROLL(uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                         \
                                                                                                   \
     uint nb = p.in_f >> 4;                                                                        \
     for (uint k0 = 0; k0 < p.in_f; k0 += 32u) {                                                   \
@@ -343,7 +344,7 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
         {   /* stage A: one 16-block per thread, into pre-transposed 8x8 tiles */                 \
             uint sy = lr0 >> 3;                                                                   \
             uint lx = lr0 & 7u;                                                                   \
-            for (uint i = 0; i < 16u; i++) {                                                      \
+            CMM_UNROLL(uint i = 0; i < 16u; i++) {                                                \
                 uint sx = 2u * il0 + (i >> 3);                                                    \
                 sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
             }                                                                                     \
@@ -358,13 +359,13 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
         threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
         threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
         threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
-        for (uint ik = 0; ik < 4u; ik++) {                                                        \
+        CMM_UNROLL(uint ik = 0; ik < 4u; ik++) {                                                  \
             simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);               \
+            CMM_UNROLL(uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);         \
             simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);               \
+            CMM_UNROLL(uint i = 0; i < 2u; i++) simdgroup_load(mb[i], lsmb + 64u * i, 8);         \
             simdgroup_barrier(mem_flags::mem_none);                                               \
-            for (uint i = 0; i < 8u; i++)                                                         \
+            CMM_UNROLL(uint i = 0; i < 8u; i++)                                                   \
                 simdgroup_multiply_accumulate(mc[i], mb[i >> 2], ma[i & 3u], mc[i]);              \
             lsma += 8u * 64u;                                                                     \
             lsmb += 4u * 64u;                                                                     \
@@ -375,12 +376,12 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     if (rt + 32u <= p.m) {                                                                        \
         device float* C = dst + (ro + 32u * (sgid & 1u)) +                                        \
                           (ulong)(rt + 16u * (sgid >> 1)) * p.out_f;                              \
-        for (uint i = 0; i < 8u; i++)                                                             \
+        CMM_UNROLL(uint i = 0; i < 8u; i++)                                                       \
             simdgroup_store(mc[i], C + 8u * (i & 3u) + 8u * p.out_f * (i >> 2), p.out_f);         \
     } else {                                                                                      \
         /* partial token tile: stage through threadgroup memory, row-guard the copy-out */        \
         threadgroup float* tc = shraw + 32u * (sgid & 1u) + (16u * (sgid >> 1)) * 64u;            \
-        for (uint i = 0; i < 8u; i++)                                                             \
+        CMM_UNROLL(uint i = 0; i < 8u; i++)                                                       \
             simdgroup_store(mc[i], tc + 8u * (i & 3u) + 8u * 64u * (i >> 2), 64u);                \
         threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
         if (sgid == 0u) {                                                                         \

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -282,6 +282,7 @@ RT_KERNEL(linear_iq3s_rt, DEC16_IQ3S)
 RT_KERNEL(linear_iq2s_rt, DEC16_IQ2S)
 RT_KERNEL(linear_iq2xs_rt, DEC16_IQ2XS)
 RT_KERNEL(linear_f16_rt, DEC16_F16)
+RT_KERNEL(linear_bf16_rt, DEC16_BF16)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -283,6 +283,7 @@ RT_KERNEL(linear_iq2s_rt, DEC16_IQ2S)
 RT_KERNEL(linear_iq2xs_rt, DEC16_IQ2XS)
 RT_KERNEL(linear_f16_rt, DEC16_F16)
 RT_KERNEL(linear_bf16_rt, DEC16_BF16)
+RT_KERNEL(linear_f32_rt, DEC16_F32)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -294,7 +294,7 @@ RT_KERNEL(linear_bf16_rt, DEC16_BF16)
 // so every tile takes the MMA path. Requires out_f % 64 == 0 and in_f % 32 == 0; other shapes
 // fall back to the per-simdgroup HGEMM.
 #define CMM_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
-#define CMM_KERNEL(NAME, DEC)                                                                     \
+#define CMM_KERNEL_TYPED(NAME, DEC, WTYPE, WMAT, XTYPE, XVEC, XMAT)                             \
 kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
                  device const uchar*  codes [[buffer(1)]],                                       \
                  device const uchar*  scm   [[buffer(2)]],                                       \
@@ -315,9 +315,9 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     uint tid = sgid * 32u + lane;                                                                 \
     uint nr1 = min(32u, p.m - rt);                                                                \
                                                                                                   \
-    threadgroup float shraw[2048];  /* 8 KB: sa(4K half) + sb(2K half); reused f32 for stores */  \
-    threadgroup half* sa = (threadgroup half*)shraw;                                              \
-    threadgroup half* sb = ((threadgroup half*)shraw) + 2048u;                                    \
+    threadgroup float shraw[2048];  /* 8 KB: 4K sa + 4K sb; reused f32 for stores */              \
+    threadgroup WTYPE* sa = (threadgroup WTYPE*)shraw;                                            \
+    threadgroup XTYPE* sb = (threadgroup XTYPE*)(shraw + 1024u);                                  \
                                                                                                   \
     uint lr0 = tid >> 1;                 /* weight (output) row 0..63 */                          \
     uint il0 = tid & 1u;                 /* which 16-element half of the 32-K step */             \
@@ -325,8 +325,8 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     uint iyk = (tid & 3u) * 8u;          /* k offset within the 32-K step */                      \
     uint lr1c = min(lr1, nr1 - 1u);      /* clamp token loads to the matrix edge */               \
                                                                                                   \
-    simdgroup_half8x8 ma[4];                                                                      \
-    simdgroup_half8x8 mb[2];                                                                      \
+    WMAT ma[4];                                                                                   \
+    XMAT mb[2];                                                                                   \
     simdgroup_float8x8 mc[8];                                                                     \
     CMM_UNROLL(uint i = 0; i < 8u; i++) mc[i] = simdgroup_float8x8(0.0f);                         \
                                                                                                   \
@@ -348,19 +348,19 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
             uint lx = lr0 & 7u;                                                                   \
             CMM_UNROLL(uint i = 0; i < 16u; i++) {                                                \
                 uint sx = 2u * il0 + (i >> 3);                                                    \
-                sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (half)wk[i];                      \
+                sa[64u * (8u * sx + sy) + 8u * (i & 7u) + lx] = (WTYPE)wk[i];                     \
             }                                                                                     \
         }                                                                                         \
-        {   /* stage B: 8 activations per thread, two vectorized f32->f16 half4 stores */         \
+        {   /* stage B: 8 activations per thread, two vectorized stores */                       \
             uint ib = 4u * (tid & 3u) + (lr1 >> 3);                                               \
             uint ly = lr1 & 7u;                                                                   \
-            threadgroup half4* sb4 = (threadgroup half4*)(sb + 64u * ib + 8u * ly);               \
-            sb4[0] = half4(yv0);                                                                  \
-            sb4[1] = half4(yv1);                                                                  \
+            threadgroup XVEC* sb4 = (threadgroup XVEC*)(sb + 64u * ib + 8u * ly);                 \
+            sb4[0] = XVEC(yv0);                                                                   \
+            sb4[1] = XVEC(yv1);                                                                   \
         }                                                                                         \
         threadgroup_barrier(mem_flags::mem_threadgroup);                                          \
-        threadgroup const half* lsma = sa + 4u * 64u * (sgid & 1u);                               \
-        threadgroup const half* lsmb = sb + 2u * 64u * (sgid >> 1);                               \
+        threadgroup const WTYPE* lsma = sa + 4u * 64u * (sgid & 1u);                              \
+        threadgroup const XTYPE* lsmb = sb + 2u * 64u * (sgid >> 1);                              \
         CMM_UNROLL(uint ik = 0; ik < 4u; ik++) {                                                  \
             simdgroup_barrier(mem_flags::mem_none);                                               \
             CMM_UNROLL(uint i = 0; i < 4u; i++) simdgroup_load(ma[i], lsma + 64u * i, 8);         \
@@ -395,6 +395,11 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
         }                                                                                         \
     }                                                                                             \
 }
+
+#define CMM_KERNEL(NAME, DEC)                                                                     \
+    CMM_KERNEL_TYPED(NAME, DEC, half, simdgroup_half8x8, half, half4, simdgroup_half8x8)
+#define CMM_BF16_KERNEL(NAME, DEC)                                                                \
+    CMM_KERNEL_TYPED(NAME, DEC, bfloat, simdgroup_bfloat8x8, float, float4, simdgroup_float8x8)
 
 // Split-K cooperative GEMM for SMALL-m deep-k shapes (a chat turn's short suffix prefill,
 // speculative verify's k+1 rows): at m <= 15 the plain tile launches only out_f/64
@@ -556,6 +561,7 @@ CMM_KERNEL(linear_iq2s_cmm, DEC16_IQ2S)
 CMM_KERNEL(linear_iq2xs_cmm, DEC16_IQ2XS)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
 CMM_KERNEL(linear_f16_cmm, DEC16_F16)
+CMM_BF16_KERNEL(linear_bf16_cmm, DEC16_BF16)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
 HGEMM_KERNEL(linear_quik6_hmm, DEC16_K6)

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -553,6 +553,7 @@ CMM_KERNEL(linear_iq3s_cmm, DEC16_IQ3S)
 CMM_KERNEL(linear_iq2s_cmm, DEC16_IQ2S)
 CMM_KERNEL(linear_iq2xs_cmm, DEC16_IQ2XS)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
+CMM_KERNEL(linear_f16_cmm, DEC16_F16)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
 HGEMM_KERNEL(linear_quik6_hmm, DEC16_K6)

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -281,6 +281,7 @@ RT_KERNEL(linear_iq3xxs_rt, DEC16_IQ3XXS)
 RT_KERNEL(linear_iq3s_rt, DEC16_IQ3S)
 RT_KERNEL(linear_iq2s_rt, DEC16_IQ2S)
 RT_KERNEL(linear_iq2xs_rt, DEC16_IQ2XS)
+RT_KERNEL(linear_f16_rt, DEC16_F16)
 // Cooperative-tile half-fragment GEMM, mul_mm-shape: one 64-output x 32-token tile per 128-thread
 // threadgroup, NK=32 K-steps. What the simpler cooperative tile above lacked (each of its shapes
 // measured and replaced): weights AND activations are staged into threadgroup memory as

--- a/crates/infr-metal/shaders/moe.metal
+++ b/crates/infr-metal/shaders/moe.metal
@@ -294,7 +294,7 @@ RT_KERNEL(linear_bf16_rt, DEC16_BF16)
 // so every tile takes the MMA path. Requires out_f % 64 == 0 and in_f % 32 == 0; other shapes
 // fall back to the per-simdgroup HGEMM.
 #define CMM_UNROLL(x) _Pragma("clang loop unroll(full)") for (x)
-#define CMM_KERNEL_TYPED(NAME, DEC, WTYPE, WMAT, XTYPE, XVEC, XMAT)                             \
+#define CMM_KERNEL_TYPED(NAME, DEC, WTYPE, WMAT, XTYPE, XVEC, XMAT, SHWORDS, SBOFF)             \
 kernel void NAME(device const float*  x     [[buffer(0)]],                                       \
                  device const uchar*  codes [[buffer(1)]],                                       \
                  device const uchar*  scm   [[buffer(2)]],                                       \
@@ -315,9 +315,9 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
     uint tid = sgid * 32u + lane;                                                                 \
     uint nr1 = min(32u, p.m - rt);                                                                \
                                                                                                   \
-    threadgroup float shraw[2048];  /* 8 KB: 4K sa + 4K sb; reused f32 for stores */              \
+    threadgroup float shraw[SHWORDS];                                                             \
     threadgroup WTYPE* sa = (threadgroup WTYPE*)shraw;                                            \
-    threadgroup XTYPE* sb = (threadgroup XTYPE*)(shraw + 1024u);                                  \
+    threadgroup XTYPE* sb = (threadgroup XTYPE*)(shraw + SBOFF);                                  \
                                                                                                   \
     uint lr0 = tid >> 1;                 /* weight (output) row 0..63 */                          \
     uint il0 = tid & 1u;                 /* which 16-element half of the 32-K step */             \
@@ -397,9 +397,11 @@ kernel void NAME(device const float*  x     [[buffer(0)]],                      
 }
 
 #define CMM_KERNEL(NAME, DEC)                                                                     \
-    CMM_KERNEL_TYPED(NAME, DEC, half, simdgroup_half8x8, half, half4, simdgroup_half8x8)
+    CMM_KERNEL_TYPED(NAME, DEC, half, simdgroup_half8x8, half, half4, simdgroup_half8x8, 2048, 1024)
 #define CMM_BF16_KERNEL(NAME, DEC)                                                                \
-    CMM_KERNEL_TYPED(NAME, DEC, bfloat, simdgroup_bfloat8x8, float, float4, simdgroup_float8x8)
+    CMM_KERNEL_TYPED(NAME, DEC, bfloat, simdgroup_bfloat8x8, float, float4, simdgroup_float8x8, 2048, 1024)
+#define CMM_F32_KERNEL(NAME, DEC)                                                                 \
+    CMM_KERNEL_TYPED(NAME, DEC, float, simdgroup_float8x8, float, float4, simdgroup_float8x8, 3072, 2048)
 
 // Split-K cooperative GEMM for SMALL-m deep-k shapes (a chat turn's short suffix prefill,
 // speculative verify's k+1 rows): at m <= 15 the plain tile launches only out_f/64
@@ -562,6 +564,7 @@ CMM_KERNEL(linear_iq2xs_cmm, DEC16_IQ2XS)
 CMM_KERNEL(linear_q6k_cmm, DEC16_Q6K)
 CMM_KERNEL(linear_f16_cmm, DEC16_F16)
 CMM_BF16_KERNEL(linear_bf16_cmm, DEC16_BF16)
+CMM_F32_KERNEL(linear_f32_cmm, DEC16_F32)
 
 HGEMM_KERNEL(linear_quik4_hmm, DEC16_K4)
 HGEMM_KERNEL(linear_quik6_hmm, DEC16_K6)

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2532,9 +2532,8 @@ impl MetalBackend {
                     let f16_rt = f16_native
                         && (2..16).contains(&m)
                         && std::env::var("INFR_METAL_NO_F16_RT").is_err();
-                    let bf16_rt = bf16_native
-                        && (2..16).contains(&m)
-                        && std::env::var("INFR_METAL_NO_BF16_RT").is_err();
+                    let bf16_rt =
+                        bf16_native && m >= 2 && std::env::var("INFR_METAL_NO_BF16_RT").is_err();
                     let native_rt = if f16_rt {
                         Some("linear_f16_rt")
                     } else if bf16_rt {

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2516,6 +2516,8 @@ impl MetalBackend {
                 } else {
                     let f16_native =
                         wdt == DType::F16 && std::env::var("INFR_METAL_NO_F16_NATIVE").is_err();
+                    let f32_native =
+                        wdt == DType::F32 && std::env::var("INFR_METAL_NO_F32_NATIVE").is_err();
                     let f16_cmm = f16_native
                         && m >= 16
                         && out_f % 64 == 0
@@ -2530,6 +2532,7 @@ impl MetalBackend {
                         && std::env::var("INFR_METAL_NO_F16_RT").is_err();
                     let (kern, elem_bytes) = match wdt {
                         DType::F16 if f16_native => ("linear_f16", 2u64),
+                        DType::F32 if f32_native => ("linear_f32", 4u64),
                         _ => ("linear_f32", 4u64),
                     };
                     if f16_cmm {
@@ -2586,9 +2589,9 @@ impl MetalBackend {
                             m.div_ceil(8) * out_f * 32,
                             32,
                         );
-                    } else if f16_native {
-                        // Read the uploaded GGUF half buffer directly. Besides halving the weight
-                        // stream, this avoids a same-size host read plus a 2x f32 cache allocation.
+                    } else if f16_native || f32_native {
+                        // Read uploaded float weights directly. F16 also halves the stream; both
+                        // avoid a host read and redundant f32 device-cache allocation.
                         let bw =
                             metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
                         let pso = self.pipelines.get(kern)?;
@@ -2610,7 +2613,7 @@ impl MetalBackend {
                             32,
                         );
                     } else {
-                        // f32/bf16 weight: dequant-to-f32 device buffer, cached.
+                        // bf16 or a forced-control float weight: dequant-to-f32 device cache.
                         let bw = self.weight_buf(weight, g, bindings)?;
                         let pso = self.pipelines.get(kern)?;
                         if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern)

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2561,10 +2561,15 @@ impl MetalBackend {
                         && std::env::var("INFR_METAL_NO_F16_RT").is_err();
                     let bf16_rt =
                         bf16_native && m >= 2 && std::env::var("INFR_METAL_NO_BF16_RT").is_err();
+                    let f32_rt = f32_native
+                        && (2..16).contains(&m)
+                        && std::env::var("INFR_METAL_NO_F32_RT").is_err();
                     let native_rt = if f16_rt {
                         Some("linear_f16_rt")
                     } else if bf16_rt {
                         Some("linear_bf16_rt")
+                    } else if f32_rt {
+                        Some("linear_f32_rt")
                     } else {
                         None
                     };

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2532,6 +2532,16 @@ impl MetalBackend {
                     let f16_rt = f16_native
                         && (2..16).contains(&m)
                         && std::env::var("INFR_METAL_NO_F16_RT").is_err();
+                    let bf16_rt = bf16_native
+                        && (2..16).contains(&m)
+                        && std::env::var("INFR_METAL_NO_BF16_RT").is_err();
+                    let native_rt = if f16_rt {
+                        Some("linear_f16_rt")
+                    } else if bf16_rt {
+                        Some("linear_bf16_rt")
+                    } else {
+                        None
+                    };
                     let (kern, elem_bytes) = match wdt {
                         DType::F16 if f16_native => ("linear_f16", 2u64),
                         DType::F32 if f32_native => ("linear_f32", 4u64),
@@ -2565,10 +2575,10 @@ impl MetalBackend {
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,
                         );
-                    } else if f16_rt {
-                        let rt = self.pipelines.get("linear_f16_rt")?;
+                    } else if let Some(rt_kern) = native_rt {
+                        let rt = self.pipelines.get(rt_kern)?;
                         if let Some(label) =
-                            counter_linear_label(self.counter_set.is_some(), "linear_f16_rt")
+                            counter_linear_label(self.counter_set.is_some(), rt_kern)
                         {
                             r.cur_op = label;
                         }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2514,27 +2514,51 @@ impl MetalBackend {
                         );
                     }
                 } else {
-                    // f16/f32/bf16 weight: dequant-to-f32 device buffer, cached.
-                    let bw = self.weight_buf(weight, g, bindings)?;
-                    let pso = self.pipelines.get("linear_f32")?;
-                    if let Some(label) =
-                        counter_linear_label(self.counter_set.is_some(), "linear_f32")
-                    {
+                    let f16_native =
+                        wdt == DType::F16 && std::env::var("INFR_METAL_NO_F16_NATIVE").is_err();
+                    let (kern, elem_bytes) = match wdt {
+                        DType::F16 if f16_native => ("linear_f16", 2u64),
+                        _ => ("linear_f32", 4u64),
+                    };
+                    let pso = self.pipelines.get(kern)?;
+                    if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern) {
                         r.cur_op = label;
                     }
-                    self.encode_tg_off(
-                        r,
-                        &pso,
-                        &[
-                            (bx.as_ref(), 0),
-                            (bw.as_ref(), w_off as u64 * 4),
-                            (bd.as_ref(), 0),
-                        ],
-                        1 << 2,
-                        &p,
-                        m * out_f * 32,
-                        32,
-                    );
+                    if f16_native {
+                        // Read the uploaded GGUF half buffer directly. Besides halving the weight
+                        // stream, this avoids a same-size host read plus a 2x f32 cache allocation.
+                        let bw =
+                            metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        self.encode_tg_off(
+                            r,
+                            &pso,
+                            &[
+                                (bx.as_ref(), 0),
+                                (&bw.raw, w_off as u64 * elem_bytes),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 2,
+                            &p,
+                            m * out_f * 32,
+                            32,
+                        );
+                    } else {
+                        // f32/bf16 weight: dequant-to-f32 device buffer, cached.
+                        let bw = self.weight_buf(weight, g, bindings)?;
+                        self.encode_tg_off(
+                            r,
+                            &pso,
+                            &[
+                                (bx.as_ref(), 0),
+                                (bw.as_ref(), w_off as u64 * elem_bytes),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 2,
+                            &p,
+                            m * out_f * 32,
+                            32,
+                        );
+                    }
                 }
                 r.loc[dst.0 as usize] = Loc::Device;
             }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2529,6 +2529,22 @@ impl MetalBackend {
                             .get("linear_f16_cmm")?
                             .max_total_threads_per_threadgroup()
                             >= 128;
+                    let bf16_cmm = bf16_native
+                        && m >= 16
+                        && out_f % 64 == 0
+                        && std::env::var("INFR_METAL_NO_BF16_CMM").is_err()
+                        && self
+                            .pipelines
+                            .get("linear_bf16_cmm")?
+                            .max_total_threads_per_threadgroup()
+                            >= 128;
+                    let native_cmm = if f16_cmm {
+                        Some("linear_f16_cmm")
+                    } else if bf16_cmm {
+                        Some("linear_bf16_cmm")
+                    } else {
+                        None
+                    };
                     let f16_rt = f16_native
                         && (2..16).contains(&m)
                         && std::env::var("INFR_METAL_NO_F16_RT").is_err();
@@ -2547,10 +2563,10 @@ impl MetalBackend {
                         DType::Bf16 if bf16_native => ("linear_bf16", 2u64),
                         _ => ("linear_f32", 4u64),
                     };
-                    if f16_cmm {
-                        let cmm = self.pipelines.get("linear_f16_cmm")?;
+                    if let Some(cmm_kern) = native_cmm {
+                        let cmm = self.pipelines.get(cmm_kern)?;
                         if let Some(label) =
-                            counter_linear_label(self.counter_set.is_some(), "linear_f16_cmm")
+                            counter_linear_label(self.counter_set.is_some(), cmm_kern)
                         {
                             r.cur_op = label;
                         }

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2518,6 +2518,8 @@ impl MetalBackend {
                         wdt == DType::F16 && std::env::var("INFR_METAL_NO_F16_NATIVE").is_err();
                     let f32_native =
                         wdt == DType::F32 && std::env::var("INFR_METAL_NO_F32_NATIVE").is_err();
+                    let bf16_native =
+                        wdt == DType::Bf16 && std::env::var("INFR_METAL_NO_BF16_NATIVE").is_err();
                     let f16_cmm = f16_native
                         && m >= 16
                         && out_f % 64 == 0
@@ -2533,6 +2535,7 @@ impl MetalBackend {
                     let (kern, elem_bytes) = match wdt {
                         DType::F16 if f16_native => ("linear_f16", 2u64),
                         DType::F32 if f32_native => ("linear_f32", 4u64),
+                        DType::Bf16 if bf16_native => ("linear_bf16", 2u64),
                         _ => ("linear_f32", 4u64),
                     };
                     if f16_cmm {
@@ -2589,7 +2592,7 @@ impl MetalBackend {
                             m.div_ceil(8) * out_f * 32,
                             32,
                         );
-                    } else if f16_native || f32_native {
+                    } else if f16_native || f32_native || bf16_native {
                         // Read uploaded float weights directly. F16 also halves the stream; both
                         // avoid a host read and redundant f32 device-cache allocation.
                         let bw =

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2516,19 +2516,56 @@ impl MetalBackend {
                 } else {
                     let f16_native =
                         wdt == DType::F16 && std::env::var("INFR_METAL_NO_F16_NATIVE").is_err();
+                    let f16_cmm = f16_native
+                        && m >= 16
+                        && out_f % 64 == 0
+                        && std::env::var("INFR_METAL_NO_F16_CMM").is_err()
+                        && self
+                            .pipelines
+                            .get("linear_f16_cmm")?
+                            .max_total_threads_per_threadgroup()
+                            >= 128;
                     let (kern, elem_bytes) = match wdt {
                         DType::F16 if f16_native => ("linear_f16", 2u64),
                         _ => ("linear_f32", 4u64),
                     };
-                    let pso = self.pipelines.get(kern)?;
-                    if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern) {
-                        r.cur_op = label;
-                    }
-                    if f16_native {
+                    if f16_cmm {
+                        let cmm = self.pipelines.get("linear_f16_cmm")?;
+                        if let Some(label) =
+                            counter_linear_label(self.counter_set.is_some(), "linear_f16_cmm")
+                        {
+                            r.cur_op = label;
+                        }
+                        let bw =
+                            metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        let dummy = self.scratch_buf(1, 14);
+                        let mut cp = p.clone();
+                        cp.extend_from_slice(&0u32.to_ne_bytes());
+                        self.encode_tg_off(
+                            r,
+                            &cmm,
+                            &[
+                                (bx.as_ref(), 0),
+                                (&bw.raw, w_off as u64 * elem_bytes),
+                                (dummy.as_ref(), 0),
+                                (dummy.as_ref(), 0),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 4,
+                            &cp,
+                            m.div_ceil(32) * (out_f / 64) * 128,
+                            128,
+                        );
+                    } else if f16_native {
                         // Read the uploaded GGUF half buffer directly. Besides halving the weight
                         // stream, this avoids a same-size host read plus a 2x f32 cache allocation.
                         let bw =
                             metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        let pso = self.pipelines.get(kern)?;
+                        if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern)
+                        {
+                            r.cur_op = label;
+                        }
                         self.encode_tg_off(
                             r,
                             &pso,
@@ -2545,6 +2582,11 @@ impl MetalBackend {
                     } else {
                         // f32/bf16 weight: dequant-to-f32 device buffer, cached.
                         let bw = self.weight_buf(weight, g, bindings)?;
+                        let pso = self.pipelines.get(kern)?;
+                        if let Some(label) = counter_linear_label(self.counter_set.is_some(), kern)
+                        {
+                            r.cur_op = label;
+                        }
                         self.encode_tg_off(
                             r,
                             &pso,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2538,10 +2538,21 @@ impl MetalBackend {
                             .get("linear_bf16_cmm")?
                             .max_total_threads_per_threadgroup()
                             >= 128;
+                    let f32_cmm = f32_native
+                        && m >= 16
+                        && out_f % 64 == 0
+                        && std::env::var("INFR_METAL_NO_F32_CMM").is_err()
+                        && self
+                            .pipelines
+                            .get("linear_f32_cmm")?
+                            .max_total_threads_per_threadgroup()
+                            >= 128;
                     let native_cmm = if f16_cmm {
                         Some("linear_f16_cmm")
                     } else if bf16_cmm {
                         Some("linear_bf16_cmm")
+                    } else if f32_cmm {
+                        Some("linear_f32_cmm")
                     } else {
                         None
                     };

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -2525,6 +2525,9 @@ impl MetalBackend {
                             .get("linear_f16_cmm")?
                             .max_total_threads_per_threadgroup()
                             >= 128;
+                    let f16_rt = f16_native
+                        && (2..16).contains(&m)
+                        && std::env::var("INFR_METAL_NO_F16_RT").is_err();
                     let (kern, elem_bytes) = match wdt {
                         DType::F16 if f16_native => ("linear_f16", 2u64),
                         _ => ("linear_f32", 4u64),
@@ -2555,6 +2558,33 @@ impl MetalBackend {
                             &cp,
                             m.div_ceil(32) * (out_f / 64) * 128,
                             128,
+                        );
+                    } else if f16_rt {
+                        let rt = self.pipelines.get("linear_f16_rt")?;
+                        if let Some(label) =
+                            counter_linear_label(self.counter_set.is_some(), "linear_f16_rt")
+                        {
+                            r.cur_op = label;
+                        }
+                        let bw =
+                            metal_buf(bindings.get(weight).expect("metal backend: unbound Weight"));
+                        let dummy = self.scratch_buf(1, 14);
+                        let mut rp = p.clone();
+                        rp.extend_from_slice(&0u32.to_ne_bytes());
+                        self.encode_tg_off(
+                            r,
+                            &rt,
+                            &[
+                                (bx.as_ref(), 0),
+                                (&bw.raw, w_off as u64 * elem_bytes),
+                                (dummy.as_ref(), 0),
+                                (dummy.as_ref(), 0),
+                                (bd.as_ref(), 0),
+                            ],
+                            1 << 4,
+                            &rp,
+                            m.div_ceil(8) * out_f * 32,
+                            32,
                         );
                     } else if f16_native {
                         // Read the uploaded GGUF half buffer directly. Besides halving the weight

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -184,7 +184,7 @@ fn bf16_rt_probe() {
         })
         .collect();
 
-    for m in [2usize, 4, 8] {
+    for m in [2usize, 4, 8, 16, 32] {
         std::env::set_var("INFR_METAL_NO_BF16_RT", "1");
         bench_chained_m(
             DType::Bf16,
@@ -196,7 +196,15 @@ fn bf16_rt_probe() {
             "bf16 native-gemv",
         );
         std::env::remove_var("INFR_METAL_NO_BF16_RT");
-        bench_chained_m(DType::Bf16, &w16, m, in_f, out_f, 16.0, "bf16 rt");
+        bench_chained_m(
+            DType::Bf16,
+            &w16,
+            m,
+            in_f,
+            out_f,
+            16.0 * m.div_ceil(8) as f64,
+            "bf16 rt",
+        );
     }
 }
 

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -156,6 +156,57 @@ fn f16_native_probe() {
     bench_chained(DType::F16, &w16, in_f, out_f, 16.0, "f16 native");
 }
 
+fn bench_f32_cold(wbytes: &[u8], in_f: usize, out_f: usize, force_cache: bool, label: &str) {
+    if force_cache {
+        std::env::set_var("INFR_METAL_NO_F32_NATIVE", "1");
+    } else {
+        std::env::remove_var("INFR_METAL_NO_F32_NATIVE");
+    }
+    let be = MetalBackend::new().unwrap();
+    let xs = vec![0.01f32; in_f];
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![1, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], DType::F32));
+    let dst = g.output(TensorDesc::new(vec![1, out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst,
+        m: 1,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+        w_off: 0,
+    });
+    let xb = be.alloc(in_f * 4, BufferUsage::Activations).unwrap();
+    let wb = be.alloc(wbytes.len(), BufferUsage::Weights).unwrap();
+    let ob = be.alloc(out_f * 4, BufferUsage::Activations).unwrap();
+    be.upload(xb.as_ref(), bytemuck::cast_slice(&xs)).unwrap();
+    be.upload(wb.as_ref(), wbytes).unwrap();
+    let mut bindings = Bindings::new();
+    bindings.bind(x, xb.as_ref());
+    bindings.bind(w, wb.as_ref());
+    bindings.bind(dst, ob.as_ref());
+    let plan = be.compile(&g).unwrap();
+
+    let t0 = std::time::Instant::now();
+    be.execute(plan.as_ref(), &bindings).unwrap();
+    println!(
+        "{label}: {:.3} ms cold execute",
+        t0.elapsed().as_secs_f64() * 1e3
+    );
+}
+
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f32_native_cold_probe() {
+    let (in_f, out_f) = (1024usize, 16384usize);
+    let wf: Vec<f32> = (0..out_f * in_f).map(|i| (i % 13) as f32 * 0.01).collect();
+    let wbytes = bytemuck::cast_slice(&wf);
+    bench_f32_cold(wbytes, in_f, out_f, true, "f32 cached copy");
+    bench_f32_cold(wbytes, in_f, out_f, false, "f32 direct");
+    std::env::remove_var("INFR_METAL_NO_F32_NATIVE");
+}
+
 #[test]
 #[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
 fn f16_cmm_probe() {

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -173,6 +173,33 @@ fn bf16_native_probe() {
     bench_chained(DType::Bf16, &w16, in_f, out_f, 16.0, "bf16 native");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn bf16_rt_probe() {
+    let (in_f, out_f) = (1152usize, 8192usize);
+    let w16: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| {
+            let v = (i % 13) as f32 * 0.01;
+            ((v.to_bits() >> 16) as u16).to_le_bytes()
+        })
+        .collect();
+
+    for m in [2usize, 4, 8] {
+        std::env::set_var("INFR_METAL_NO_BF16_RT", "1");
+        bench_chained_m(
+            DType::Bf16,
+            &w16,
+            m,
+            in_f,
+            out_f,
+            16.0 * m as f64,
+            "bf16 native-gemv",
+        );
+        std::env::remove_var("INFR_METAL_NO_BF16_RT");
+        bench_chained_m(DType::Bf16, &w16, m, in_f, out_f, 16.0, "bf16 rt");
+    }
+}
+
 fn bench_f32_cold(wbytes: &[u8], in_f: usize, out_f: usize, force_cache: bool, label: &str) {
     if force_cache {
         std::env::set_var("INFR_METAL_NO_F32_NATIVE", "1");

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -290,6 +290,30 @@ fn f32_native_cold_probe() {
 
 #[test]
 #[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f32_rt_probe() {
+    let (in_f, out_f) = (1152usize, 8192usize);
+    let w32: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| ((i % 13) as f32 * 0.01).to_le_bytes())
+        .collect();
+
+    for m in [2usize, 4, 8] {
+        std::env::set_var("INFR_METAL_NO_F32_RT", "1");
+        bench_chained_m(
+            DType::F32,
+            &w32,
+            m,
+            in_f,
+            out_f,
+            32.0 * m as f64,
+            "f32 native-gemv",
+        );
+        std::env::remove_var("INFR_METAL_NO_F32_RT");
+        bench_chained_m(DType::F32, &w32, m, in_f, out_f, 32.0, "f32 rt");
+    }
+}
+
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
 fn f32_cmm_probe() {
     let (in_f, out_f) = (1152usize, 8192usize);
     let w32: Vec<u8> = (0..out_f * in_f)

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -140,6 +140,22 @@ fn q5k_swar_probe() {
     bench_chained(DType::Q5K, &wq5k, 1152, 65536, 5.5, "q5k head");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f16_native_probe() {
+    let (in_f, out_f) = (1152usize, 65536usize);
+    let wf: Vec<f32> = (0..out_f * in_f).map(|i| (i % 13) as f32 * 0.01).collect();
+    let w16: Vec<u8> = wf
+        .into_iter()
+        .flat_map(|v| half::f16::from_f32(v).to_le_bytes())
+        .collect();
+
+    std::env::set_var("INFR_METAL_NO_F16_NATIVE", "1");
+    bench_chained(DType::F16, &w16, in_f, out_f, 32.0, "f16 cached-f32");
+    std::env::remove_var("INFR_METAL_NO_F16_NATIVE");
+    bench_chained(DType::F16, &w16, in_f, out_f, 16.0, "f16 native");
+}
+
 fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
     let mut out = Vec::new();
     for blk_i in 0..(n_elem / 32) {

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -156,6 +156,28 @@ fn f16_native_probe() {
     bench_chained(DType::F16, &w16, in_f, out_f, 16.0, "f16 native");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f16_cmm_probe() {
+    let (m, in_f, out_f) = (32usize, 1152usize, 8192usize);
+    let w16: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| half::f16::from_f32((i % 13) as f32 * 0.01).to_le_bytes())
+        .collect();
+
+    std::env::set_var("INFR_METAL_NO_F16_CMM", "1");
+    bench_chained_m(
+        DType::F16,
+        &w16,
+        m,
+        in_f,
+        out_f,
+        16.0 * m as f64,
+        "f16 native-gemv",
+    );
+    std::env::remove_var("INFR_METAL_NO_F16_CMM");
+    bench_chained_m(DType::F16, &w16, m, in_f, out_f, 16.0, "f16 cmm");
+}
+
 fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
     let mut out = Vec::new();
     for blk_i in 0..(n_elem / 32) {

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -290,6 +290,30 @@ fn f32_native_cold_probe() {
 
 #[test]
 #[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f32_cmm_probe() {
+    let (in_f, out_f) = (1152usize, 8192usize);
+    let w32: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| ((i % 13) as f32 * 0.01).to_le_bytes())
+        .collect();
+
+    for m in [16usize, 32] {
+        std::env::set_var("INFR_METAL_NO_F32_CMM", "1");
+        bench_chained_m(
+            DType::F32,
+            &w32,
+            m,
+            in_f,
+            out_f,
+            32.0 * m as f64,
+            "f32 native-gemv",
+        );
+        std::env::remove_var("INFR_METAL_NO_F32_CMM");
+        bench_chained_m(DType::F32, &w32, m, in_f, out_f, 32.0, "f32 cmm");
+    }
+}
+
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
 fn f16_cmm_probe() {
     let (m, in_f, out_f) = (32usize, 1152usize, 8192usize);
     let w16: Vec<u8> = (0..out_f * in_f)

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -184,6 +184,7 @@ fn bf16_rt_probe() {
         })
         .collect();
 
+    std::env::set_var("INFR_METAL_NO_BF16_CMM", "1");
     for m in [2usize, 4, 8, 16, 32] {
         std::env::set_var("INFR_METAL_NO_BF16_RT", "1");
         bench_chained_m(
@@ -205,6 +206,34 @@ fn bf16_rt_probe() {
             16.0 * m.div_ceil(8) as f64,
             "bf16 rt",
         );
+    }
+    std::env::remove_var("INFR_METAL_NO_BF16_CMM");
+}
+
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn bf16_cmm_probe() {
+    let (in_f, out_f) = (1152usize, 8192usize);
+    let w16: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| {
+            let v = (i % 13) as f32 * 0.01;
+            ((v.to_bits() >> 16) as u16).to_le_bytes()
+        })
+        .collect();
+
+    for m in [16usize, 32] {
+        std::env::set_var("INFR_METAL_NO_BF16_CMM", "1");
+        bench_chained_m(
+            DType::Bf16,
+            &w16,
+            m,
+            in_f,
+            out_f,
+            16.0 * m.div_ceil(8) as f64,
+            "bf16 rt",
+        );
+        std::env::remove_var("INFR_METAL_NO_BF16_CMM");
+        bench_chained_m(DType::Bf16, &w16, m, in_f, out_f, 16.0, "bf16 cmm");
     }
 }
 

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -156,6 +156,23 @@ fn f16_native_probe() {
     bench_chained(DType::F16, &w16, in_f, out_f, 16.0, "f16 native");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn bf16_native_probe() {
+    let (in_f, out_f) = (1152usize, 65536usize);
+    let w16: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| {
+            let v = (i % 13) as f32 * 0.01;
+            ((v.to_bits() >> 16) as u16).to_le_bytes()
+        })
+        .collect();
+
+    std::env::set_var("INFR_METAL_NO_BF16_NATIVE", "1");
+    bench_chained(DType::Bf16, &w16, in_f, out_f, 32.0, "bf16 cached-f32");
+    std::env::remove_var("INFR_METAL_NO_BF16_NATIVE");
+    bench_chained(DType::Bf16, &w16, in_f, out_f, 16.0, "bf16 native");
+}
+
 fn bench_f32_cold(wbytes: &[u8], in_f: usize, out_f: usize, force_cache: bool, label: &str) {
     if force_cache {
         std::env::set_var("INFR_METAL_NO_F32_NATIVE", "1");

--- a/crates/infr-metal/tests/gemv_bw.rs
+++ b/crates/infr-metal/tests/gemv_bw.rs
@@ -178,6 +178,30 @@ fn f16_cmm_probe() {
     bench_chained_m(DType::F16, &w16, m, in_f, out_f, 16.0, "f16 cmm");
 }
 
+#[test]
+#[ignore = "requires a Metal GPU; evidence probe, not a correctness test"]
+fn f16_rt_probe() {
+    let (in_f, out_f) = (1152usize, 8192usize);
+    let w16: Vec<u8> = (0..out_f * in_f)
+        .flat_map(|i| half::f16::from_f32((i % 13) as f32 * 0.01).to_le_bytes())
+        .collect();
+
+    for m in [2usize, 4, 8] {
+        std::env::set_var("INFR_METAL_NO_F16_RT", "1");
+        bench_chained_m(
+            DType::F16,
+            &w16,
+            m,
+            in_f,
+            out_f,
+            16.0 * m as f64,
+            "f16 native-gemv",
+        );
+        std::env::remove_var("INFR_METAL_NO_F16_RT");
+        bench_chained_m(DType::F16, &w16, m, in_f, out_f, 16.0, "f16 rt");
+    }
+}
+
 fn synth_q5_0(n_elem: usize, seed: u32) -> Vec<u8> {
     let mut out = Vec::new();
     for blk_i in 0..(n_elem / 32) {

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -143,7 +143,7 @@ fn f16_small_multirow_linear_uses_the_exact_row_tile() {
 
     let exec = include_str!("../src/exec.rs");
     asserts_token_seq(exec, "let f16_rt = f16_native && (2..16).contains(&m)");
-    asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_rt\")");
+    asserts_token_seq(exec, "Some(\"linear_f16_rt\")");
 }
 
 #[test]
@@ -167,6 +167,16 @@ fn bf16_linear_reads_the_bound_weight_directly() {
         exec,
         "DType::Bf16 if bf16_native => (\"linear_bf16\", 2u64)",
     );
+}
+
+#[test]
+fn bf16_small_multirow_linear_uses_the_exact_row_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "RT_KERNEL(linear_bf16_rt, DEC16_BF16)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let bf16_rt = bf16_native && (2..16).contains(&m)");
+    asserts_token_seq(exec, "Some(\"linear_bf16_rt\")");
 }
 
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -66,7 +66,7 @@ fn asserts_token_seq(src: &str, needle: &str) {
     );
 }
 
-// The three tripwires below guard OPTIMIZATIONS, not correctness. The parity tests pass whether
+// The four tripwires below guard OPTIMIZATIONS, not correctness. The parity tests pass whether
 // or not these are present (a reverted optimization is still numerically right, just slower), so
 // nothing else in the suite would notice if one silently vanished — the exact failure mode this
 // file's header describes. That is why they assert on shader source at all.
@@ -97,6 +97,24 @@ fn q5k_reconstructs_four_codes_per_word() {
     asserts_token_seq(src, "uint packed = (q & 0x0F0F0F0Fu)");
     asserts_token_seq(src, "(h & 0x01010101u) << 4u");
     asserts_token_seq(src, "packed >> 24u");
+}
+
+#[test]
+fn regular_cmm_unrolls_its_fixed_tile_loops() {
+    let src = include_str!("../shaders/moe.metal");
+    asserts_token_seq(
+        src,
+        "#define CMM_UNROLL(x) _Pragma(\"clang loop unroll(full)\") for (x)",
+    );
+    let compact = despace(src);
+    let cmm = compact
+        .split_once(&despace("#define CMM_KERNEL(NAME, DEC)"))
+        .unwrap()
+        .1
+        .split_once(&despace("#define CMMKS_KERNEL(NAME, DEC)"))
+        .unwrap()
+        .0;
+    assert!(cmm.matches("CMM_UNROLL").count() >= 8);
 }
 
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -170,12 +170,12 @@ fn bf16_linear_reads_the_bound_weight_directly() {
 }
 
 #[test]
-fn bf16_small_multirow_linear_uses_the_exact_row_tile() {
+fn bf16_multirow_linear_uses_the_exact_row_tile() {
     let shader = include_str!("../shaders/moe.metal");
     asserts_token_seq(shader, "RT_KERNEL(linear_bf16_rt, DEC16_BF16)");
 
     let exec = include_str!("../src/exec.rs");
-    asserts_token_seq(exec, "let bf16_rt = bf16_native && (2..16).contains(&m)");
+    asserts_token_seq(exec, "let bf16_rt = bf16_native && m >= 2");
     asserts_token_seq(exec, "Some(\"linear_bf16_rt\")");
 }
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -169,6 +169,16 @@ fn f32_large_multirow_linear_uses_the_cooperative_tile() {
 }
 
 #[test]
+fn f32_small_multirow_linear_uses_the_exact_row_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "RT_KERNEL(linear_f32_rt, DEC16_F32)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let f32_rt = f32_native && (2..16).contains(&m)");
+    asserts_token_seq(exec, "Some(\"linear_f32_rt\")");
+}
+
+#[test]
 fn bf16_linear_reads_the_bound_weight_directly() {
     let shader = include_str!("../shaders/linear.metal");
     asserts_token_seq(shader, "kernel void linear_bf16");

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -146,6 +146,16 @@ fn f16_small_multirow_linear_uses_the_exact_row_tile() {
     asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_rt\")");
 }
 
+#[test]
+fn f32_linear_reads_the_bound_weight_directly() {
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(
+        exec,
+        "let f32_native = wdt == DType::F32 && std::env::var(\"INFR_METAL_NO_F32_NATIVE\").is_err()",
+    );
+    asserts_token_seq(exec, "DType::F32 if f32_native => (\"linear_f32\", 4u64)");
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -156,6 +156,19 @@ fn f32_linear_reads_the_bound_weight_directly() {
     asserts_token_seq(exec, "DType::F32 if f32_native => (\"linear_f32\", 4u64)");
 }
 
+#[test]
+fn bf16_linear_reads_the_bound_weight_directly() {
+    let shader = include_str!("../shaders/linear.metal");
+    asserts_token_seq(shader, "kernel void linear_bf16");
+    asserts_token_seq(shader, "as_type<float>((uint)wo[i] << 16u)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(
+        exec,
+        "DType::Bf16 if bf16_native => (\"linear_bf16\", 2u64)",
+    );
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -136,6 +136,16 @@ fn f16_multirow_linear_uses_the_cooperative_tile() {
     asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_cmm\")");
 }
 
+#[test]
+fn f16_small_multirow_linear_uses_the_exact_row_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "RT_KERNEL(linear_f16_rt, DEC16_F16)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let f16_rt = f16_native && (2..16).contains(&m)");
+    asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_rt\")");
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -126,6 +126,16 @@ fn f16_linear_reads_the_bound_weight_directly() {
     asserts_token_seq(exec, "DType::F16 if f16_native => (\"linear_f16\", 2u64)");
 }
 
+#[test]
+fn f16_multirow_linear_uses_the_cooperative_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "CMM_KERNEL(linear_f16_cmm, DEC16_F16)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let f16_cmm = f16_native && m >= 16");
+    asserts_token_seq(exec, "self.pipelines.get(\"linear_f16_cmm\")");
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -109,7 +109,7 @@ fn regular_cmm_unrolls_its_fixed_tile_loops() {
     let compact = despace(src);
     let cmm = compact
         .split_once(&despace(
-            "#define CMM_KERNEL_TYPED(NAME, DEC, WTYPE, WMAT, XTYPE, XVEC, XMAT)",
+            "#define CMM_KERNEL_TYPED(NAME, DEC, WTYPE, WMAT, XTYPE, XVEC, XMAT, SHWORDS, SBOFF)",
         ))
         .unwrap()
         .1
@@ -156,6 +156,16 @@ fn f32_linear_reads_the_bound_weight_directly() {
         "let f32_native = wdt == DType::F32 && std::env::var(\"INFR_METAL_NO_F32_NATIVE\").is_err()",
     );
     asserts_token_seq(exec, "DType::F32 if f32_native => (\"linear_f32\", 4u64)");
+}
+
+#[test]
+fn f32_large_multirow_linear_uses_the_cooperative_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "CMM_F32_KERNEL(linear_f32_cmm, DEC16_F32)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let f32_cmm = f32_native && m >= 16");
+    asserts_token_seq(exec, "Some(\"linear_f32_cmm\")");
 }
 
 #[test]

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -117,6 +117,15 @@ fn regular_cmm_unrolls_its_fixed_tile_loops() {
     assert!(cmm.matches("CMM_UNROLL").count() >= 8);
 }
 
+#[test]
+fn f16_linear_reads_the_bound_weight_directly() {
+    let shader = include_str!("../shaders/linear.metal");
+    asserts_token_seq(shader, "kernel void linear_f16");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "DType::F16 if f16_native => (\"linear_f16\", 2u64)");
+}
+
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can
 // rot into a tautology (matching something that is always present) and nothing would say so.
 

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -108,7 +108,9 @@ fn regular_cmm_unrolls_its_fixed_tile_loops() {
     );
     let compact = despace(src);
     let cmm = compact
-        .split_once(&despace("#define CMM_KERNEL(NAME, DEC)"))
+        .split_once(&despace(
+            "#define CMM_KERNEL_TYPED(NAME, DEC, WTYPE, WMAT, XTYPE, XVEC, XMAT)",
+        ))
         .unwrap()
         .1
         .split_once(&despace("#define CMMKS_KERNEL(NAME, DEC)"))
@@ -177,6 +179,16 @@ fn bf16_multirow_linear_uses_the_exact_row_tile() {
     let exec = include_str!("../src/exec.rs");
     asserts_token_seq(exec, "let bf16_rt = bf16_native && m >= 2");
     asserts_token_seq(exec, "Some(\"linear_bf16_rt\")");
+}
+
+#[test]
+fn bf16_large_multirow_linear_uses_the_cooperative_tile() {
+    let shader = include_str!("../shaders/moe.metal");
+    asserts_token_seq(shader, "CMM_BF16_KERNEL(linear_bf16_cmm, DEC16_BF16)");
+
+    let exec = include_str!("../src/exec.rs");
+    asserts_token_seq(exec, "let bf16_cmm = bf16_native && m >= 16");
+    asserts_token_seq(exec, "Some(\"linear_bf16_cmm\")");
 }
 
 // The two below test the TRIPWIRE ITSELF. A guard nobody has watched fail is not a guard: it can

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -560,6 +560,14 @@ fn linear_woff_f16_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f32_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 353);
+    check_linear_woff(DType::F32, f32_bytes(&wf), 1, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_f16_rt() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 352);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -576,6 +576,14 @@ fn linear_woff_f32_cmm() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f32_rt() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 359);
+    check_linear_woff(DType::F32, f32_bytes(&wf), 8, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_bf16_gemv() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 354);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -584,6 +584,14 @@ fn linear_woff_bf16_rt() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_bf16_rt_multirow() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 356);
+    check_linear_woff(DType::Bf16, bf16_bytes(&wf), 32, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_f16_rt() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 352);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -576,6 +576,14 @@ fn linear_woff_bf16_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_bf16_rt() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 355);
+    check_linear_woff(DType::Bf16, bf16_bytes(&wf), 8, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_f16_rt() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 352);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -568,6 +568,14 @@ fn linear_woff_f32_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_bf16_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 354);
+    check_linear_woff(DType::Bf16, bf16_bytes(&wf), 1, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_f16_rt() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 352);
@@ -687,6 +695,30 @@ fn linear_f16_parity() {
     let bound = vec![
         (x, f32_bytes(&rand_f32(m * in_f, 22))),
         (w, f16_bytes(&rand_f32(out_f * in_f, 23))),
+    ];
+    assert_parity(&g, &bound, dst, m * out_f, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_bf16_parity() {
+    let (m, in_f, out_f) = (2usize, 256usize, 128usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], DType::Bf16));
+    let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst,
+        m: m as u32,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+        w_off: 0,
+    });
+    let bound = vec![
+        (x, f32_bytes(&rand_f32(m * in_f, 231))),
+        (w, bf16_bytes(&rand_f32(out_f * in_f, 232))),
     ];
     assert_parity(&g, &bound, dst, m * out_f, 1e-3);
 }

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -560,6 +560,14 @@ fn linear_woff_f16_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f16_rt() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 352);
+    check_linear_woff(DType::F16, f16_bytes(&wf), 8, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_f16_cmm() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 351);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -568,6 +568,14 @@ fn linear_woff_f32_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f32_cmm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 358);
+    check_linear_woff(DType::F32, f32_bytes(&wf), 40, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_bf16_gemv() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 354);

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -585,9 +585,41 @@ fn linear_woff_bf16_rt() {
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn linear_woff_bf16_rt_multirow() {
-    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let (in_f, slices) = (256usize, [96usize, 80, 80]);
     let wf = rand_f32(256 * in_f, 356);
     check_linear_woff(DType::Bf16, bf16_bytes(&wf), 32, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_woff_bf16_cmm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 357);
+    check_linear_woff(DType::Bf16, bf16_bytes(&wf), 40, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_bf16_cmm_preserves_wide_finite_weights() {
+    let (m, in_f, out_f) = (16usize, 32usize, 64usize);
+    let mut g = Graph::new();
+    let x = g.input(TensorDesc::new(vec![m, in_f], DType::F32));
+    let w = g.weight(TensorDesc::new(vec![out_f, in_f], DType::Bf16));
+    let dst = g.output(TensorDesc::new(vec![m, out_f], DType::F32));
+    g.push(Op::Linear {
+        x,
+        weight: w,
+        dst,
+        m: m as u32,
+        in_f: in_f as u32,
+        out_f: out_f as u32,
+        w_off: 0,
+    });
+    let bound = vec![
+        (x, f32_bytes(&vec![2.0f32.powi(-14); m * in_f])),
+        (w, bf16_bytes(&vec![65536.0; out_f * in_f])),
+    ];
+    assert_parity(&g, &bound, dst, m * out_f, 1e-3);
 }
 
 #[test]

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -560,6 +560,14 @@ fn linear_woff_f16_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f16_cmm() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 351);
+    check_linear_woff(DType::F16, f16_bytes(&wf), 40, in_f, &slices, true, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_q8_0_coop_gemm() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 36);
@@ -665,6 +673,14 @@ fn linear_f16_parity() {
         (w, f16_bytes(&rand_f32(out_f * in_f, 23))),
     ];
     assert_parity(&g, &bound, dst, m * out_f, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn linear_f16_cmm_parity() {
+    let (m, in_f, out_f) = (40usize, 256usize, 128usize);
+    let wf = rand_f32(out_f * in_f, 230);
+    check_quant_linear_parity_impl(DType::F16, f16_bytes(&wf), m, in_f, out_f, 1e-3, true);
 }
 
 // Quantized Linear: Metal dequants the weight to f32 (via infr_gguf) and matmuls. Compare to a

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -552,6 +552,14 @@ fn linear_woff_q8_0_gemv() {
 
 #[test]
 #[ignore = "requires a Metal GPU"]
+fn linear_woff_f16_gemv() {
+    let (in_f, slices) = (256usize, [128usize, 64, 64]);
+    let wf = rand_f32(256 * in_f, 350);
+    check_linear_woff(DType::F16, f16_bytes(&wf), 1, in_f, &slices, false, 1e-3);
+}
+
+#[test]
+#[ignore = "requires a Metal GPU"]
 fn linear_woff_q8_0_coop_gemm() {
     let (in_f, slices) = (256usize, [128usize, 64, 64]);
     let wf = rand_f32(256 * in_f, 36);


### PR DESCRIPTION
## Summary

- instantiate the exact eight-row Metal tile for native F32 weights
- route F32 linear workloads with 2-15 rows through the tile
- retain native GEMV for one row and cooperative matmul for aligned workloads with 16 or more rows
- add route tripwires, sliced-offset parity, and an isolated benchmark probe

Stacked on #62.

## Performance

Apple M3 Pro, `8192x1152` linear after a 60-second cooldown:

| Rows | Native F32 GEMV | F32 row tile | Speedup |
| ---: | ---: | ---: | ---: |
| 2 | 0.627 ms | 0.342 ms | 1.83x |
| 4 | 1.348 ms | 0.327 ms | 4.12x |
| 8 | 2.548 ms | 0.456 ms | 5.59x |

## Validation

- `cargo fmt --check`
- `cargo clippy -p infr-metal --all-targets --locked -- -D warnings`
- `cargo test -p infr-metal --locked -- --include-ignored`
- 126 Metal parity tests passed
