### PR TITLE
perf(metal): widen four-row flash KV tiles

### DIFF
--- a/crates/infr-metal/shaders/attention.metal
+++ b/crates/infr-metal/shaders/attention.metal
@@ -421,7 +421,7 @@ kernel void attnflash_f16kv(device const half*  q   [[buffer(0)]],
 // P rounds through f32 shared and enters the V MMA as an f32 fragment against half V fragments.
 // Tail KV blocks read up to 7 rows past the causal limit (same in-buffer contract as above);
 // 8-row blocks entirely past it are skipped, so reads never go further.
-template<uint hd, uint NSG>   // compile-time head_dim + simdgroup count: fully unrolled, exact shared sizing
+template<uint hd, uint NSG, uint C> // compile-time shape: fully unrolled, exact shared sizing
 kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
                                device const half*  k   [[buffer(1)]],
                                device const half*  v   [[buffer(2)]],
@@ -430,7 +430,8 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
                                uint3  tgpig [[threadgroup_position_in_grid]],
                                ushort sgitg [[simdgroup_index_in_threadgroup]],
                                ushort tiisg [[thread_index_in_simdgroup]]) {
-    constexpr uint QT = 8, C = 64, NQ = QT / NSG, SH = C;
+    constexpr uint QT = 8, NQ = QT / NSG, SH = C;
+    constexpr uint NP = C / 64u;                  // score pairs owned per lane
     threadgroup half  sq[QT * hd];    // Q tile (rows x hd, half)
     threadgroup float so[QT * hd];    // O accumulator (rows x hd, f32)
     threadgroup float ss[QT * SH];    // scores, then P, per KV block (rows x C, f32)
@@ -499,19 +500,31 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
             uint j = jj * NSG + sgitg;
             uint absr = abs0 + j;   // rows past p.rows compute junk, never stored
             uint lor = (p.window > 0u && absr + 1u > p.window) ? (absr + 1u - p.window) : 0u;
-            threadgroup float2* ss2 = (threadgroup float2*)(ss + j * SH);
-            float2 s2 = ss2[tiisg] * p.scale;
-            uint c0 = ic + 2u * tiisg;
-            bool v0 = (c0 >= lor) && (c0 <= absr);
-            bool v1 = (c0 + 1u >= lor) && (c0 + 1u <= absr);
             float m = M[jj];
-            float mnew = simd_max(max(m, max(v0 ? s2.x : -MAXFLOAT / 2, v1 ? s2.y : -MAXFLOAT / 2)));
+            threadgroup float2* ss2 = (threadgroup float2*)(ss + j * SH);
+            float2 scores[NP];
+            bool2 valid[NP];
+            float local_max = m;
+            for (uint kk = 0; kk < NP; kk++) {
+                scores[kk] = ss2[tiisg + 32u * kk] * p.scale;
+                uint c0 = ic + 64u * kk + 2u * tiisg;
+                valid[kk] = bool2((c0 >= lor) && (c0 <= absr),
+                                  (c0 + 1u >= lor) && (c0 + 1u <= absr));
+                local_max = max(local_max,
+                                max(valid[kk].x ? scores[kk].x : -MAXFLOAT / 2,
+                                    valid[kk].y ? scores[kk].y : -MAXFLOAT / 2));
+            }
+            float mnew = simd_max(local_max);
             float ms = exp(m - mnew);
-            float pw0 = v0 ? exp(s2.x - mnew) : 0.0f;
-            float pw1 = v1 ? exp(s2.y - mnew) : 0.0f;
-            S[jj] = S[jj] * ms + simd_sum(pw0 + pw1);
+            float local_sum = 0.0f;
+            for (uint kk = 0; kk < NP; kk++) {
+                float2 pw = float2(valid[kk].x ? exp(scores[kk].x - mnew) : 0.0f,
+                                   valid[kk].y ? exp(scores[kk].y - mnew) : 0.0f);
+                ss2[tiisg + 32u * kk] = pw;
+                local_sum += pw.x + pw.y;
+            }
+            S[jj] = S[jj] * ms + simd_sum(local_sum);
             M[jj] = mnew;
-            ss2[tiisg] = float2(pw0, pw1);
             threadgroup float4* so4 = (threadgroup float4*)so + j * hd4;
             for (uint i = tiisg; i < hd4; i += 32u) so4[i] *= ms;
         }
@@ -565,11 +578,14 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
     }
 }
 
