### PR TITLE
fix(metal): thread RequestCtx through the macOS chat/seam path

### DIFF
--- a/crates/infr-llama/src/chat/metal.rs
+++ b/crates/infr-llama/src/chat/metal.rs
@@ -82,7 +82,7 @@ impl ChatModel for MetalSeamChat {
         // (No INFR_METAL_PROFILE suppression: the Metal backend reads it at CONSTRUCTION —
         // which happens inside this first generate — so unsetting it here would disable
         // profiling for the whole session, not just the warmup.)
-        self.generate("Hi", 2, &mut |_| {})?;
+        self.generate("Hi", 2, None, &mut |_| {})?;
         // Drop the warmup tokens so the first real prompt prefills clean slots from row 0
         // instead of forking off a garbage prefix.
         if let Some(s) = &mut self.session {
@@ -95,12 +95,17 @@ impl ChatModel for MetalSeamChat {
         &mut self,
         prompt: &str,
         max_new: usize,
+        req: Option<&crate::sampling::RequestCtx>,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
         // MTP (INFR_MTP=1 on a qwen35 head-bearing GGUF): the draft-verify-catchup loop over the
         // Metal trunk + head, instead of the plain session decode. The committed stream is the
         // target's greedy stream (the same invariant Vulkan MTP holds), so the two are
         // token-identical — pinned by the greedy-equivalence check in the CLI validation.
+        //
+        // `req` is deliberately NOT threaded here: the MTP driver is greedy-only (see
+        // `mtp::mtp_enabled`'s doc and `generate_mtp_spec_metal`), so per-request sampling has
+        // nowhere to land. The Vulkan twin drops it on the same branch for the same reason.
         if self.wants_mtp()? {
             let head = self.mtp_head.as_ref().expect("wants_mtp loaded it");
             return crate::mtp::generate_mtp_spec_metal(&self.model, head, prompt, max_new, |p| {
@@ -108,10 +113,13 @@ impl ChatModel for MetalSeamChat {
             });
         }
         self.ensure_session()?;
-        self.model
-            .generate_metal_session(self.session.as_mut().unwrap(), prompt, max_new, |p| {
-                on_piece(p)
-            })
+        self.model.generate_metal_session(
+            self.session.as_mut().unwrap(),
+            prompt,
+            max_new,
+            req,
+            |p| on_piece(p),
+        )
     }
 
     fn generate_constrained(
@@ -119,6 +127,7 @@ impl ChatModel for MetalSeamChat {
         prompt: &str,
         max_new: usize,
         constraint: &mut crate::grammar::Constraint,
+        req: Option<&crate::sampling::RequestCtx>,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
         self.ensure_session()?;
@@ -127,6 +136,7 @@ impl ChatModel for MetalSeamChat {
             prompt,
             max_new,
             Some(constraint),
+            req,
             |p| on_piece(p),
         )
     }
@@ -187,7 +197,7 @@ impl ChatModel for SpecMetalChat {
     fn warmup(&mut self) -> Result<()> {
         // Compile BOTH models' pipelines now (a spec round drives target prefill, draft decode,
         // and the batched verify) so serve's first request doesn't pay two cold starts.
-        self.generate("Hi", 2, &mut |_| {})?;
+        self.generate("Hi", 2, None, &mut |_| {})?;
         // Drop the warmup tokens so the first real prompt prefills clean slots from row 0.
         if let Some(s) = &mut self.target_session {
             s.reset_cache();
@@ -202,6 +212,9 @@ impl ChatModel for SpecMetalChat {
         &mut self,
         prompt: &str,
         max_new: usize,
+        // Speculative decode is GREEDY-ONLY (`generate_metal_spec` asserts INFR_TEMP=0 — the
+        // accept rule requires the target's argmax), so per-request sampling has nowhere to land.
+        _req: Option<&crate::sampling::RequestCtx>,
         on_piece: &mut dyn FnMut(&str),
     ) -> Result<GenStats> {
         self.ensure_sessions()?;

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -1149,6 +1149,7 @@ pub(crate) fn generate_dense_metal(
     prompt: &[u32],
     max_new: usize,
     on_token: impl FnMut(u32),
+    req: Option<&crate::sampling::RequestCtx>,
 ) -> AResult<(Vec<u32>, GenStats)> {
     generate_dense_metal_session(
         mtl,
@@ -1162,6 +1163,7 @@ pub(crate) fn generate_dense_metal(
         &mut None,
         prompt.len() + max_new + 1,
         None,
+        req,
     )
 }
 
@@ -1183,6 +1185,7 @@ pub(crate) fn generate_dense_metal_session(
     state: &mut Option<SeamKv>,
     want_ctx: usize,
     constraint: Option<&mut crate::grammar::Constraint>,
+    req: Option<&crate::sampling::RequestCtx>,
 ) -> AResult<(Vec<u32>, GenStats)> {
     generate_dense_backend(
         mtl,
@@ -1208,7 +1211,7 @@ pub(crate) fn generate_dense_metal_session(
         None,
         None,
         None,
-        None,
+        req,
     )
 }
 

--- a/crates/infr-llama/src/seam/model.rs
+++ b/crates/infr-llama/src/seam/model.rs
@@ -946,9 +946,10 @@ impl SeamModel {
         session: &mut DenseMetalSession,
         prompt: &str,
         max_new: usize,
+        req: Option<&crate::sampling::RequestCtx>,
         on_piece: impl FnMut(&str),
     ) -> Result<crate::GenStats> {
-        self.generate_metal_session_constrained(session, prompt, max_new, None, on_piece)
+        self.generate_metal_session_constrained(session, prompt, max_new, None, req, on_piece)
     }
 
     /// [`generate_metal_session`](Self::generate_metal_session) with an optional llguidance
@@ -960,6 +961,7 @@ impl SeamModel {
         prompt: &str,
         max_new: usize,
         constraint: Option<&mut crate::grammar::Constraint>,
+        req: Option<&crate::sampling::RequestCtx>,
         mut on_piece: impl FnMut(&str),
     ) -> Result<crate::GenStats> {
         let enc = self
@@ -982,6 +984,7 @@ impl SeamModel {
             &mut session.pool.slots[slot],
             session.max_ctx,
             constraint,
+            req,
         )?;
         Ok(stats)
     }
@@ -995,6 +998,7 @@ impl SeamModel {
         &self,
         prompt: &str,
         max_new: usize,
+        req: Option<&crate::sampling::RequestCtx>,
         mut on_piece: impl FnMut(&str),
     ) -> Result<crate::GenStats> {
         let enc = self
@@ -1014,6 +1018,7 @@ impl SeamModel {
             &prompt_tokens,
             max_new,
             |id| stream_token(&self.tokenizer, &mut acc, &mut printed, id, &mut on_piece),
+            req,
         )?;
         Ok(stats)
     }
@@ -1092,6 +1097,7 @@ impl SeamModel {
             &mut session.pool.slots[t_slot],
             session.max_ctx,
             None,
+            None, // req: internal spec/DG path, greedy
         )?;
         let prompt_secs = t0.elapsed().as_secs_f64();
         let mut t_next = *first.first().ok_or_else(|| anyhow!("empty first token"))?;
@@ -1138,6 +1144,7 @@ impl SeamModel {
                 &mut draft_session.pool.slots[d_slot],
                 draft_session.max_ctx,
                 None,
+                None, // req: internal spec/DG path, greedy
             )?;
             // Verify: one batched target forward over [t_next, cand..]; row i's argmax is the
             // target's choice after consuming everything up to and including suffix row i.
@@ -1242,6 +1249,7 @@ impl SeamModel {
             session.pool.single(),
             session.max_ctx,
             None,
+            None, // req: internal spec/DG path, greedy
         )?;
         Ok(stats)
     }

--- a/crates/infr-llama/tests/cpu_backend.rs
+++ b/crates/infr-llama/tests/cpu_backend.rs
@@ -721,7 +721,7 @@ fn metal_spec_decode_matches_target_only_greedy() {
     {
         let mut sess = target.metal_session(1024).expect("target-only session");
         target
-            .generate_metal_session(&mut sess, &prompt, 64, |p| plain.push_str(p))
+            .generate_metal_session(&mut sess, &prompt, 64, None, |p| plain.push_str(p))
             .expect("target-only greedy");
     }
 
@@ -756,13 +756,13 @@ fn metal_decode_chain_matches_per_token_greedy() {
     std::env::set_var("INFR_DECODE_CHAIN", "1");
     let mut per_token = String::new();
     model
-        .generate_metal(&prompt, 32, |p| per_token.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| per_token.push_str(p))
         .expect("per-token greedy");
 
     std::env::set_var("INFR_DECODE_CHAIN", "8");
     let mut chained = String::new();
     model
-        .generate_metal(&prompt, 32, |p| chained.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| chained.push_str(p))
         .expect("chained greedy");
 
     std::env::remove_var("INFR_DECODE_CHAIN");
@@ -787,13 +787,13 @@ fn metal_decode_chain_matches_per_token_sampling() {
     std::env::set_var("INFR_DECODE_CHAIN", "1");
     let mut per_token = String::new();
     model
-        .generate_metal(&prompt, 32, |p| per_token.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| per_token.push_str(p))
         .expect("per-token sampling");
 
     std::env::set_var("INFR_DECODE_CHAIN", "8");
     let mut chained = String::new();
     model
-        .generate_metal(&prompt, 32, |p| chained.push_str(p))
+        .generate_metal(&prompt, 32, None, |p| chained.push_str(p))
         .expect("chained sampling");
 
     for var in [
@@ -828,18 +828,18 @@ fn metal_seam_multi_slot_prefix_sharing() {
 
     let mut ta = String::new();
     let sa = model
-        .generate_metal_session(&mut sess, &pa, 8, |p| ta.push_str(p))
+        .generate_metal_session(&mut sess, &pa, 8, None, |p| ta.push_str(p))
         .expect("conv A");
     assert!(sa.n_prompt > 0);
 
     // Conversation B: different question, same system prefix → new slot seeded from A's.
     let mut tb = String::new();
     let sb = model
-        .generate_metal_session(&mut sess, &pb, 8, |p| tb.push_str(p))
+        .generate_metal_session(&mut sess, &pb, 8, None, |p| tb.push_str(p))
         .expect("conv B");
     let mut fresh_b = String::new();
     model
-        .generate_metal(&pb, 8, |p| fresh_b.push_str(p))
+        .generate_metal(&pb, 8, None, |p| fresh_b.push_str(p))
         .expect("fresh B");
     assert_eq!(
         tb.trim(),
@@ -858,11 +858,11 @@ fn metal_seam_multi_slot_prefix_sharing() {
     let pa2 = format!("{pa}{ta} And the capital of Spain is");
     let mut ta2 = String::new();
     let sa2 = model
-        .generate_metal_session(&mut sess, &pa2, 8, |p| ta2.push_str(p))
+        .generate_metal_session(&mut sess, &pa2, 8, None, |p| ta2.push_str(p))
         .expect("conv A turn 2");
     let mut fresh_a2 = String::new();
     model
-        .generate_metal(&pa2, 8, |p| fresh_a2.push_str(p))
+        .generate_metal(&pa2, 8, None, |p| fresh_a2.push_str(p))
         .expect("fresh A2");
     assert_eq!(
         ta2.trim(),


### PR DESCRIPTION
`main` does not compile on macOS.

The parallel-slots slice (`5f57f85`) added `req: Option<&RequestCtx>` to `ChatModel::generate`/`generate_constrained` and to the seam backend, and updated every caller **visible on Linux** — but `crates/infr-llama/src/chat/metal.rs` and the `generate_metal*` wrappers are `cfg(target_os = "macos")`, so clippy, `cargo test --workspace` and all 25 `gpu_seam` tests were green on Linux while the macOS build was broken.

The macOS CI job on the pending Metal PR stack is what surfaced it:
- `E0050`: method `generate` has 4 parameters but the trait declares 5 (`chat/metal.rs:95`, `:118`, `:202`)
- `chat/cpu.rs:49` already passed `req` into a 3-arg `generate_metal`

This threads `req` through the Metal chain properly rather than just satisfying the compiler, so **Metal serve honors per-request sampling like Vulkan does**: `generate_metal`, `generate_metal_session{,_constrained}`, `generate_dense_metal{,_session}`.

Greedy-only paths take `None` and say why: the MTP driver and the speculative decoder both require the target's argmax, so per-request sampling has nowhere to land — the same branches the Vulkan twin drops it on.

**This PR exists to get the macOS runner to verify it** — it cannot be checked on the Linux dev box.