### PR TITLE
fix(runtime): address correctness review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed
+
+- `Gguf::open` now snapshots files into immutable memory before exposing tensor
+  bytes, preventing later file changes from invalidating live references.
+
+### Fixed
+
+- Reject GGUF tensors whose encoded byte count overflows `usize` and model
+  metadata with zero attention heads.
+- Stop malformed pipe-format tool arrays from entering a non-progress allocation
+  loop.
+- Treat model JSON as a tool call only when the request offers a non-empty tool
+  list.
+- Publish graceful-shutdown state and its signal number atomically so
+  interrupted CLI commands retain the correct exit status.
+- Drop completed CPU spin-pool results when a sibling task panics.

--- a/crates/infr-chat/src/tools.rs
+++ b/crates/infr-chat/src/tools.rs
@@ -100,13 +100,13 @@ const MAX_VALUE_DEPTH: usize = 64;
 ///
 /// `s` has already had `<|"|>` replaced with `"`.
 ///
-/// Returns `None` — and only ever `None` — when nesting would exceed [`MAX_VALUE_DEPTH`];
-/// every other malformation stays lenient-by-design (partial objects, missing quotes and
-/// unterminated strings all yield a best-effort `Value`, as callers rely on). `None`
-/// propagates all the way out so the caller drops the whole call instead of acting on a
-/// truncated one. Note the degradation could NOT be "return `Value::Null` in place and stop
-/// consuming": the array arm loops `while` the cursor hasn't reached `]`, so a value that
-/// returns without advancing `i` spins forever pushing `Null`s — a hang and an OOM in place
+/// Returns `None` when nesting would exceed [`MAX_VALUE_DEPTH`] or when the current byte is
+/// a container delimiter that cannot begin a value. Other malformations stay lenient-by-design
+/// (partial objects, missing quotes and unterminated strings all yield a best-effort `Value`, as
+/// callers rely on). `None` propagates all the way out so the caller drops the whole call instead
+/// of acting on a truncated one. Note the degradation could NOT be "return `Value::Null` in place
+/// and stop consuming": the array arm loops `while` the cursor hasn't reached `]`, so a value
+/// that returns without advancing `i` spins forever pushing `Null`s — a hang and an OOM in place
 /// of the stack overflow. Propagating `None` is the only exit that terminates every loop.
 fn parse_value(s: &[u8], mut i: usize, depth: usize) -> Option<(Value, usize)> {
     // skip whitespace
@@ -115,6 +115,11 @@ fn parse_value(s: &[u8], mut i: usize, depth: usize) -> Option<(Value, usize)> {
     }
     if i >= s.len() {
         return Some((Value::Null, i));
+    }
+    // A closing delimiter is not a value. Returning a successful empty bareword without consuming
+    // it leaves the surrounding container loop on the same byte forever.
+    if matches!(s[i], b',' | b'}' | b']') {
+        return None;
     }
     // Refuse before descending into a container, so the frame budget is checked once per level.
     if matches!(s[i], b'{' | b'[') && depth >= MAX_VALUE_DEPTH {
@@ -699,6 +704,20 @@ mod tests {
         let (clean, calls) = parse_tool_calls(text);
         assert!(calls.is_empty());
         assert_eq!(clean, text);
+    }
+
+    #[test]
+    fn unexpected_container_delimiter_is_not_a_value() {
+        assert!(
+            parse_value(b"}", 0, 0).is_none(),
+            "a value parser must reject a delimiter without consuming it"
+        );
+    }
+
+    #[test]
+    fn malformed_array_delimiter_does_not_loop() {
+        let (_, calls) = parse_tool_calls("<|tool_call>call:x{a:[}]}<tool_call|>");
+        assert!(calls.is_empty());
     }
 
     #[test]

--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -503,10 +503,11 @@ enum Cmd {
 // ---------------------------------------------------------------------------
 
 /// `SIGINT`/`SIGTERM` handler. **Async-signal-safe by construction**: the first signal does nothing
-/// but a lock-free atomic store ([`infr_core::shutdown::request_shutdown`]) — no allocation, no
-/// locking, no Rust `println!` (which takes the stdout lock and would deadlock against an
-/// interrupted `print!`). The engine's poll sites see the latch at their next submit boundary,
-/// drain the GPU work already in flight, unwind, and let the backend's `Drop` destroy the device.
+/// but a lock-free atomic compare-exchange ([`infr_core::shutdown::request_shutdown`]) — no
+/// allocation, no locking, no Rust `println!` (which takes the stdout lock and would deadlock
+/// against an interrupted `print!`). The engine's poll sites see the latch at their next submit
+/// boundary, drain the GPU work already in flight, unwind, and let the backend's `Drop` destroy the
+/// device.
 ///
 /// The SECOND signal is the user saying they have given up waiting, and is honoured immediately:
 /// `write(2)` and `_exit(2)` are both on POSIX's async-signal-safe list (unlike `exit`, which runs
@@ -1855,6 +1856,15 @@ impl infr_server::ChatGenerator for ParallelGenerator {
     }
 }
 
+/// Tool-call parsing is enabled only when the request offers at least one tool and has not
+/// explicitly disabled calls with `tool_choice: "none"`.
+fn tool_parsing_allowed(tools: Option<&serde_json::Value>, tool_choice: Option<&str>) -> bool {
+    tools
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|tools| !tools.is_empty())
+        && tool_choice != Some("none")
+}
+
 /// The OpenAI chat body, shared by every serve backend: render the conversation through the model's
 /// own template, honour a FORCED tool_choice with an llguidance constraint, then stream the reply
 /// through the reasoning/content/tool-call splitter with stop sequences applied to the raw text.
@@ -1948,7 +1958,7 @@ fn run_chat(
                 "[tools] forced tool call produced no parseable call; falling back to unconstrained"
             );
         }
