### PR TITLE
perf(metal): flash four-row deep prefill

### DIFF
--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -354,6 +354,17 @@ mod tests {
     }
 
     #[test]
+    fn attention_flash_policy_reuses_kv_at_four_rows() {
+        assert!(prefer_attention_flash(true, 4, 16, 4096, 128, true));
+        assert!(!prefer_attention_flash(true, 3, 16, 4096, 128, true));
+        assert!(!prefer_attention_flash(true, 1, 64, 4096, 128, true));
+        assert!(!prefer_attention_flash(true, 4, 16, 63, 128, true));
+        assert!(!prefer_attention_flash(false, 4, 16, 4096, 128, true));
+        assert!(!prefer_attention_flash(true, 4, 16, 4096, 128, false));
+        assert!(!prefer_attention_flash(true, 4, 16, 4096, 256, false));
+    }
+
+    #[test]
     #[ignore = "requires a Metal GPU"]
     fn replay_gpu_decode_ops_observe_dynamic_inputs() {
         let be = MetalBackend::new().expect("Metal backend");
@@ -922,6 +933,22 @@ fn prefer_deltanet_norm_prep(rows: usize) -> bool {
 
 fn prefer_conv1d_parallel(rows: usize, kernel: usize) -> bool {
     rows >= kernel.saturating_sub(1).max(2)
+}
+
+fn prefer_attention_flash(
+    f16: bool,
+    rows: usize,
+    n_head: usize,
+    kv_len: usize,
+    head_dim: usize,
+    flash2_ok: bool,
+) -> bool {
+    let launch_wide = rows * n_head >= 128;
+    let launch_four = rows == 4 && rows * n_head >= 64 && flash2_ok;
+    f16 && (launch_wide || launch_four)
+        && kv_len >= 64
+        && head_dim.is_multiple_of(8)
+        && (head_dim <= 128 || flash2_ok)
 }
 
 fn counter_linear_label(enabled: bool, kern: &'static str) -> Option<&'static str> {
@@ -3974,11 +4001,7 @@ impl MetalBackend {
                 });
                 // hd > 128 has no single-simdgroup flash fallback (its register accumulator
                 // tops out at 128), so the wide gate only opens there when flash2 itself can run.
-                let flash = f16
-                    && rows * nh >= 128
-                    && kv_len >= 64
-                    && hd % 8 == 0
-                    && (hd <= 128 || flash2_ok);
+                let flash = prefer_attention_flash(f16, rows, nh, kv_len, hd, flash2_ok);
                 let split = !flash && (rows * nh < 128 || kv_len >= 128);
                 let flash2 = flash && flash2_ok;
                 // The split kernels REQUIRE their full NSG*32-thread threadgroup: every simdgroup

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -2310,6 +2310,38 @@ fn attention_flash2_hd128_matches_reference() {
     assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
 }
 
+// Four-row deep prefill reuses each K/V tile across the query rows through cooperative flash.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_flash2_four_row_prefill_matches_reference() {
+    let (rows, kv_len, nh, nkv, hd, pos) = (4usize, 136usize, 16usize, 8usize, 128usize, 131usize);
+    let mut g = Graph::new();
+    let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let vc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
+    let dst = g.output(TensorDesc::new(vec![rows, nh, hd], DType::F32));
+    g.push(Op::Attention {
+        q,
+        k_cache: kc,
+        v_cache: vc,
+        dst,
+        rows: rows as u32,
+        kv_len: kv_len as u32,
+        n_head: nh as u32,
+        n_kv: nkv as u32,
+        head_dim: hd as u32,
+        scale: 1.0 / (hd as f32).sqrt(),
+        mask: infr_core::graph::AttnMask::Causal,
+        pos: pos as u32,
+    });
+    let bound = vec![
+        (q, f32_bytes(&rand_f32(rows * nh * hd, 601))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 602))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 603))),
+    ];
+    assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
 // hd=256 (gemma): the cooperative flash instantiation with 8 O fragments per simdgroup.
 #[test]
 #[ignore = "requires a Metal GPU"]


### PR DESCRIPTION
## Summary
- route exactly four-row, long-context f16 Metal attention through cooperative flash when the model has at least 16 heads
- retain the existing wide, shallow, decode, and capacity-capped device routes
- add focused route-policy coverage and an exact-shape Metal parity test

## Why
The vector attention route launches once per query row and streams the same deep K/V prefix four times. The cooperative flash kernel tiles the four query rows together and reuses each K/V tile across them.

The extension is deliberately narrow: `rows == 4`, `rows * n_head >= 64`, `kv_len >= 64`, and a device that supports the kernel's full 128-thread threadgroup. Devices without that capacity keep the prior vector route.

## Performance
Qwen3-0.6B Q4_K_M on M3 Pro, exact four-row prefill at depth 4096. Measurements used #85's corrected row/depth benchmark semantics, with three alternating cooled 10-repetition runs:

- prior vector route: 180.5, 171.5, 167.3 t/s; median 171.5
- cooperative flash: 221.9, 223.8, 223.3 t/s; median 223.3
- improvement: **+30.2%**

Neighbor checks:
- shallow pp4: 577.1 t/s; remains below the `kv_len >= 64` gate
- tg128 at depth 4096: 111.3 t/s; decode remains `rows == 1`

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p infr-metal --all-targets --locked -- -D warnings`
- `cargo test -p infr-metal --locked`
- `cargo test -p infr-metal --test parity attention_flash2_four_row_prefill_matches_reference --locked -- --ignored --nocapture`
- `cargo build --release -p infr-cli --locked`

## Known upstream CI failures
Current upstream main independently causes:
- workspace Clippy/tests to fail because the new `DType::I2S` is missing from a Vulkan test match
- the CPU-goldens job to invoke deprecated `huggingface-cli` instead of `hf`
- the Metal kernel-name scraper to treat the negative-test literal `linear_quik_bogus` as a dispatch target
