### PR TITLE
perf(metal): hoist deltanet qk norms

### DIFF
--- a/crates/infr-metal/shaders/deltanet.metal
+++ b/crates/infr-metal/shaders/deltanet.metal
@@ -58,13 +58,54 @@ kernel void deltanet_gates_f32(device const float* b       [[buffer(0)]],
 }
 
 #define DN_VPT 4u
+struct DeltaNetNormParams { uint rows; uint nk; uint kd; float eps; };
+
+// Multi-row norm prep: one simdgroup per token/key-head computes q/k L2 norms once,
+// instead of repeating both reductions for every value-head state column.
+template<uint KPL>
+kernel void deltanet_norm_f32_t(device const float* q      [[buffer(0)]],
+                                device const float* k      [[buffer(1)]],
+                                device float*       q_norm [[buffer(2)]],
+                                device float*       k_norm [[buffer(3)]],
+                                constant DeltaNetNormParams& p [[buffer(4)]],
+                                uint tgpig [[threadgroup_position_in_grid]],
+                                uint lane  [[thread_index_in_simdgroup]],
+                                uint sgid  [[simdgroup_index_in_threadgroup]]) {
+    uint i = tgpig * DN_VPT + sgid;
+    if (i >= p.rows * p.nk) return;
+    ulong base = (ulong)i * p.kd + lane * KPL;
+    float qv[KPL], kv[KPL];
+    float sq = 0.0f, sk = 0.0f;
+#pragma unroll
+    for (uint j = 0; j < KPL; j++) {
+        qv[j] = q[base + j];
+        kv[j] = k[base + j];
+        sq += qv[j] * qv[j];
+        sk += kv[j] * kv[j];
+    }
+    float qn = sqrt(simd_sum(sq) + p.eps);
+    float kn = sqrt(simd_sum(sk) + p.eps);
+    float qscale = rsqrt((float)p.kd);
+#pragma unroll
+    for (uint j = 0; j < KPL; j++) {
+        q_norm[base + j] = qv[j] / qn * qscale;
+        k_norm[base + j] = kv[j] / kn;
+    }
+}
+
+typedef decltype(deltanet_norm_f32_t<4>) deltanet_norm_f32_k;
+template [[host_name("deltanet_norm_k1")]] kernel deltanet_norm_f32_k deltanet_norm_f32_t<1>;
+template [[host_name("deltanet_norm_k2")]] kernel deltanet_norm_f32_k deltanet_norm_f32_t<2>;
+template [[host_name("deltanet_norm_k4")]] kernel deltanet_norm_f32_k deltanet_norm_f32_t<4>;
+template [[host_name("deltanet_norm_k8")]] kernel deltanet_norm_f32_k deltanet_norm_f32_t<8>;
+
 // KPL (k entries per lane, = kd/32) is a COMPILE-TIME template parameter: with a runtime
 // bound the ls[]/qv[]/kv[] arrays are runtime-indexed, the compiler cannot promote them to
 // registers, and the "register-resident" state silently spills to thread-private memory —
 // measured 1.7x SLOWER than the old threadgroup-staged shape (507 ms vs 302 per qwen35
 // prefill). Unrolled at fixed KPL the arrays genuinely live in registers: 185 ms, 1.6x
 // faster than the old shape.