-typedef decltype(attnflash2_f16kv_t<64, 4>) attnflash2_t;
-template [[host_name("attnflash2_f16kv_hd64")]]  kernel attnflash2_t attnflash2_f16kv_t<64, 4>;
-template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_f16kv_t<128, 4>;
+typedef decltype(attnflash2_f16kv_t<64, 4, 64>) attnflash2_t;
+template [[host_name("attnflash2_f16kv_hd64")]]  kernel attnflash2_t attnflash2_f16kv_t<64, 4, 64>;
+template [[host_name("attnflash2_f16kv_hd128")]] kernel attnflash2_t attnflash2_f16kv_t<128, 4, 64>;
 // hd=256 (gemma): sq 4KB + so 8KB + ss 2KB = 14KB shared, 8 O fragments per simdgroup.
-template [[host_name("attnflash2_f16kv_hd256")]] kernel attnflash2_t attnflash2_f16kv_t<256, 4>;
+template [[host_name("attnflash2_f16kv_hd256")]] kernel attnflash2_t attnflash2_f16kv_t<256, 4, 64>;
+typedef decltype(attnflash2_f16kv_t<128, 4, 128>) attnflash2_c128_t;
+template [[host_name("attnflash2_c128_f16kv_hd128")]]
+kernel attnflash2_c128_t attnflash2_f16kv_t<128, 4, 128>;
 
 // ---- Vector flash attention for decode (f16 KV cache, hd 64 or 128, one query row per
 // threadgroup): the llama.cpp `kernel_flash_attn_ext_vec` structure. NSG simdgroups each own

--- a/crates/infr-metal/shaders/attention.metal
+++ b/crates/infr-metal/shaders/attention.metal
@@ -495,7 +495,7 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
             }
         }
         threadgroup_barrier(mem_flags::mem_threadgroup);
