### PR TITLE
fix(metal): honor benchmark depth and row count

### DIFF
--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -2004,6 +2004,53 @@ fn print_bench_avg(samples: &[f64], label: &str, depth: usize, tag: &str, reps: 
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MetalBenchMetric {
+    Prompt,
+    Decode,
+    Turn,
+}
+
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MetalBenchShape {
+    max_ctx: usize,
+    depth_warm_prompt: Option<usize>,
+    measured_prompt: usize,
+    measured_gen: usize,
+    tokens: usize,
+    metric: MetalBenchMetric,
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn metal_bench_shape(
+    n_prompt: usize,
+    n_gen: usize,
+    depth: usize,
+    pg: Option<(usize, usize)>,
+) -> MetalBenchShape {
+    let (p_eff, g_eff) = pg.unwrap_or((n_prompt, n_gen));
+    let depth_warm_prompt = (depth > 0).then_some(depth + 1);
+    let (measured_prompt, measured_gen, tokens, metric) = if let Some((p, g)) = pg {
+        (depth + p, g, p + g, MetalBenchMetric::Turn)
+    } else if n_gen > 0 {
+        (depth + 1, n_gen, n_gen, MetalBenchMetric::Decode)
+    } else {
+        // The runner batches all but the final prompt token. Include that frontier token so the
+        // timed graph contains exactly `n_prompt` rows.
+        (depth + n_prompt + 1, 0, n_prompt, MetalBenchMetric::Prompt)
+    };
+    MetalBenchShape {
+        max_ctx: depth + p_eff.max(1) + g_eff + 16,
+        depth_warm_prompt,
+        measured_prompt,
+        measured_gen,
+        tokens,
+        metric,
+    }
+}
+
 /// Metal twin of [`cmd_bench_cpu`]: same pp/tg/pg + depth methodology on the Apple-GPU seam
 /// backend (`SeamModel::bench_metal`). On non-macOS this arm is unreachable (the backend crate
 /// compiles to nothing), so the whole body is cfg-gated.
@@ -2026,40 +2073,40 @@ fn cmd_bench_metal(
     #[cfg(target_os = "macos")]
     {
         let model = infr_llama::SeamModel::load(gguf, tok)?;
-        let measure_tg = pg.is_none() && n_gen > 0;
+        let shape = metal_bench_shape(n_prompt, n_gen, depth, pg);
         // ONE session for warmup + every rep: backend, uploaded weights, compiled pipelines and
         // the dequant/repack weight caches persist (each rep still measures a full prefill —
-        // `bench_metal` resets the materialized tokens). A fresh backend per rep re-paid those
+        // the depth warm resets the materialized tokens). A fresh backend per rep re-paid those
         // one-time costs inside the measurement.
-        let ctx = pg.map(|(p, g)| p + g).unwrap_or(if measure_tg {
-            depth.max(1) + n_gen
-        } else {
-            n_prompt
-        }) + 2;
-        let mut sess = model.metal_session(ctx)?;
+        let mut sess = model.metal_session(shape.max_ctx)?;
         // One untimed warmup: page-cache the mmap + build the weight caches + compile pipelines.
-        let _ = model.bench_metal(
-            &mut sess,
-            depth.max(1),
-            if measure_tg || pg.is_some() { 1 } else { 0 },
-        );
+        let _ = model.bench_metal(&mut sess, 8, 2, true, false);
         let mut samples = Vec::with_capacity(reps);
         for _ in 0..reps {
-            let ts = if let Some((p, g)) = pg {
-                let s = model.bench_metal(&mut sess, p, g)?;
-                (p + g) as f64 / (s.prompt_secs + s.decode_secs)
-            } else if measure_tg {
-                let s = model.bench_metal(&mut sess, depth.max(1), n_gen)?;
-                n_gen as f64 / s.decode_secs
+            let reset_measured = if let Some(warm_prompt) = shape.depth_warm_prompt {
+                let _ = model.bench_metal(&mut sess, warm_prompt, 0, true, false)?;
+                false
             } else {
-                let s = model.bench_metal(&mut sess, n_prompt, 0)?;
-                n_prompt as f64 / s.prompt_secs
+                true
             };
+            let s = model.bench_metal(
+                &mut sess,
+                shape.measured_prompt,
+                shape.measured_gen,
+                reset_measured,
+                true,
+            )?;
+            let secs = match shape.metric {
+                MetalBenchMetric::Prompt => s.prompt_secs,
+                MetalBenchMetric::Decode => s.decode_secs,
+                MetalBenchMetric::Turn => s.prompt_secs + s.decode_secs,
+            };
+            let ts = shape.tokens as f64 / secs.max(1e-9);
             samples.push(ts);
         }
         let label = if let Some((p, g)) = pg {
             format!("pg{p}+{g}")
-        } else if measure_tg {
+        } else if shape.metric == MetalBenchMetric::Decode {
             format!("tg{n_gen}")
         } else {
             format!("pp{n_prompt}")
@@ -3576,6 +3623,40 @@ fn cmd_multi(
 mod tests {
     use super::*;
     use infr_llama::arch::*;
+
+    #[test]
+    fn metal_prefill_bench_materializes_depth_and_times_exact_rows() {
+        let shallow = metal_bench_shape(4, 0, 0, None);
+        assert_eq!(shallow.depth_warm_prompt, None);
+        assert_eq!(shallow.measured_prompt, 5);
+        assert_eq!(shallow.measured_gen, 0);
+        assert_eq!(shallow.tokens, 4);
+        assert_eq!(shallow.metric, MetalBenchMetric::Prompt);
+
+        let deep = metal_bench_shape(4, 0, 4096, None);
+        assert_eq!(deep.depth_warm_prompt, Some(4097));
+        assert_eq!(deep.measured_prompt, 4101);
+        assert_eq!(deep.measured_gen, 0);
+        assert_eq!(deep.tokens, 4);
+        assert_eq!(deep.metric, MetalBenchMetric::Prompt);
+    }
+
+    #[test]
+    fn metal_decode_and_turn_benches_preserve_depth_prefix() {
+        let decode = metal_bench_shape(0, 128, 4096, None);
+        assert_eq!(decode.depth_warm_prompt, Some(4097));
+        assert_eq!(decode.measured_prompt, 4097);
+        assert_eq!(decode.measured_gen, 128);
+        assert_eq!(decode.tokens, 128);
+        assert_eq!(decode.metric, MetalBenchMetric::Decode);
+
+        let turn = metal_bench_shape(0, 0, 4096, Some((32, 16)));
+        assert_eq!(turn.depth_warm_prompt, Some(4097));
+        assert_eq!(turn.measured_prompt, 4128);
+        assert_eq!(turn.measured_gen, 16);
+        assert_eq!(turn.tokens, 48);
+        assert_eq!(turn.metric, MetalBenchMetric::Turn);
+    }
 
     #[test]
     fn model_spec_parses_device_suffix() {

--- a/crates/infr-llama/src/seam/model.rs
+++ b/crates/infr-llama/src/seam/model.rs
@@ -1486,19 +1486,25 @@ impl SeamModel {
     /// Runs through a persistent [`DenseMetalSession`] so backend, uploaded weights, compiled
     /// pipelines, and the dequant/repack weight caches all survive across reps — a fresh backend
     /// per rep re-paid every one-time cost inside the measurement (a factored-format checkpoint
-    /// re-repacked hundreds of MB per rep). The materialized tokens reset each call, so every
-    /// rep still measures a FULL prefill (llama-bench keeps one context across reps the same way).
+    /// re-repacked hundreds of MB per rep). `reset_tokens` starts a fresh repetition; leaving it
+    /// false preserves a preceding untimed depth warm so the next call measures only its suffix.
+    /// `profile` controls whether this call contributes to the backend's profiler summary.
     #[cfg(target_os = "macos")]
     pub fn bench_metal(
         &self,
         session: &mut DenseMetalSession,
         n_prompt: usize,
         n_gen: usize,
+        reset_tokens: bool,
+        profile: bool,
     ) -> Result<crate::GenStats> {
         let prompt: Vec<u32> = (0..n_prompt.max(1)).map(|i| (i % 100) as u32).collect();
-        if let Some(s) = session.pool.single().as_mut() {
-            s.reset_tokens();
+        if reset_tokens {
+            if let Some(s) = session.pool.single().as_mut() {
+                s.reset_tokens();
+            }
         }
+        let _profile_guard = (!profile).then(|| session.mtl.suppress_profiling());
         let (_, stats) = crate::seam::generate_dense_metal_session(
             &session.mtl,
             &self.gguf,

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1253,7 +1253,7 @@ impl MetalBackend {
             let tg = (pso.max_total_threads_per_threadgroup() as usize).min(threads.max(1)) as u64;
             enc.dispatch_threads(MTLSize::new(threads as u64, 1, 1), MTLSize::new(tg, 1, 1));
             enc.end_encoding();
-            let t0 = self.profiling.then(std::time::Instant::now);
+            let t0 = self.profiling_enabled().then(std::time::Instant::now);
             cb.commit();
             cb.wait_until_completed();
             if let Some(t0) = t0 {
@@ -1350,7 +1350,7 @@ impl MetalBackend {
             // Counter profiling: every encoder carries a stage-boundary timestamp pair, so each
             // op's GPU time is measured IN CONTEXT (the batch still commits once). The walk ends
             // the encoder between ops; everything an op encodes lands in its encoder(s).
-            r.enc = Some(if let Some(set) = self.counter_set.as_ref() {
+            r.enc = Some(if let Some(set) = self.active_counter_set() {
                 const CSB_CAP: u64 = 4096;
                 if r.csb.is_none() {
                     let d = metal::CounterSampleBufferDescriptor::new();
@@ -1466,7 +1466,7 @@ impl MetalBackend {
         objc::rc::autoreleasepool(|| {
             let cb = self.queue.new_command_buffer();
             self.encode_tape(cb, tape);
-            let t0 = self.profiling.then(std::time::Instant::now);
+            let t0 = self.profiling_enabled().then(std::time::Instant::now);
             cb.commit();
             cb.wait_until_completed();
             if let Some(t0) = t0 {
@@ -1483,7 +1483,7 @@ impl MetalBackend {
             enc.end_encoding();
         }
         if let Some(cb) = r.cb.take() {
-            let t0 = self.profiling.then(std::time::Instant::now);
+            let t0 = self.profiling_enabled().then(std::time::Instant::now);
             cb.commit();
             cb.wait_until_completed();
             if let Some(t0) = t0 {
@@ -1565,7 +1565,7 @@ impl MetalBackend {
     }
 
     fn replay_capable(&self, g: &infr_core::graph::Graph, bindings: &Bindings) -> bool {
-        if self.counter_set.is_some() || !replay_shape(g, bindings) {
+        if self.active_counter_set().is_some() || !replay_shape(g, bindings) {
             return false;
         }
         let Some((kern, need)) = g.ops.iter().find_map(|op| match op {
@@ -1629,7 +1629,7 @@ impl MetalBackend {
         bindings: &Bindings,
         n: usize,
     ) -> Result<Option<Vec<u32>>> {
-        if n == 0 || n > 64 || self.counter_set.is_some() {
+        if n == 0 || n > 64 || self.active_counter_set().is_some() {
             return Ok(None);
         }
         let Some(g) = plan
@@ -1729,7 +1729,7 @@ impl MetalBackend {
                 blit.copy_from_buffer(&sampled_buf.raw, 0, &result, (i * 4) as u64, 4);
                 blit.end_encoding();
             }
-            let t0 = self.profiling.then(std::time::Instant::now);
+            let t0 = self.profiling_enabled().then(std::time::Instant::now);
             cb.commit();
             cb.wait_until_completed();
             if let Some(t0) = t0 {
@@ -1858,7 +1858,7 @@ impl MetalBackend {
             }
         }
 
-        if self.profiling {
+        if self.profiling_enabled() {
             for (idx, op) in g.ops.iter().enumerate() {
                 if r.skip.contains(&idx) {
                     continue;
@@ -1873,7 +1873,7 @@ impl MetalBackend {
                 }
                 // Counter mode: seal this op's encoder (the command buffer stays open) so the
                 // next op's dispatches land in their own sampled encoder.
-                if self.counter_set.is_some() {
+                if self.active_counter_set().is_some() {
                     if let Some(e) = r.enc.take() {
                         e.end_encoding();
                     }
@@ -1888,7 +1888,7 @@ impl MetalBackend {
                     None
                 };
                 let mut pr = self.prof.lock().unwrap();
-                let name = if self.counter_set.is_some() {
+                let name = if self.active_counter_set().is_some() {
                     r.cur_op
                 } else {
                     op_name(op)

--- a/crates/infr-metal/src/lib.rs
+++ b/crates/infr-metal/src/lib.rs
@@ -61,6 +61,35 @@ impl infr_core::backend::Buffer for MetalBuffer {
     }
 }
 
+#[derive(Default)]
+struct ProfileGate {
+    suppressions: std::sync::atomic::AtomicUsize,
+}
+
+impl ProfileGate {
+    fn enabled(&self, configured: bool) -> bool {
+        configured && self.suppressions.load(std::sync::atomic::Ordering::Relaxed) == 0
+    }
+
+    fn suppress(&self) -> ProfileSuppression<'_> {
+        self.suppressions
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        ProfileSuppression { gate: self }
+    }
+}
+
+struct ProfileSuppression<'a> {
+    gate: &'a ProfileGate,
+}
+
+impl Drop for ProfileSuppression<'_> {
+    fn drop(&mut self) {
+        self.gate
+            .suppressions
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 pub struct MetalBackend {
     device: Device,
     queue: CommandQueue,
@@ -93,6 +122,7 @@ pub struct MetalBackend {
     /// in-context (no per-op flush distortion). `None` when the device lacks stage-boundary
     /// sampling or the timestamp counter set.
     pub(crate) counter_set: Option<metal::CounterSet>,
+    profile_gate: ProfileGate,
     /// One (cpu_ns, gpu_ticks) correlation taken at init — with a second one at resolve time,
     /// the ratio converts GPU-clock ticks to nanoseconds (the domains drift only with clock
     /// rate changes; a long baseline keeps the estimate stable).
@@ -155,11 +185,30 @@ impl MetalBackend {
             profiling: std::env::var("INFR_METAL_PROFILE").is_ok(),
             prof_ops: std::env::var("INFR_METAL_PROFILE").as_deref() == Ok("2"),
             counter_set,
+            profile_gate: ProfileGate::default(),
             ts_base,
             prof: std::sync::Mutex::new(profile::Profile::default()),
             replay: std::sync::Mutex::new(None),
             scratch: std::sync::Mutex::new(std::collections::HashMap::new()),
         })
+    }
+
+    /// Temporarily exclude work from the configured profiler. Benchmark setup uses this so
+    /// pipeline warmup and depth materialization do not contaminate measured forwards.
+    pub fn suppress_profiling(&self) -> impl Drop + '_ {
+        self.profile_gate.suppress()
+    }
+
+    pub(crate) fn profiling_enabled(&self) -> bool {
+        self.profile_gate.enabled(self.profiling)
+    }
+
+    pub(crate) fn active_counter_set(&self) -> Option<&metal::CounterSetRef> {
+        if self.profiling_enabled() {
+            self.counter_set.as_deref()
+        } else {
+            None
+        }
     }
 }
 
@@ -366,4 +415,28 @@ fn metal_buf(b: &dyn infr_core::backend::Buffer) -> &MetalBuffer {
     b.as_any()
         .downcast_ref::<MetalBuffer>()
         .expect("metal backend: buffer is not a MetalBuffer (mixed backends?)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProfileGate;
+
+    #[test]
+    fn profile_gate_restores_nested_suppression() {
+        let gate = ProfileGate::default();
+        assert!(gate.enabled(true));
+
+        {
+            let _outer = gate.suppress();
+            assert!(!gate.enabled(true));
+            {
+                let _inner = gate.suppress();
+                assert!(!gate.enabled(true));
+            }
+            assert!(!gate.enabled(true));
+        }
+
+        assert!(gate.enabled(true));
+        assert!(!gate.enabled(false));
+    }
 }


### PR DESCRIPTION
## Summary
- preserve the Metal session's untimed depth-warmed KV state for the measured suffix
- include the unprocessed frontier token so ppN executes exactly N prefill rows
- align Metal pp/tg/pg session sizing and timing semantics with their CLI labels
- exclude pipeline and depth warmups from Metal profiler summaries
- add shape-contract and profiling-scope regression tests

## Root cause
The Metal benchmark helper reset materialized tokens on every call. The CLI performed a nominal depth warm, then reset it before timing a fresh shallow prompt. It also passed N prompt tokens to a runner that batches all but the final token, so ppN measured N-1 rows.

Profiling was configured for the whole backend, so untimed pipeline and depth warmups were included in profile counters and forward totals.

## Behavior
For pp4 at depth 4096, the benchmark now:

1. resets the session and feeds 4097 tokens untimed, materializing exactly 4096 KV rows
2. preserves that prefix
3. feeds a 4101-token prompt whose uncached timed graph contains exactly four rows
4. suppresses profiling for setup calls while retaining every measured repetition

A temporary runtime trace confirmed the deep warm executes four 1024-row chunks and the timed Q5_K linears execute with rows=4. A two-repetition PROFILE=3 run reports exactly two forwards.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p infr-metal --all-targets --locked -- -D warnings`
- `cargo clippy -p infr-cli --all-targets --locked -- -D warnings`
- `cargo test -p infr-metal -p infr-cli --locked`
- `cargo build --release -p infr-cli --locked`
- Qwen3-0.6B Q4_K_M, M3 Pro, PROFILE=3: pp4 at depth 4096 reports exactly 2 profiled forwards for 2 measured reps
- earlier shape checks on Qwen3.5-0.8B Q4_K_M:
  - shallow pp4: 366.6 t/s
  - pp4 at depth 4096: 322.2 t/s
  - tg128 at depth 4096: 142.3 t/s
  - pg4+4 at depth 4096: 194.0 t/s

## Known upstream CI failures
Current upstream main independently causes:
- workspace Clippy/tests to fail because the new `DType::I2S` is missing from a Vulkan test match
- the CPU-goldens job to invoke deprecated `huggingface-cli` instead of `hf`
- the Metal kernel-name scraper to treat the negative-test literal `linear_quik_bogus` as a dispatch target