-template<uint KPL, bool PREPARED_GATES>
+template<uint KPL, bool PREPARED_GATES, bool PREPARED_NORM>
 kernel void deltanet_f32_t(device const float* q       [[buffer(0)]],
                          device const float* k       [[buffer(1)]],
                          device const float* v       [[buffer(2)]],
@@ -102,15 +143,19 @@ kernel void deltanet_f32_t(device const float* q       [[buffer(0)]],
         for (uint j = 0; j < KPL; j++) {
             qv[j] = q[qb + j];
             kv[j] = k[qb + j];
-            sq += qv[j] * qv[j];
-            sk += kv[j] * kv[j];
+            if (!PREPARED_NORM) {
+                sq += qv[j] * qv[j];
+                sk += kv[j] * kv[j];
+            }
         }
-        float qn = sqrt(simd_sum(sq) + p.eps);
-        float kn = sqrt(simd_sum(sk) + p.eps);
+        if (!PREPARED_NORM) {
+            float qn = sqrt(simd_sum(sq) + p.eps);
+            float kn = sqrt(simd_sum(sk) + p.eps);
 #pragma unroll
-        for (uint j = 0; j < KPL; j++) {
-            qv[j] = qv[j] / qn * qscale;
-            kv[j] = kv[j] / kn;
+            for (uint j = 0; j < KPL; j++) {
+                qv[j] = qv[j] / qn * qscale;
+                kv[j] = kv[j] / kn;
+            }
         }
         float beta, decay;
         if (PREPARED_GATES) {
@@ -151,12 +196,16 @@ kernel void deltanet_f32_t(device const float* q       [[buffer(0)]],
     for (uint j = 0; j < KPL; j++) S[(ulong)(lane * KPL + j) * p.vd + d] = ls[j];
 }
 
-typedef decltype(deltanet_f32_t<4, false>) deltanet_f32_k;
-template [[host_name("deltanet_f32_k1")]] kernel deltanet_f32_k deltanet_f32_t<1, false>;
-template [[host_name("deltanet_f32_k2")]] kernel deltanet_f32_k deltanet_f32_t<2, false>;
-template [[host_name("deltanet_f32_k4")]] kernel deltanet_f32_k deltanet_f32_t<4, false>;
-template [[host_name("deltanet_f32_k8")]] kernel deltanet_f32_k deltanet_f32_t<8, false>;
-template [[host_name("deltanet_gates_k1")]] kernel deltanet_f32_k deltanet_f32_t<1, true>;
-template [[host_name("deltanet_gates_k2")]] kernel deltanet_f32_k deltanet_f32_t<2, true>;
-template [[host_name("deltanet_gates_k4")]] kernel deltanet_f32_k deltanet_f32_t<4, true>;
-template [[host_name("deltanet_gates_k8")]] kernel deltanet_f32_k deltanet_f32_t<8, true>;
+typedef decltype(deltanet_f32_t<4, false, false>) deltanet_f32_k;
+template [[host_name("deltanet_f32_k1")]] kernel deltanet_f32_k deltanet_f32_t<1, false, false>;
+template [[host_name("deltanet_f32_k2")]] kernel deltanet_f32_k deltanet_f32_t<2, false, false>;
+template [[host_name("deltanet_f32_k4")]] kernel deltanet_f32_k deltanet_f32_t<4, false, false>;
+template [[host_name("deltanet_f32_k8")]] kernel deltanet_f32_k deltanet_f32_t<8, false, false>;
+template [[host_name("deltanet_gates_k1")]] kernel deltanet_f32_k deltanet_f32_t<1, true, false>;
+template [[host_name("deltanet_gates_k2")]] kernel deltanet_f32_k deltanet_f32_t<2, true, false>;
+template [[host_name("deltanet_gates_k4")]] kernel deltanet_f32_k deltanet_f32_t<4, true, false>;
+template [[host_name("deltanet_gates_k8")]] kernel deltanet_f32_k deltanet_f32_t<8, true, false>;
+template [[host_name("deltanet_prepared_k1")]] kernel deltanet_f32_k deltanet_f32_t<1, true, true>;
+template [[host_name("deltanet_prepared_k2")]] kernel deltanet_f32_k deltanet_f32_t<2, true, true>;
+template [[host_name("deltanet_prepared_k4")]] kernel deltanet_f32_k deltanet_f32_t<4, true, true>;
+template [[host_name("deltanet_prepared_k8")]] kernel deltanet_f32_k deltanet_f32_t<8, true, true>;

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -226,6 +226,16 @@ mod tests {
     }
 
     #[test]
+    fn deltanet_msl_has_hoisted_qk_norm() {
+        let src = include_str!("../shaders/deltanet.metal");
+        assert!(contains_tokens(src, "kernel void deltanet_norm_f32_t"));
+        assert!(contains_tokens(src, "host_name(\"deltanet_prepared_k4\")"));
+        // Q/k prep first wins at 8 rows; 4 rows measured neutral because it stays inline.
+        assert!(!prefer_deltanet_norm_prep(4));
+        assert!(prefer_deltanet_norm_prep(8));
+    }
+
+    #[test]
     fn argmax_split_policy_only_targets_vocab_scale_inputs() {
         assert_eq!(argmax_split_groups(151_936), Some(38));
         assert_eq!(argmax_split_groups(32_768), Some(8));
@@ -742,6 +752,10 @@ fn prefer_rmsnorm_vec4(rows: usize, dim: usize) -> bool {
 }
 
 fn prefer_deltanet_gate_prep(rows: usize) -> bool {
+    rows >= 8
+}
+
+fn prefer_deltanet_norm_prep(rows: usize) -> bool {
     rows >= 8
 }
 
@@ -4456,15 +4470,22 @@ impl MetalBackend {
                         // promotion needs the fixed bound) — pick the instantiation.
                         let gate_prep = prefer_deltanet_gate_prep(rr)
                             && std::env::var("INFR_METAL_NO_DN_GATE_PREP").is_err();
-                        let dn_kern: &'static str = match (gate_prep, kd / 32) {
-                            (false, 1) => "deltanet_f32_k1",
-                            (false, 2) => "deltanet_f32_k2",
-                            (false, 4) => "deltanet_f32_k4",
-                            (false, _) => "deltanet_f32_k8",
-                            (true, 1) => "deltanet_gates_k1",
-                            (true, 2) => "deltanet_gates_k2",
-                            (true, 4) => "deltanet_gates_k4",
-                            (true, _) => "deltanet_gates_k8",
+                        let norm_prep = gate_prep
+                            && prefer_deltanet_norm_prep(rr)
+                            && std::env::var("INFR_METAL_NO_DN_NORM_PREP").is_err();
+                        let dn_kern: &'static str = match (gate_prep, norm_prep, kd / 32) {
+                            (false, _, 1) => "deltanet_f32_k1",
+                            (false, _, 2) => "deltanet_f32_k2",
+                            (false, _, 4) => "deltanet_f32_k4",
+                            (false, _, _) => "deltanet_f32_k8",
+                            (true, false, 1) => "deltanet_gates_k1",
+                            (true, false, 2) => "deltanet_gates_k2",
+                            (true, false, 4) => "deltanet_gates_k4",
+                            (true, false, _) => "deltanet_gates_k8",
+                            (true, true, 1) => "deltanet_prepared_k1",
+                            (true, true, 2) => "deltanet_prepared_k2",
+                            (true, true, 4) => "deltanet_prepared_k4",
+                            (true, true, _) => "deltanet_prepared_k8",
                         };
                         let fits = self
                             .pipelines
@@ -4483,6 +4504,14 @@ impl MetalBackend {
                                 self.scratch_buf(rr * nv * 2, 15)
                             } else {
                                 bb.clone()
+                            };
+                            let (scan_q, scan_k) = if norm_prep {
+                                (
+                                    self.scratch_buf(rr * nk * kd, 16),
+                                    self.scratch_buf(rr * nk * kd, 17),
+                                )
+                            } else {
+                                (bq.clone(), bk.clone())
                             };
                             let bd = self.dev_dst(r, dst, rr * nv * vd);
                             let sbuf = metal_buf(sb);
@@ -4515,12 +4544,34 @@ impl MetalBackend {
                                     rr * nv,
                                 );
                             }
+                            if norm_prep {
+                                let norm_kern = match kd / 32 {
+                                    1 => "deltanet_norm_k1",
+                                    2 => "deltanet_norm_k2",
+                                    4 => "deltanet_norm_k4",
+                                    _ => "deltanet_norm_k8",
+                                };
+                                let npso = self.pipelines.get(norm_kern)?;
+                                let mut np = (rr as u32).to_ne_bytes().to_vec();
+                                np.extend_from_slice(&(nk as u32).to_ne_bytes());
+                                np.extend_from_slice(&(kd as u32).to_ne_bytes());
+                                np.extend_from_slice(&eps.to_ne_bytes());
+                                self.encode_tg_w(
+                                    r,
+                                    &npso,
+                                    &[bq.as_ref(), bk.as_ref(), scan_q.as_ref(), scan_k.as_ref()],
+                                    (1 << 2) | (1 << 3),
+                                    &np,
+                                    (rr * nk).div_ceil(4) * 128,
+                                    128,
+                                );
+                            }
                             self.encode_tg_w(
                                 r,
                                 &pso,
                                 &[
-                                    bq.as_ref(),
-                                    bk.as_ref(),
+                                    scan_q.as_ref(),
+                                    scan_k.as_ref(),
                                     bv.as_ref(),
                                     bb.as_ref(),
                                     ba.as_ref(),

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -2873,12 +2873,12 @@ fn deltanet_parity() {
     assert_close(&cpu[1], &mtl[1], 1e-4, "deltanet state");
 }
 
-// Multi-row scan at the qwen3-next head shape: the state must carry across rows exactly (the
-// device kernel loops rows with each lane owning its state column).
+// Prepared multi-row scan at the qwen3-next head shape: the state must carry across rows exactly
+// while the gate and q/k prep dispatches feed the token-serial device kernel.
 #[test]
 #[ignore = "requires a Metal GPU"]
 fn deltanet_multirow_parity() {
-    let (rows, nv, nk, kd, vd) = (5usize, 4usize, 2usize, 128usize, 128usize);
+    let (rows, nv, nk, kd, vd) = (8usize, 4usize, 2usize, 128usize, 128usize);
     let mut g = Graph::new();
     let q = g.input(TensorDesc::new(vec![rows, nk * kd], DType::F32));
     let k = g.input(TensorDesc::new(vec![rows, nk * kd], DType::F32));


### PR DESCRIPTION
## Summary
- normalize DeltaNet q/k once per token and key head in a parallel Metal pass
- feed prepared q/k scratch into compile-time-specialized token-serial scans
- keep rows below 8 on inline normalization with no scratch allocation
- add an environment control and exercise the prepared path in parity

## Performance
Alternating release benchmark on M3 Pro at the qwen35 DeltaNet shape (nv=32, nk=16, kd=128, vd=128):

| Rows | Q/K prepared | Inline norm | Change |
|---:|---:|---:|---:|
| 8 | 0.452 ms | 0.498 ms | 9.2% faster |
| 16 | 0.533 ms | 0.712 ms | 25.1% faster |
| 32 | 0.753 ms | 1.034 ms | 27.2% faster |
| 64 | 1.099 ms | 1.711 ms | 35.8% faster |
| 128 | 1.927 ms | 2.936 ms | 34.4% faster |
| 256 | 3.854 ms | 5.895 ms | 34.6% faster |
| 512 | 7.510 ms | 11.218 ms | 33.1% faster |

Rows 4 remains on the inline path.

Real-model validation on Qwen3.5-0.8B Q4_K_M, pp512, r=3:
- prepared q/k: 2875.5 tok/s
- inline normalization control: 2366.8 tok/s
- end-to-end gain: 21.5%
- matched llama.cpp sweep: 2872 vs 3044 tok/s, improving Metal to 0.94x

Decode is unchanged by the row gate and remains ahead of llama.cpp on this model: 1.27x at tg128 and 1.25x at tg64@d4096.

## Validation
- rebased onto upstream main at c2f9d99
- cargo fmt --all --check
- cargo clippy -p infr-metal --all-targets --locked -- -D warnings
- cargo test -p infr-metal --locked -- --include-ignored
- 17 unit tests, all kernel-name checks, and 133 Metal parity tests passed
- all six GitHub CI checks pass

No planning or performance docs are included.