-        // online softmax — rows split across simdgroups, 2 scores (one float2) per lane
+        // online softmax — rows split across simdgroups, C / 32 scores (float2s) per lane
         for (uint jj = 0; jj < NQ; jj++) {
             uint j = jj * NSG + sgitg;
             uint absr = abs0 + j;   // rows past p.rows compute junk, never stored

--- a/crates/infr-metal/shaders/attention.metal
+++ b/crates/infr-metal/shaders/attention.metal
@@ -471,8 +471,8 @@ kernel void attnflash2_f16kv_t(device const half*  q   [[buffer(0)]],
     for (uint jj = 0; jj < NQ; jj++) { S[jj] = 0.0f; M[jj] = -MAXFLOAT / 2; }
 
     for (uint ic = lo_min & ~(C - 1u); ic <= abs_max; ic += C) {
-        // Q*K^T — 8 score fragments split across simdgroups (fragment f covers KV rows
-        // ic+8f, columns interleaved so each simdgroup's two fragments are NSG apart)
+        // Q*K^T — C / 8 score fragments split across simdgroups (fragment f covers KV rows
+        // ic+8f, columns interleaved so each simdgroup's fragments are NSG apart)
         {
             device const half* pk = k + ((ulong)(ic + 8u * sgitg) * p.n_kv + kvh) * hd;
             threadgroup float* ps = ss + 8u * sgitg;

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -385,8 +385,8 @@ mod tests {
                 16,
                 4096,
                 128,
-                Some("attnflash2_f16kv_hd128"),
-                true,
+                || true,
+                || Some("attnflash2_f16kv_hd128"),
             ),
             Some("attnflash2_c128_f16kv_hd128"),
         );
@@ -397,15 +397,17 @@ mod tests {
                 16,
                 4096,
                 128,
-                Some("attnflash2_f16kv_hd128"),
-                false,
+                || false,
+                || Some("attnflash2_f16kv_hd128"),
             ),
             Some("attnflash2_f16kv_hd128"),
         );
         assert_eq!(
-            select_attention_flash2_kern(true, 4, 16, 4096, 128, None, false),
+            select_attention_flash2_kern(true, 4, 16, 4096, 128, || false, || None),
             None,
         );
+
+        let mut probed = false;
         assert_eq!(
             select_attention_flash2_kern(
                 true,
@@ -413,11 +415,15 @@ mod tests {
                 16,
                 4096,
                 128,
-                Some("attnflash2_f16kv_hd128"),
-                true,
+                || {
+                    probed = true;
+                    true
+                },
+                || Some("attnflash2_f16kv_hd128"),
             ),
             Some("attnflash2_f16kv_hd128"),
         );
+        assert!(!probed, "non-four-row shapes must not build the C128 PSO");
     }
 
     #[test]
@@ -1108,13 +1114,13 @@ fn select_attention_flash2_kern(
     n_head: usize,
     kv_len: usize,
     head_dim: usize,
-    standard: Option<&'static str>,
-    c128_ok: bool,
+    c128_pipeline_ok: impl FnOnce() -> bool,
+    standard_pipeline: impl FnOnce() -> Option<&'static str>,
 ) -> Option<&'static str> {
-    if f16 && rows == 4 && n_head >= 16 && kv_len >= 64 && head_dim == 128 && c128_ok {
+    if f16 && rows == 4 && n_head >= 16 && kv_len >= 64 && head_dim == 128 && c128_pipeline_ok() {
         Some("attnflash2_c128_f16kv_hd128")
     } else {
-        standard
+        standard_pipeline()
     }
 }
 
@@ -4169,26 +4175,26 @@ impl MetalBackend {
                     256 => Some("attnflash2_f16kv_hd256"),
                     _ => None,
                 };
-                let standard_flash2_kern = standard_flash2_kern.filter(|kn| {
-                    self.pipelines
-                        .get(kn)
-                        .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
-                        .unwrap_or(false)
-                });
-                let flash2_c128_ok = hd == 128
-                    && self
-                        .pipelines
-                        .get("attnflash2_c128_f16kv_hd128")
-                        .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
-                        .unwrap_or(false);
                 let flash2_kern = select_attention_flash2_kern(
                     f16,
                     rows,
                     nh,
                     kv_len,
                     hd,
-                    standard_flash2_kern,
-                    flash2_c128_ok,
+                    || {
+                        self.pipelines
+                            .get("attnflash2_c128_f16kv_hd128")
+                            .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                            .unwrap_or(false)
+                    },
+                    || {
+                        standard_flash2_kern.filter(|kn| {
+                            self.pipelines
+                                .get(kn)
+                                .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                                .unwrap_or(false)
+                        })
+                    },
                 );
                 let flash2_ok = flash2_kern.is_some();
                 // hd > 128 has no single-simdgroup flash fallback (its register accumulator

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1110,12 +1110,7 @@ fn prefer_attention_flash128(
     head_dim: usize,
     pipeline_ok: bool,
 ) -> bool {
-    f16
-        && rows == 4
-        && n_head >= 16
-        && kv_len >= 64
-        && head_dim == 128
-        && pipeline_ok
+    f16 && rows == 4 && n_head >= 16 && kv_len >= 64 && head_dim == 128 && pipeline_ok
 }
 
 fn select_attention_flash2_kern(

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -1102,17 +1102,6 @@ fn prefer_attention_flash(
         && (head_dim <= 128 || flash2_ok)
 }
 
-fn prefer_attention_flash128(
-    f16: bool,
-    rows: usize,
-    n_head: usize,
-    kv_len: usize,
-    head_dim: usize,
-    pipeline_ok: bool,
-) -> bool {
-    f16 && rows == 4 && n_head >= 16 && kv_len >= 64 && head_dim == 128 && pipeline_ok
-}
-
 fn select_attention_flash2_kern(
     f16: bool,
     rows: usize,
@@ -1122,7 +1111,7 @@ fn select_attention_flash2_kern(
     standard: Option<&'static str>,
     c128_ok: bool,
 ) -> Option<&'static str> {
-    if prefer_attention_flash128(f16, rows, n_head, kv_len, head_dim, c128_ok) {
+    if f16 && rows == 4 && n_head >= 16 && kv_len >= 64 && head_dim == 128 && c128_ok {
         Some("attnflash2_c128_f16kv_hd128")
     } else {
         standard

--- a/crates/infr-metal/src/exec.rs
+++ b/crates/infr-metal/src/exec.rs
@@ -377,6 +377,50 @@ mod tests {
     }
 
     #[test]
+    fn attention_flash128_policy_is_exact() {
+        assert_eq!(
+            select_attention_flash2_kern(
+                true,
+                4,
+                16,
+                4096,
+                128,
+                Some("attnflash2_f16kv_hd128"),
+                true,
+            ),
+            Some("attnflash2_c128_f16kv_hd128"),
+        );
+        assert_eq!(
+            select_attention_flash2_kern(
+                true,
+                4,
+                16,
+                4096,
+                128,
+                Some("attnflash2_f16kv_hd128"),
+                false,
+            ),
+            Some("attnflash2_f16kv_hd128"),
+        );
+        assert_eq!(
+            select_attention_flash2_kern(true, 4, 16, 4096, 128, None, false),
+            None,
+        );
+        assert_eq!(
+            select_attention_flash2_kern(
+                true,
+                8,
+                16,
+                4096,
+                128,
+                Some("attnflash2_f16kv_hd128"),
+                true,
+            ),
+            Some("attnflash2_f16kv_hd128"),
+        );
+    }
+
+    #[test]
     fn q5k_row_tile_policy_is_limited_to_four_rows() {
         for m in [1usize, 2, 3, 5] {
             assert!(!prefer_q5k_rt("linear_q5k", m, true));
@@ -1056,6 +1100,38 @@ fn prefer_attention_flash(
         && kv_len >= 64
         && head_dim.is_multiple_of(8)
         && (head_dim <= 128 || flash2_ok)
+}
+
+fn prefer_attention_flash128(
+    f16: bool,
+    rows: usize,
+    n_head: usize,
+    kv_len: usize,
+    head_dim: usize,
+    pipeline_ok: bool,
+) -> bool {
+    f16
+        && rows == 4
+        && n_head >= 16
+        && kv_len >= 64
+        && head_dim == 128
+        && pipeline_ok
+}
+
+fn select_attention_flash2_kern(
+    f16: bool,
+    rows: usize,
+    n_head: usize,
+    kv_len: usize,
+    head_dim: usize,
+    standard: Option<&'static str>,
+    c128_ok: bool,
+) -> Option<&'static str> {
+    if prefer_attention_flash128(f16, rows, n_head, kv_len, head_dim, c128_ok) {
+        Some("attnflash2_c128_f16kv_hd128")
+    } else {
+        standard
+    }
 }
 
 fn counter_linear_label(enabled: bool, kern: &'static str) -> Option<&'static str> {
@@ -4103,18 +4179,34 @@ impl MetalBackend {
                 // (fully unrolled QK/PV loops) and needs a 128-thread threadgroup
                 // (pipeline-cap gated like the split kernels); other head sizes keep the
                 // single-simdgroup flash.
-                let flash2_kern = match hd {
+                let standard_flash2_kern = match hd {
                     64 => Some("attnflash2_f16kv_hd64"),
                     128 => Some("attnflash2_f16kv_hd128"),
                     256 => Some("attnflash2_f16kv_hd256"),
                     _ => None,
                 };
-                let flash2_ok = flash2_kern.is_some_and(|kn| {
+                let standard_flash2_kern = standard_flash2_kern.filter(|kn| {
                     self.pipelines
                         .get(kn)
                         .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
                         .unwrap_or(false)
                 });
+                let flash2_c128_ok = hd == 128
+                    && self
+                        .pipelines
+                        .get("attnflash2_c128_f16kv_hd128")
+                        .map(|pl| pl.max_total_threads_per_threadgroup() >= 128)
+                        .unwrap_or(false);
+                let flash2_kern = select_attention_flash2_kern(
+                    f16,
+                    rows,
+                    nh,
+                    kv_len,
+                    hd,
+                    standard_flash2_kern,
+                    flash2_c128_ok,
+                );
+                let flash2_ok = flash2_kern.is_some();
                 // hd > 128 has no single-simdgroup flash fallback (its register accumulator
                 // tops out at 128), so the wide gate only opens there when flash2 itself can run.
                 let flash = prefer_attention_flash(f16, rows, nh, kv_len, hd, flash2_ok);

--- a/crates/infr-metal/tests/kernel_names.rs
+++ b/crates/infr-metal/tests/kernel_names.rs
@@ -79,6 +79,14 @@ fn iq4nl_has_a_native_four_row_decode_body() {
 }
 
 #[test]
+fn four_row_attention_has_a_wide_kv_chunk() {
+    let src = include_str!("../shaders/attention.metal");
+    asserts_token_seq(src, "template<uint hd, uint NSG, uint C>");
+    asserts_token_seq(src, "constexpr uint NP = C / 64u");
+    asserts_token_seq(src, "host_name(\"attnflash2_c128_f16kv_hd128\")");
+}
+
+#[test]
 fn moe_cmm_masks_inactive_matrix_row_fragments() {
     // Partial expert tiles must skip dead 8-row fragments instead of running the full MMA and
     // discarding half of it (see moe.metal). `row_base` is derived from `sgid` alone, which is

--- a/crates/infr-metal/tests/parity.rs
+++ b/crates/infr-metal/tests/parity.rs
@@ -2866,11 +2866,13 @@ fn attention_flash2_hd128_matches_reference() {
     assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
 }
 
-// Four-row deep prefill reuses each K/V tile across the query rows through cooperative flash.
-#[test]
-#[ignore = "requires a Metal GPU"]
-fn attention_flash2_four_row_prefill_matches_reference() {
-    let (rows, kv_len, nh, nkv, hd, pos) = (4usize, 136usize, 16usize, 8usize, 128usize, 131usize);
+fn attention_flash2_four_row_prefill_match(
+    kv_len: usize,
+    mask: infr_core::graph::AttnMask,
+    pos: usize,
+    seed: u64,
+) {
+    let (rows, nh, nkv, hd) = (4usize, 16usize, 8usize, 128usize);
     let mut g = Graph::new();
     let q = g.input(TensorDesc::new(vec![rows, nh, hd], DType::F32));
     let kc = g.input(TensorDesc::new(vec![kv_len, nkv, hd], DType::F16));
@@ -2887,15 +2889,38 @@ fn attention_flash2_four_row_prefill_matches_reference() {
         n_kv: nkv as u32,
         head_dim: hd as u32,
         scale: 1.0 / (hd as f32).sqrt(),
-        mask: infr_core::graph::AttnMask::Causal,
+        mask,
         pos: pos as u32,
     });
     let bound = vec![
-        (q, f32_bytes(&rand_f32(rows * nh * hd, 601))),
-        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, 602))),
-        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, 603))),
+        (q, f32_bytes(&rand_f32(rows * nh * hd, seed))),
+        (kc, f16_bytes(&rand_f32(kv_len * nkv * hd, seed + 1))),
+        (vc, f16_bytes(&rand_f32(kv_len * nkv * hd, seed + 2))),
     ];
     assert_parity(&g, &bound, dst, rows * nh * hd, 5e-3);
+}
+
+// Four-row deep prefill reuses each K/V tile across the query rows through cooperative flash.
+#[test]
+#[ignore = "requires a Metal GPU"]
+fn attention_flash2_four_row_prefill_matches_reference() {
+    // Causal prefill: rows=4, nh=16, hd=128. kv_len=136 crosses the first C128 chunk
+    // and has a non-aligned 8-position tail.
+    attention_flash2_four_row_prefill_match(136, infr_core::graph::AttnMask::Causal, 131, 601);
+
+    // Sliding-window masking should clip the same prefill window with its lower bound still in
+    // the first C128 chunk.
+    let kv_len = 136usize;
+    let win = 64usize;
+    let pos = 131usize;
+    let lo = pos.saturating_sub(win - 1);
+    assert!(lo < 128, "lower bound must sit in the first C128 chunk");
+    attention_flash2_four_row_prefill_match(
+        kv_len,
+        infr_core::graph::AttnMask::SlidingWindow(win),
+        pos,
+        602,
+    );
 }
 
 // hd=256 (gemma): the cooperative flash instantiation with 8 O fragments per simdgroup.


### PR DESCRIPTION
## Summary

- specialize cooperative four-row, hd128 flash attention for 128 KV positions per tile
- lazily select the C128 pipeline and retain the existing C64 pipeline as fallback
- cover causal tail and sliding-window masking at the C128 boundary

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p infr-metal attention_flash128_policy_is_exact`
- `cargo test -p infr-metal --test kernel_names`
- `cargo check -p infr-metal --all-targets --locked`
- Metal 32023.883 compiled `common.metal` + `attention.metal`; AIR exports `attnflash2_c128_f16kv_hd128`
- dispatch test was confirmed to fail when C128 selection was disabled, then pass after restoration
- all seven PR CI jobs passed, including the expanded causal-tail/sliding-window parity test on a real Metal runner

## Performance evidence

Paired same-runner A/B at `rows=4`, `n_head=16`, `n_kv=8`, `head_dim=128`, `kv_len=4096`, `pos=4092`, f16 KV, causal mask. Each process used deterministic inputs, at least 50 warmups and one second of GPU warmup, then 10 calibrated 2–5 second blocks; block 0 was discarded. C128/C64 order alternated across five `macos-15` runners. The metric is one-op synchronous `MetalBackend::execute` wall latency, not isolated kernel time.

| Pair | C128 median (µs) | C64 median (µs) | Ratio |
|---|---:|---:|---:|
| 1 AB | 1911.881 | 2164.915 | 0.883121 |
| 2 BA | 1676.385 | 1957.752 | 0.856281 |
| 3 AB | 1629.594 | 1951.521 | 0.835038 |
| 4 BA | 2045.393 | 2174.325 | 0.940703 |
| 5 AB | 2454.246 | 2778.088 | 0.883430 |

Runner-level geometric-mean ratio: **0.879009** (**12.099% faster**). Runner-level bootstrap 95% CI: **[0.851989, 0.911652]**. The predeclared win criterion was an upper bound below `0.95`; this passes.

Evidence run: https://github.com/digitaloten/infr/actions/runs/30352605155