### PR TITLE
perf(metal): parallelize batched conv1d

### DIFF
--- a/crates/infr-metal/shaders/deltanet.metal
+++ b/crates/infr-metal/shaders/deltanet.metal
@@ -29,6 +29,51 @@ kernel void conv1d_silu_f32(device const float* x     [[buffer(0)]],
     for (uint j = 0; j + 1 < kk; j++) state[j * p.channels + ch] = st[j];
 }
 
+// Multi-row pass 1: each output reads its causal window from the virtual sequence
+// [old state | x], so all rows*channels elements are independent.
+kernel void conv1d_silu_par_f32(device const float* x     [[buffer(0)]],
+                                device const float* w     [[buffer(1)]],
+                                device const float* state [[buffer(2)]],
+                                device float*       dst   [[buffer(3)]],
+                                constant ConvSiluParams& p [[buffer(4)]],
+                                uint gid [[thread_position_in_grid]]) {
+    if (gid >= p.rows * p.channels) return;
+    uint t = gid / p.channels;
+    uint ch = gid % p.channels;
+    uint km1 = p.kwidth - 1u;
+    float acc = 0.0f;
+    if (t >= km1) {
+        ulong base = (ulong)(t - km1) * p.channels + ch;
+        for (uint k = 0; k < p.kwidth; k++) {
+            acc += x[base + (ulong)k * p.channels] * w[ch * p.kwidth + k];
+        }
+    } else {
+        for (uint k = 0; k < p.kwidth; k++) {
+            uint i = t + k;
+            float xv;
+            if (i < km1) {
+                xv = state[i * p.channels + ch];
+            } else {
+                xv = x[(i - km1) * p.channels + ch];
+            }
+            acc += xv * w[ch * p.kwidth + k];
+        }
+    }
+    dst[gid] = acc / (1.0f + exp(-acc));
+}
+
+// Multi-row pass 2: rows >= K-1, so the final K-1 inputs directly become state.
+kernel void conv1d_shift_f32(device const float* x [[buffer(0)]],
+                             device float* state   [[buffer(1)]],
+                             constant ConvSiluParams& p [[buffer(2)]],
+                             uint gid [[thread_position_in_grid]]) {
+    uint km1 = p.kwidth - 1u;
+    if (gid >= km1 * p.channels) return;
+    uint k = gid / p.channels;
+    uint ch = gid % p.channels;
+    state[gid] = x[(p.rows - km1 + k) * p.channels + ch];
+}
+
 // One SIMDGROUP per (value-dim d, value-head h) — the llama.cpp kernel_gated_delta_net
 // parallelization. The simdgroup's 32 lanes split the k-dim (KPL = kd/32 state entries per
 // lane, register-resident ls[] for the WHOLE chunk — the old shape re-read the state column

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -236,6 +236,15 @@ mod tests {
     }
 
     #[test]
+    fn conv1d_msl_has_parallel_prefill_passes() {
+        let src = include_str!("../shaders/deltanet.metal");
+        assert!(contains_tokens(src, "kernel void conv1d_silu_par_f32"));
+        assert!(contains_tokens(src, "kernel void conv1d_shift_f32"));
+        assert!(!prefer_conv1d_parallel(2, 4));
+        assert!(prefer_conv1d_parallel(3, 4));
+    }
+
+    #[test]
     fn argmax_split_policy_only_targets_vocab_scale_inputs() {
         assert_eq!(argmax_split_groups(151_936), Some(38));
         assert_eq!(argmax_split_groups(32_768), Some(8));
@@ -757,6 +766,10 @@ fn prefer_deltanet_gate_prep(rows: usize) -> bool {
 
 fn prefer_deltanet_norm_prep(rows: usize) -> bool {
     rows >= 8
+}
+
+fn prefer_conv1d_parallel(rows: usize, kernel: usize) -> bool {
+    rows >= kernel.saturating_sub(1).max(2)
 }
 
 fn counter_linear_label(enabled: bool, kern: &'static str) -> Option<&'static str> {
@@ -4374,18 +4387,41 @@ impl MetalBackend {
                         let i = state.0 as usize;
                         r.dev[i] = Some(Arc::new(sbuf.raw.clone()));
                         r.loc[i] = Loc::Device;
-                        let pso = self.pipelines.get("conv1d_silu_f32")?;
                         let mut p = (rr as u32).to_ne_bytes().to_vec();
                         p.extend_from_slice(&(cc as u32).to_ne_bytes());
                         p.extend_from_slice(&(kk as u32).to_ne_bytes());
-                        self.encode_w(
-                            r,
-                            &pso,
-                            &[bx.as_ref(), bw.as_ref(), &sbuf.raw, bd.as_ref()],
-                            (1 << 2) | (1 << 3),
-                            &p,
-                            cc,
-                        );
+                        let parallel = prefer_conv1d_parallel(rr, kk)
+                            && std::env::var("INFR_METAL_NO_CONV1D_PAR").is_err();
+                        if parallel {
+                            let pso = self.pipelines.get("conv1d_silu_par_f32")?;
+                            self.encode_w(
+                                r,
+                                &pso,
+                                &[bx.as_ref(), bw.as_ref(), &sbuf.raw, bd.as_ref()],
+                                1 << 3,
+                                &p,
+                                rr * cc,
+                            );
+                            let shift = self.pipelines.get("conv1d_shift_f32")?;
+                            self.encode_w(
+                                r,
+                                &shift,
+                                &[bx.as_ref(), &sbuf.raw],
+                                1 << 1,
+                                &p,
+                                (kk - 1) * cc,
+                            );
+                        } else {
+                            let pso = self.pipelines.get("conv1d_silu_f32")?;
+                            self.encode_w(
+                                r,
+                                &pso,
+                                &[bx.as_ref(), bw.as_ref(), &sbuf.raw, bd.as_ref()],
+                                (1 << 2) | (1 << 3),
+                                &p,
+                                cc,
+                            );
+                        }
                         r.loc[dst.0 as usize] = Loc::Device;
                         return Ok(());
                     }


### PR DESCRIPTION
## Summary

- compute multi-row causal depthwise Conv1d outputs in parallel over `rows * channels`
- rebuild the recurrent state in a second ordered pass
- keep decode and undersized batches on the original one-dispatch serial kernel
- retain `INFR_METAL_NO_CONV1D_PAR=1` as an A/B and fallback switch

## Why

The existing Metal kernel assigned one thread per channel and looped every token row serially. That preserves recurrence but underfills the GPU during Qwen3.5 prefill. Reading each output from the virtual `[old state | input]` sequence removes the row dependency; a second pass then installs the final `K-1` inputs as recurrent state.

## Performance

Qwen3.5-0.8B Q4_K_M, Apple M3 Pro, pp512, cooled r=5 order-swapped pairs:

| path | run 1 | run 2 | mean |
| --- | ---: | ---: | ---: |
| serial control | 2903.0 t/s | 2828.4 t/s | 2865.7 t/s |
| parallel | 3096.9 t/s | 3040.3 t/s | 3068.6 t/s |

Mean improvement: **+7.1%**.

Decode remains on the serial kernel and stayed neutral at tg128: 164.4 t/s control vs 164.1 t/s default.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p infr-metal --locked -- --include-ignored`
  - 18 unit tests
  - 16 kernel-name/tripwire tests
  - 134 Metal parity tests
  - all remaining Metal backend and micro-probe tests
- `cargo build --release -p infr-cli --locked`

No documentation or planning files are included.