-        let mut stream = infr_engine::ChatStream::new(tool_choice != Some("none"));
+        let mut stream = infr_engine::ChatStream::new(tool_parsing_allowed(tools, tool_choice));
         // Stop sequences run on the RAW decoded text, BEFORE the reasoning/tool splitter — so a
         // stop string that spans two tokens still fires, and a partial stop prefix is held back
         // instead of being streamed out (see `StopMatcher`). A hit latches an abort on THIS
@@ -2444,7 +2454,7 @@ fn cmd_bench_metal(
         // the depth warm resets the materialized tokens). A fresh backend per rep re-paid those
         // one-time costs inside the measurement.
         let mut sess = model.metal_session(shape.max_ctx)?;
-        // One untimed warmup: page-cache the mmap + build the weight caches + compile pipelines.
+        // One untimed warmup: build the weight caches and compile pipelines.
         let _ = model.bench_metal(&mut sess, 8, 2, true, false);
         let mut samples = Vec::with_capacity(reps);
         for _ in 0..reps {
@@ -2519,7 +2529,7 @@ fn cmd_bench_cpu(
 ) -> anyhow::Result<()> {
     let model = infr_llama::SeamModel::load_with(gguf, tok, cfg.clone())?;
     let measure_tg = pg.is_none() && n_gen > 0;
-    // One untimed warmup (page-cache the mmap'd weights) before the timed reps.
+    // One untimed warmup to build runtime caches before the timed reps.
     let _ = model.bench(depth.max(1), if measure_tg || pg.is_some() { 1 } else { 0 });
     let mut samples = Vec::with_capacity(reps);
     for _ in 0..reps {
@@ -4162,6 +4172,17 @@ mod tests {
             ubatch: None,
             threads: None,
         }
+    }
+
+    #[test]
+    fn tool_parsing_requires_nonempty_tools() {
+        let empty = serde_json::json!([]);
+        let tools = serde_json::json!([{"type": "function", "function": {"name": "bash"}}]);
+
+        assert!(!tool_parsing_allowed(None, None));
+        assert!(!tool_parsing_allowed(Some(&empty), None));
+        assert!(tool_parsing_allowed(Some(&tools), None));
+        assert!(!tool_parsing_allowed(Some(&tools), Some("none")));
     }
 
     #[test]

--- a/crates/infr-core/src/backend.rs
+++ b/crates/infr-core/src/backend.rs
@@ -497,8 +497,8 @@ pub trait Backend: Send + Sync {
     /// allocations (`BufferUsage::Weights`/`HostWeights`) advance a visible progress display;
     /// dropping the guard finishes and clears it. The ticking lives in each backend's `alloc`, so
     /// no loader can forget a tensor — a loader only opens the scope around its upload loop.
-    /// Backends without a display (the CPU interpreter's zero-copy mmap load is instant) keep
-    /// this default no-op scope.
+    /// Backends without a display (the CPU interpreter has no backend upload phase) keep this
+    /// default no-op scope.
     fn weight_progress(&self, _total_bytes: Option<u64>) -> Box<dyn ProgressScope> {
         struct NoProgress;
         impl ProgressScope for NoProgress {}

--- a/crates/infr-core/src/shutdown.rs
+++ b/crates/infr-core/src/shutdown.rs
@@ -15,7 +15,7 @@
 //! this latch:
 //!
 //! * The CLI's signal handler does exactly ONE thing — [`request_shutdown`], a lock-free atomic
-//!   store. Nothing else in the handler is async-signal-safe, so nothing else is in it.
+//!   compare-exchange. Nothing else in the handler is async-signal-safe, so nothing else is in it.
 //! * Everything that can issue GPU work polls [`shutdown_requested`] at the boundary where it is
 //!   about to submit MORE work, and stops there. Work already submitted is always drained
 //!   (`vkQueueWaitIdle` / fence wait) — never abandoned.
@@ -32,33 +32,29 @@
 //! a poll loop that observes it one iteration late is fine — the guarantee is "stops promptly", not
 //! "stops instantly".
 
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::atomic::{AtomicI32, Ordering};
 
-static SHUTDOWN: AtomicBool = AtomicBool::new(false);
-/// The signal number that latched it (0 = none), so the CLI can exit 128+signo.
+/// The signal number that latched shutdown (`0` means no request). Publishing the request and its
+/// signal as one atomic transition prevents observers from seeing shutdown without an exit status.
 static SIGNO: AtomicI32 = AtomicI32::new(0);
 
 /// Latch the shutdown request. Returns `true` if THIS call was the one that latched it, `false` if
 /// it was already set (i.e. this is a second signal — the caller may then decide the user has given
 /// up waiting and force-exit).
 ///
-/// **Async-signal-safe**: a `compare_exchange` and a `store` on lock-free atomics, nothing else. No
-/// allocation, no locking, no I/O. It is called directly from the CLI's `SIGINT`/`SIGTERM` handler.
+/// **Async-signal-safe**: one `compare_exchange` on a lock-free atomic, nothing else. No allocation,
+/// no locking, no I/O. It is called directly from the CLI's `SIGINT`/`SIGTERM` handler.
 pub fn request_shutdown(signo: i32) -> bool {
-    let first = SHUTDOWN
-        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-        .is_ok();
-    if first {
-        SIGNO.store(signo, Ordering::Relaxed);
-    }
-    first
+    SIGNO
+        .compare_exchange(0, signo, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
 }
 
 /// Has a shutdown been requested? One relaxed atomic load — cheap enough for a per-op poll inside
 /// the Vulkan recording loop (it is dwarfed by the descriptor writes of a single dispatch).
 #[inline]
 pub fn shutdown_requested() -> bool {
-    SHUTDOWN.load(Ordering::Relaxed)
+    SIGNO.load(Ordering::Relaxed) != 0
 }
 
 /// The signal that latched the shutdown, or `None` if none has. The CLI turns this into the

--- a/crates/infr-cpu/src/lib.rs
+++ b/crates/infr-cpu/src/lib.rs
@@ -1,10 +1,10 @@
 //! CPU reference backend — a correctness-first interpreter of the backend-agnostic
 //! [`infr_core`] compute [`Graph`]. Projection matmuls and attention use rayon for multi-core
 //! parallelism; QK/PV inner loops use an 8-accumulator dot for AVX autovectorization.
-//! Weights are read **zero-copy from the GGUF mmap** (no `memcpy`, no owned RAM): the bulk
-//! projection weights (`Op::Linear`) are dequantized one row at a time straight from the mapping
-//! inside the dot, so 12B / MoE models cost only their on-disk size in page cache. Only the tiny
-//! norm weights are dequant-cached; the model writes (KV / conv / recurrent state, per-step IO) use
+//! Weights are read without additional copies from the immutable GGUF snapshot: the bulk
+//! projection weights (`Op::Linear`) are dequantized one row at a time straight from that native
+//! byte layout inside the dot, so there is no full-model f32 materialization. Only the tiny norm
+//! weights are dequant-cached; the model writes (KV / conv / recurrent state, per-step IO) use
 //! small owned buffers. It exists to (a) run every model without a GPU and (b) serve as the oracle
 //! the GPU backends are validated against.
 #![allow(clippy::needless_range_loop)]
@@ -111,10 +111,11 @@ type WeightCache = HashMap<(usize, usize, DType), Arc<Vec<f32>>>;
 // scalar only (no SIMD; this path is memory/allocation-bound, not compute-bound, so a plain scalar
 // loop over int8 bytes already beats dequantizing the whole row to f32 first).
 
-/// A host buffer. Weights are **mapped** — a zero-copy [`TensorBytes`] view straight into the GGUF
-/// mmap (read-only, no `memcpy`, no owned RAM). Everything the model writes (KV / conv / recurrent
-/// state, per-step IO) is **owned** — a plain byte vec behind a `Mutex` (so `&dyn Buffer` stays
-/// `Send + Sync` and writes are safe). `&dyn Buffer` reads go through [`CpuBuffer::read`].
+/// A host buffer. Weights are **snapshot-backed** — a read-only [`TensorBytes`] view into the
+/// immutable GGUF bytes, with no additional allocation or copy per weight. Everything the model
+/// writes (KV / conv / recurrent state, per-step IO) is **owned** — a plain byte vec behind a
+/// `Mutex` (so `&dyn Buffer` stays `Send + Sync` and writes are safe). `&dyn Buffer` reads go
+/// through [`CpuBuffer::read`].
 pub enum CpuBuffer {
     Owned(Mutex<Vec<u8>>),
     Mapped(TensorBytes),
@@ -181,11 +182,12 @@ pub struct CpuBackend {
     /// back the previous model's f32 — the len/dtype discriminates the two.
     weight_cache: Mutex<WeightCache>,
     /// (layer, expert)-granular repack cache for the interleaved-x8 Q4_K GEMM ([`Q4kPack`]):
-    /// keyed by the expert weight slice's (address, length) — stable for the mmap'd/upload-once
-    /// weight buffers this backend binds (same lifetime argument as `weight_cache`). ggml pays
-    /// its `block_q4_Kx8` repack once at LOAD; this pays it once per (expert, session) instead
-    /// of once per CALL. Byte-budgeted (`kernels.cpu.repack_mb`, default 4096 MiB): over budget,
-    /// packs are built transient and not inserted. The `usize` is the current cached-bytes total.
+    /// keyed by the expert weight slice's (address, length) — stable for the snapshot-backed,
+    /// upload-once weight buffers this backend binds (same lifetime argument as `weight_cache`).
+    /// ggml pays its `block_q4_Kx8` repack once at LOAD; this pays it once per (expert, session)
+    /// instead of once per CALL. Byte-budgeted (`kernels.cpu.repack_mb`, default 4096 MiB): over
+    /// budget, packs are built transient and not inserted. The `usize` is the current cached-bytes
+    /// total.
     #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
     repack_cache: Mutex<RepackCacheState>,
     /// Q6_K sibling of `repack_cache` (same keying and budget knob; separate accounting) — holds
@@ -314,7 +316,7 @@ impl CpuBackend {
         repack::cache_insert_if_absent(&mut guard, key, pack, bytes, self.repack_budget_bytes())
     }
 
-    /// Wrap a zero-copy GGUF mmap view as a read-only weight buffer (no allocation, no `memcpy`).
+    /// Wrap a GGUF snapshot view as a read-only weight buffer without another allocation or copy.
     pub fn map_weight(&self, bytes: TensorBytes) -> Box<dyn Buffer> {
         Box::new(CpuBuffer::Mapped(bytes))
     }

--- a/crates/infr-cpu/src/pool.rs
+++ b/crates/infr-cpu/src/pool.rs
@@ -153,6 +153,23 @@ fn worker_loop(me: usize, shared: Arc<Shared>) {
     }
 }
 
+struct CollectGuard<'a, T> {
+    slots: *mut std::mem::MaybeUninit<T>,
+    initialized: &'a [AtomicBool],
+}
+
+impl<T> Drop for CollectGuard<'_, T> {
+    fn drop(&mut self) {
+        for (i, initialized) in self.initialized.iter().enumerate() {
+            if initialized.load(Ordering::Acquire) {
+                // SAFETY: each true flag is published only after its corresponding slot has been
+                // initialized, and `run` waits for all tasks before propagating a panic.
+                unsafe { std::ptr::drop_in_place(self.slots.add(i).cast::<T>()) };
+            }
+        }
+    }
+}
+
 #[cfg_attr(infr_profile, infr_prof::instrument)]
 impl SpinPool {
     /// Thread count follows rayon's (`RAYON_NUM_THREADS` / available parallelism) so `-t` pins
@@ -317,26 +334,20 @@ impl SpinPool {
         let mut out: Vec<std::mem::MaybeUninit<T>> = Vec::with_capacity(n);
         // SAFETY: every index 0..n is written exactly once below before assume-init.
         unsafe { out.set_len(n) };
+        let initialized: Vec<AtomicBool> = (0..n).map(|_| AtomicBool::new(false)).collect();
+        let guard = CollectGuard {
+            slots: out.as_mut_ptr(),
+            initialized: &initialized,
+        };
         let base = SendPtr(out.as_mut_ptr());
-        self.run(n, &move |i| {
+        self.run(n, &|i| {
             // SAFETY: each task writes only its own slot.
             unsafe { base.get().add(i).write(std::mem::MaybeUninit::new(f(i))) };
+            initialized[i].store(true, Ordering::Release);
         });
-        // SAFETY: all n slots are initialized. `run` returns only after every task completed, and
-        // if any task panicked `run` re-panics before we get here, so the rebuild below is only
-        // reached on the all-written path.
-        //
-        // LEAK ON PANIC (not UB, but not free either): `run` catches each task's panic
-        // individually and only re-panics once ALL tasks have finished — so by the time that panic
-        // unwinds through here, the non-panicking tasks have already written their slots. `out` is
-        // still typed `Vec<MaybeUninit<T>>`, and dropping a `MaybeUninit<T>` is a no-op, so every
-        // `T` that WAS constructed leaks its destructor. That is not free at the call sites this
-        // has: `T` is `Q8`/`Q8x32`, each holding several heap `Vec`s, so an aborted quantize of an
-        // m-row activation leaks up to m of them. It is a real leak, not merely a lost value —
-        // fixing it would mean tracking which indices were written and dropping those in place.
-        // The old comment claimed only that a panic "propagates out of `run` before we get here",
-        // which is true but says nothing about what the already-written slots cost on that path.
-        //
+        // Every slot is initialized after a successful `run`; disable the unwind-only destructor.
+        std::mem::forget(guard);
+
         // The rebuild is done via `from_raw_parts` rather than
         // `transmute::<Vec<MaybeUninit<T>>, Vec<T>>`: `Vec` is not `repr(C)`, so transmuting
         // between two instantiations of it is not a language guarantee even though
@@ -450,6 +461,37 @@ mod tests {
             hits[t].fetch_add(1, Ordering::Relaxed);
         });
         assert!(hits.iter().all(|h| h.load(Ordering::Relaxed) == 1));
+    }
+
+    #[test]
+    fn collect_drops_completed_values_when_another_task_panics() {
+        struct DropCounter(Arc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let pool = SpinPool::new(&CpuCfg::default());
+        let drops = Arc::new(AtomicUsize::new(0));
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = pool.collect(2, &|i| {
+                if i == 1 {
+                    panic!("task boom");
+                }
+                DropCounter(Arc::clone(&drops))
+            });
+        }));
+        std::panic::set_hook(prev);
+
+        assert!(caught.is_err(), "the task panic must propagate");
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            1,
+            "the value completed before the panic must be dropped"
+        );
     }
 
     #[test]

--- a/crates/infr-gguf/src/lib.rs
+++ b/crates/infr-gguf/src/lib.rs
@@ -1,7 +1,7 @@
 //! GGUF loader — `WeightSource` impl.
 //!
-//! Parses the GGUF binary format (little-endian) by mmap-ping the file and
-//! walking a byte cursor through header → metadata KV pairs → tensor directory.
+//! Parses the GGUF binary format (little-endian) into an immutable memory snapshot and
+//! walks a byte cursor through header → metadata KV pairs → tensor directory.
 //! Quantised weight blocks are returned as-is; the backend owns dequantisation.
 //!
 //! References:
@@ -17,8 +17,8 @@ use infr_core::{
     tensor::DType,
     WeightSource,
 };
-use memmap2::Mmap;
-use std::{collections::HashMap, fs::File, path::Path, sync::Arc};
+use memmap2::{Mmap, MmapMut};
+use std::{collections::HashMap, fs::File, io::Read, path::Path, sync::Arc};
 
 // ─── constants ────────────────────────────────────────────────────────────────
 
@@ -61,21 +61,21 @@ const MAX_META_DEPTH: usize = 64;
 
 // ─── public struct ────────────────────────────────────────────────────────────
 
-/// A parsed, mmap-backed GGUF file.
+/// A parsed GGUF snapshot.
 ///
-/// The `Mmap` handle keeps the backing memory alive for the lifetime of this
+/// The anonymous read-only `Mmap` owns a stable copy of the file bytes for the lifetime of this
 /// struct; `tensor_bytes` returns slices directly into that region.
 pub struct Gguf {
     mmap: Arc<Mmap>,
     metadata: Metadata,
     tensors: Vec<TensorInfo>,
-    /// Absolute byte offset into `mmap` where tensor data begins.
+    /// Absolute byte offset into the snapshot where tensor data begins.
     data_region_start: usize,
 }
 
-/// An owning, ref-counted view of a tensor's bytes in the mmap'd file — a zero-copy `[u8]` slice that
-/// keeps the whole `Mmap` alive via `Arc`, so it can outlive the borrow of `&Gguf` (e.g. a CPU
-/// backend buffer that reads weights straight from the mapping with no `memcpy`).
+/// An owning, ref-counted view of a tensor's bytes in the immutable snapshot. It keeps the whole
+/// snapshot alive via `Arc`, so it can outlive the borrow of `&Gguf` (e.g. a CPU backend buffer that
+/// reads weights directly with no additional `memcpy`).
 #[derive(Clone)]
 pub struct TensorBytes {
     mmap: Arc<Mmap>,
@@ -331,7 +331,7 @@ pub fn block_layout(dtype: DType) -> (usize, usize) {
 /// same bounds checks catch loudly instead. `debug_assert` states the contract so a new caller that
 /// breaks it trips in tests rather than inheriting the rounding.
 #[cfg_attr(infr_profile, infr_prof::instrument)]
-fn tensor_nbytes(dtype: DType, numel: usize) -> usize {
+fn checked_tensor_nbytes(dtype: DType, numel: usize) -> Option<usize> {
     // i2_s stores `numel/4` bytes of 2-bit ternary codes followed by ONE per-tensor f32 scale (see
     // `DType::I2S`). The scale is part of the tensor's data region (ggml rounds the next tensor's
     // offset up to `general.alignment`, so the on-disk stride is `numel/4 + 4` padded to 32B, but
@@ -342,14 +342,19 @@ fn tensor_nbytes(dtype: DType, numel: usize) -> usize {
             numel.is_multiple_of(4),
             "i2_s packs 4 ternary codes per byte; numel {numel} is not a multiple of 4"
         );
-        return numel.div_ceil(4) + 4;
+        return numel.div_ceil(4).checked_add(4);
     }
     let (be, bb) = block_layout(dtype);
     debug_assert!(
         numel.is_multiple_of(be),
         "{dtype:?} blocks hold {be} elements; numel {numel} is not a whole number of blocks"
     );
-    numel.div_ceil(be) * bb
+    numel.div_ceil(be).checked_mul(bb)
+}
+
+#[cfg_attr(infr_profile, infr_prof::instrument)]
+fn tensor_nbytes(dtype: DType, numel: usize) -> usize {
+    checked_tensor_nbytes(dtype, numel).expect("tensor byte count overflows usize")
 }
 
 /// Bytes occupied by `numel` elements of `dtype` in its GGUF block layout (`numel` must be a whole
@@ -375,32 +380,26 @@ pub fn nbytes(dtype: DType, numel: usize) -> usize {
 
 #[cfg_attr(infr_profile, infr_prof::instrument)]
 impl Gguf {
-    /// Open and parse a GGUF file.
+    /// Open and parse a stable snapshot of a GGUF file.
     ///
-    /// The file is memory-mapped; no tensor bytes are copied into RAM.
+    /// File-backed mappings cannot safely expose shared references because another handle or
+    /// process can modify or truncate the file while those references are live. Read into an
+    /// anonymous mapping first, then make it read-only, so every safe caller observes immutable
+    /// bytes after this function returns.
     pub fn open(path: &Path) -> Result<Self> {
-        let file = File::open(path)?;
-        // SAFETY: the file is not modified while this Mmap is live.
-        let mmap = unsafe { Mmap::map(&file) }?;
-
-        // Best-effort madvise hints. All are advisory: `advise()` returns an
-        // `io::Result`, but a rejected/unsupported hint must never fail the load —
-        // weight correctness does not depend on any hint landing, so we swallow errors.
-        // NOTE: we deliberately do NOT use `Advice::Sequential`. Decode re-reads the
-        // ENTIRE model every token, so `MADV_SEQUENTIAL`'s drop-behind eviction would
-        // throw away pages we need on the very next token — wrong for this access
-        // pattern. Only `WillNeed`/`HugePage` fit.
-        #[cfg(unix)]
-        {
-            // Populate/readahead the whole mapping into the page cache now, front-loading
-            // the weight read at load instead of faulting it in lazily on the first token.
-            let _ = mmap.advise(memmap2::Advice::WillNeed);
-            // Linux only: request 2 MB transparent huge pages to cut dTLB page-walks over
-            // the multi-GB sequential weight stream. On file-backed mmaps this is frequently
-            // a no-op (THP-for-filesystem is not always enabled) — hence best-effort.
-            #[cfg(target_os = "linux")]
-            let _ = mmap.advise(memmap2::Advice::HugePage);
-        }
+        let mut file = File::open(path)?;
+        let file_len = usize::try_from(file.metadata()?.len()).map_err(|_| {
+            Error::Loader(format!(
+                "GGUF: file size for {path:?} does not fit in usize"
+            ))
+        })?;
+        let mut snapshot = MmapMut::map_anon(file_len)?;
+        file.read_exact(&mut snapshot)?;
+        let mmap = snapshot.make_read_only()?;
+        // Best-effort transparent huge pages reduce dTLB pressure when CPU inference scans the
+        // anonymous multi-gigabyte snapshot. The hint is advisory and does not affect correctness.
+        #[cfg(target_os = "linux")]
+        let _ = mmap.advise(memmap2::Advice::HugePage);
 
         // All parsing happens in this block so the borrow of `mmap` ends
         // before we move `mmap` into the returned struct.
@@ -531,7 +530,11 @@ impl Gguf {
                         )));
                     }
                 }
-                let nbytes = tensor_nbytes(dtype, numel);
+                let nbytes = checked_tensor_nbytes(dtype, numel).ok_or_else(|| {
+                    Error::Loader(format!(
+                        "GGUF: tensor '{name}' shape {shape:?} byte size overflows usize"
+                    ))
+                })?;
                 tensors.push(TensorInfo {
                     name,
                     shape,
@@ -573,9 +576,9 @@ impl Gguf {
         })
     }
 
-    /// Zero-copy, ref-counted view of a tensor's raw bytes (keeps the `Mmap` alive via `Arc`). Unlike
-    /// [`WeightSource::tensor_bytes`] the result is not borrow-bound to `&self`, so a backend can hold
-    /// it as a weight buffer and read straight from the mapping — no `memcpy` into owned RAM.
+    /// Ref-counted view of a tensor's raw bytes that keeps the immutable snapshot alive. Unlike
+    /// [`WeightSource::tensor_bytes`], the result is not borrow-bound to `&self`, so a backend can
+    /// retain it as a weight buffer without another copy.
     pub fn tensor_bytes_arc(&self, name: &str) -> Result<TensorBytes> {
         let (off, len) = self.resolve(name)?;
         Ok(TensorBytes {
@@ -585,7 +588,7 @@ impl Gguf {
         })
     }
 
-    /// Look up a tensor by name and return its `(absolute_offset, len)` in the mmap,
+    /// Look up a tensor by name and return its `(absolute_offset, len)` in the snapshot,
     /// bounds-checked against the file size with `checked_add` so a crafted
     /// offset/length can't overflow. Shared by [`Self::tensor_bytes_arc`] and
     /// [`WeightSource::tensor_bytes`] so the lookup + overflow-safe bounds check lives
@@ -625,10 +628,9 @@ impl WeightSource for Gguf {
         &self.tensors
     }
 
-    /// Returns a slice into the mmap'd data region for the named tensor.
+    /// Returns a slice into the immutable tensor-data snapshot.
     ///
-    /// The slice lifetime is tied to `&self` (i.e. the `Gguf` struct keeps
-    /// the `Mmap` alive).
+    /// The slice lifetime is tied to `&self` (i.e. the `Gguf` struct keeps the snapshot alive).
     fn tensor_bytes(&self, name: &str) -> Result<&[u8]> {
         let (start, len) = self.resolve(name)?;
         Ok(&self.mmap[start..start + len])
@@ -752,26 +754,20 @@ mod tests {
         assert!(gguf.chat_template().is_none());
     }
 
-    // ── madvise hints are transparent ─────────────────────────────────────────
+    // ── immutable snapshot ────────────────────────────────────────────────────
 
-    /// The best-effort `madvise` hints applied to the weight mmap in `Gguf::open`
-    /// (`WillNeed`, and `HugePage` on Linux) must not change what the mapping reads
-    /// back. Open the fixture and assert the tensor bytes are byte-for-byte identical
-    /// to the raw tensor-data region of the source buffer — i.e. the hint is a no-op
-    /// on observable content. This is the only path that exercises the advise() calls.
     #[test]
-    fn madvise_hints_are_transparent() {
+    fn snapshot_stays_stable_after_source_changes() {
         let bytes = build_fixture();
         let tmp = write_temp_gguf(&bytes);
         let gguf = Gguf::open(tmp.path()).expect("open fixture");
 
-        // tensor0 is F32 [4] at data offset 0 → the last 16 bytes of the buffer.
+        // A second safe file handle can replace the source after `open`. Tensor references must
+        // continue to read the owned snapshot, never changed file-backed memory.
+        std::fs::write(tmp.path(), vec![0xFF; bytes.len()]).expect("replace source file");
         let expected = &bytes[bytes.len() - 16..];
         let data = gguf.tensor_bytes("tensor0").expect("tensor_bytes");
-        assert_eq!(
-            data, expected,
-            "mmap read must be byte-for-byte with the source"
-        );
+        assert_eq!(data, expected);
     }
 
     // ── malformed / truncated header hardening ────────────────────────────────
@@ -1036,6 +1032,17 @@ mod tests {
     }
 
     // ── block-alignment hardening ─────────────────────────────────────────────
+
+    #[test]
+    fn tensor_byte_count_overflow_errors() {
+        let b = build_typed_fixture(0, 1u64 << 62, 0);
+        let tmp = write_temp_gguf(&b);
+        let err = Gguf::open(tmp.path()).map(|_| ());
+        assert!(
+            matches!(err, Err(Error::Loader(_))),
+            "overflowing F32 byte count should be Error::Loader, got {err:?}"
+        );
+    }
 
     /// A GGUF holding exactly one tensor of `ggml_type` with the given 1-D length, and `data_len`
     /// bytes of zeros in the data region. The round-trip fixture uses F32 (`block_elems == 1`), so

--- a/crates/infr-llama/src/config.rs
+++ b/crates/infr-llama/src/config.rs
@@ -176,6 +176,28 @@ pub struct Config {
     pub sub_norm: bool,
 }
 
+fn positive_model_dimension(key: &str, value: u64) -> Result<usize> {
+    let value = value as usize;
+    if value == 0 {
+        bail!("{key} must be positive");
+    }
+    Ok(value)
+}
+
+fn positive_array_model_dimension(
+    values: Option<&[MetaValue]>,
+    key: &str,
+    index: usize,
+) -> Result<Option<usize>> {
+    let Some(value) = values
+        .and_then(|values| values.get(index))
+        .and_then(MetaValue::as_u64)
+    else {
+        return Ok(None);
+    };
+    positive_model_dimension(&format!("{key}[{index}]"), value).map(Some)
+}
+
 #[cfg_attr(infr_profile, infr_prof::instrument)]
 impl Config {
     /// Whether layer `il` uses sliding-window (vs full) attention. gemma interleaves SWA with full
@@ -411,8 +433,14 @@ impl Config {
         }
         let n_layer = n_layer_all - n_layer_nextn;
         let n_embd = meta_u64(g, &mk("embedding_length")).context("embedding_length")? as usize;
-        let n_head = meta_u64(g, &mk("attention.head_count")).context("head_count")? as usize;
-        let n_kv = meta_u64(g, &mk("attention.head_count_kv")).unwrap_or(n_head as u64) as usize;
+        let n_head = positive_model_dimension(
+            &mk("attention.head_count"),
+            meta_u64(g, &mk("attention.head_count")).context("head_count")?,
+        )?;
+        let n_kv = match meta_u64(g, &mk("attention.head_count_kv")) {
+            Some(value) => positive_model_dimension(&mk("attention.head_count_kv"), value)?,
+            None => n_head,
+        };
         let n_ff_layers: Vec<usize> = if let Some(arr) = g
             .metadata()
             .get(&mk("feed_forward_length"))
@@ -541,15 +569,8 @@ impl Config {
             rope_theta
         };
         let (head_dim, n_kv, rope_dim, head_dim_swa, n_kv_swa, rope_dim_swa) = if gemma4 {
-            let hk = g
-                .metadata()
-                .get(&mk("attention.head_count_kv"))
-                .and_then(MetaValue::as_arr);
-            let kv_at = |i: usize| {
-                hk.and_then(|a| a.get(i))
-                    .and_then(MetaValue::as_u64)
-                    .map(|v| v as usize)
-            };
+            let kv_key = mk("attention.head_count_kv");
+            let hk = g.metadata().get(&kv_key).and_then(MetaValue::as_arr);
             let full_idx = swa_pattern.saturating_sub(1);
             let hd_full =
                 meta_u64(g, &mk("attention.key_length")).unwrap_or(head_dim as u64) as usize;
@@ -561,10 +582,10 @@ impl Config {
                 meta_u64(g, &mk("rope.dimension_count_swa")).unwrap_or(hd_swa as u64) as usize;
             (
                 hd_full,
-                kv_at(full_idx).unwrap_or(n_kv),
+                positive_array_model_dimension(hk, &kv_key, full_idx)?.unwrap_or(n_kv),
                 rd_full,
                 hd_swa,
-                kv_at(0).unwrap_or(n_kv),
+                positive_array_model_dimension(hk, &kv_key, 0)?.unwrap_or(n_kv),
                 rd_swa,
             )
         } else {
@@ -762,5 +783,88 @@ impl Config {
             shexp_gated,
             sub_norm,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_str(bytes: &mut Vec<u8>, value: &str) {
+        push_u64(bytes, value.len() as u64);
+        bytes.extend_from_slice(value.as_bytes());
+    }
+
+    fn push_u32_metadata(bytes: &mut Vec<u8>, key: &str, value: u32) {
+        push_str(bytes, key);
+        push_u32(bytes, 4); // GGUF_TYPE_UINT32
+        push_u32(bytes, value);
+    }
+
+    fn gemma4_zero_kv_heads_fixture() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        push_u32(&mut bytes, 0x4655_4747); // GGUF magic
+        push_u32(&mut bytes, 3);
+        push_u64(&mut bytes, 1); // tensor count
+        push_u64(&mut bytes, 6); // metadata count
+
+        push_str(&mut bytes, "general.architecture");
+        push_u32(&mut bytes, 8); // GGUF_TYPE_STRING
+        push_str(&mut bytes, "gemma4");
+        push_u32_metadata(&mut bytes, "gemma4.block_count", 1);
+        push_u32_metadata(&mut bytes, "gemma4.embedding_length", 8);
+        push_u32_metadata(&mut bytes, "gemma4.attention.head_count", 8);
+        push_u32_metadata(&mut bytes, "gemma4.feed_forward_length", 16);
+
+        push_str(&mut bytes, "gemma4.attention.head_count_kv");
+        push_u32(&mut bytes, 9); // GGUF_TYPE_ARRAY
+        push_u32(&mut bytes, 4); // GGUF_TYPE_UINT32
+        push_u64(&mut bytes, 1);
+        push_u32(&mut bytes, 0);
+
+        push_str(&mut bytes, "token_embd.weight");
+        push_u32(&mut bytes, 2);
+        push_u64(&mut bytes, 8);
+        push_u64(&mut bytes, 1);
+        push_u32(&mut bytes, 0); // F32
+        push_u64(&mut bytes, 0);
+        while !bytes.len().is_multiple_of(32) {
+            bytes.push(0);
+        }
+        bytes.extend_from_slice(&[0; 32]);
+        bytes
+    }
+
+    #[test]
+    fn model_dimensions_must_be_positive() {
+        assert!(positive_model_dimension("test.head_count", 0).is_err());
+        assert_eq!(positive_model_dimension("test.head_count", 1).unwrap(), 1);
+    }
+
+    #[test]
+    fn gemma4_array_kv_heads_must_be_positive() {
+        let path = std::env::temp_dir().join(format!(
+            "infr-llama-gemma4-zero-kv-heads-{}.gguf",
+            std::process::id()
+        ));
+        std::fs::write(&path, gemma4_zero_kv_heads_fixture()).expect("write GGUF fixture");
+        let gguf = Gguf::open(&path).expect("open GGUF fixture");
+        std::fs::remove_file(path).expect("remove GGUF fixture");
+
+        let Err(err) = Config::from_gguf(&gguf) else {
+            panic!("zero KV heads must fail");
+        };
+        assert_eq!(
+            err.to_string(),
+            "gemma4.attention.head_count_kv[0] must be positive"
+        );
     }
 }

--- a/crates/infr-llama/src/seam/model.rs
+++ b/crates/infr-llama/src/seam/model.rs
@@ -38,8 +38,8 @@ pub struct BenchPlacement {
 /// A **GPU-free** model for the CPU reference backend. Holds only what the agnostic CPU compute
 /// graph needs — the parsed [`Config`], the host f32 token embeddings (for the gather + tied lm
 /// head), the tokenizer, and the gemma4 E2B per-layer-embd tensors. No `VulkanBackend`, no VRAM,
-/// no weight upload: the projection weights are streamed straight from the kept-open GGUF mmap at
-/// forward time. Dense Qwen3/Llama, Gemma 3, Gemma 4 (dense + E2B), qwen3moe, and qwen35
+/// no weight upload: projection weights stream from the immutable GGUF snapshot at forward time.
+/// Dense Qwen3/Llama, Gemma 3, Gemma 4 (dense + E2B), qwen3moe, and qwen35
 /// (`MixerW::DeltaNet`) all drive this same struct.
 pub struct SeamModel {
     gguf: Gguf,

--- a/crates/infr-vulkan/src/pager.rs
+++ b/crates/infr-vulkan/src/pager.rs
@@ -356,10 +356,10 @@ impl GpuPager {
 
 /// Parallel memcpy of one expert's bytes into the mapped staging ring. The single-thread copy is
 /// the staging bottleneck (the bandwidth probe's 22 GB/s is a hot-source best case; streaming
-/// distinct experts out of a 37 GB page-cache-backed mmap into write-combined ReBAR runs well
-/// below that) — chunked `copy_nonoverlapping` across the rayon pool recovers most of the
-/// PCIe/DRAM headroom. 4 MiB chunks: big enough for streaming stores, small enough to spread a
-/// 14-18 MB expert across several workers.
+/// distinct experts out of a 37 GB immutable snapshot into write-combined ReBAR runs well below
+/// that) — chunked `copy_nonoverlapping` across the rayon pool recovers most of the PCIe/DRAM
+/// headroom. 4 MiB chunks: big enough for streaming stores, small enough to spread a 14-18 MB
+/// expert across several workers.
 fn par_copy_to_mapped(src: &[u8], dst: *mut u8) {
     use rayon::prelude::*;
     const CHUNK: usize = 4 << 20;


### PR DESCRIPTION
## Summary

- reject malformed pipe-format arrays, unsolicited tool parsing, and zero attention-head metadata
- return loader errors for GGUF tensor-size overflow and snapshot GGUF bytes before exposing references
- publish shutdown state atomically and drop completed spin-pool results during panic unwinding
- add regression coverage and update runtime documentation

## Verification

- `cargo fmt --all -- --check`
- `cargo build --release --workspace --locked`
- `cargo test --workspace --locked`
- changed-package Clippy checks with `-D warnings`

The exact workspace Clippy gate reaches a pre-existing arm64 test warning at `crates/infr-cpu/src/kernels.rs:9757` (`TIER_TOL` is unused on this target). `cargo nextest` is not installed locally, so the full workspace suite was run with `cargo test` instead.