### PR TITLE
Add native Windows build and runtime support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,6 +1174,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "tracing",
+ "windows",
 ]
 
 [[package]]

--- a/crates/infr-core/Cargo.toml
+++ b/crates/infr-core/Cargo.toml
@@ -18,5 +18,8 @@ toml.workspace = true
 libc.workspace = true
 tracing.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = ["Win32_System_SystemInformation"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/infr-core/src/hostmem.rs
+++ b/crates/infr-core/src/hostmem.rs
@@ -21,11 +21,8 @@
 /// a new allocation can have without swapping — it already accounts for reclaimable page cache, so
 /// it is exactly the figure this tier wants and not something derivable from `MemTotal`.
 ///
-/// **Every other platform answers `None` today**, and that is a gap rather than a design: macOS
-/// would need `host_statistics64`'s free/inactive/purgeable split and Windows
-/// `GlobalMemoryStatusEx`, neither of which is reachable through this workspace's existing
-/// dependencies, and neither of which could be verified on the machine this was written on. Adding
-/// either means adding a dependency, which is the user's call. Backlog B36.
+/// **Windows** reads `ullAvailPhys` from `GlobalMemoryStatusEx`. Every other platform answers
+/// `None` today; macOS would need `host_statistics64`'s free/inactive/purgeable split.
 ///
 /// **A cgroup memory limit overrides it.** `/proc/meminfo` is host-wide and knows nothing about the
 /// limit a container or a `systemd-run --scope -p MemoryMax=` puts on this process — measured on
@@ -41,10 +38,24 @@ pub fn available_bytes() -> Option<u64> {
             None => host,
         })
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(windows)]
+    {
+        Some(windows_memory_status()?.ullAvailPhys)
+    }
+    #[cfg(not(any(target_os = "linux", windows)))]
     {
         None
     }
+}
+
+#[cfg(windows)]
+fn windows_memory_status() -> Option<windows::Win32::System::SystemInformation::MEMORYSTATUSEX> {
+    use windows::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+
+    let mut status = MEMORYSTATUSEX::default();
+    status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    unsafe { GlobalMemoryStatusEx(&mut status).ok()? };
+    Some(status)
 }
 
 /// Memory this process may still commit before its cgroup kills it, or `None` when no ancestor
@@ -320,6 +331,22 @@ mod tests {
             * 1024;
         assert!(avail > 0, "available must be non-zero");
         assert!(avail <= total, "available {avail} exceeds total {total}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn the_windows_live_probe_is_plausible() {
+        let avail = available_bytes().expect("windows GlobalMemoryStatusEx should answer");
+        let status = windows_memory_status().expect("GlobalMemoryStatusEx");
+        assert!(
+            status.ullTotalPhys > 0,
+            "total physical memory must be non-zero"
+        );
+        assert!(
+            avail <= status.ullTotalPhys,
+            "available {avail} exceeds total {}",
+            status.ullTotalPhys
+        );
     }
 
     /// Headroom is the point: the budget never equals what is available, however much there is.

--- a/crates/infr-core/src/kernel_cache.rs
+++ b/crates/infr-core/src/kernel_cache.rs
@@ -427,6 +427,7 @@ mod tests {
     /// A pid that is guaranteed DEAD (spawned and reaped). Reusing a just-reaped pid is
     /// theoretically possible but the kernel hands out pids sequentially, so it will not happen
     /// within one test.
+    #[cfg(unix)]
     fn spawn_and_reap() -> u32 {
         let mut c = std::process::Command::new("true")
             .spawn()
@@ -517,6 +518,7 @@ mod tests {
 
     /// THE TRIPWIRE. A blob that hangs the GPU is perfectly well-formed, so no envelope check can
     /// see it — the only evidence is that the run which SEEDED from it never came back.
+    #[cfg(unix)]
     #[test]
     fn tripwire_discards_a_blob_whose_seeded_run_died() {
         let dir = tmp_dir("tripwire");
@@ -570,6 +572,7 @@ mod tests {
     /// Sibling caches in ONE process (distinct nonces on the same path) own SEPARATE markers — so
     /// one instance's clean `disarm()` never deletes a live sibling's, and a still-armed sibling
     /// that later dies uncleanly is still caught.
+    #[cfg(unix)]
     #[test]
     fn sibling_markers_are_independent() {
         let dir = tmp_dir("siblings");

--- a/crates/infr-hub/src/download.rs
+++ b/crates/infr-hub/src/download.rs
@@ -14,10 +14,11 @@ use infr_core::error::{Error, Result};
 use infr_core::progress::{self, Unit};
 use reqwest::blocking::Response;
 use sha2::{Digest, Sha256};
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::io::AsRawFd;
 use std::{
     fs,
     io::{Read, Write},
-    os::unix::io::AsRawFd,
     path::{Path, PathBuf},
 };
 use tracing::{debug, info};
@@ -413,10 +414,12 @@ fn response_validator(headers: &reqwest::header::HeaderMap) -> Option<String> {
 
 /// An advisory exclusive `flock` on a lockfile, released when dropped. Serializes concurrent
 /// downloads of the same blob so two processes can't interleave writes into the shared temp.
+#[cfg(not(target_os = "windows"))]
 struct FileLock {
     _file: fs::File,
 }
 
+#[cfg(not(target_os = "windows"))]
 impl FileLock {
     fn acquire(path: &Path) -> Result<Self> {
         let file = fs::OpenOptions::new()
@@ -438,10 +441,147 @@ impl FileLock {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 impl Drop for FileLock {
     fn drop(&mut self) {
         // Closing the fd releases the lock; the explicit unlock is belt-and-suspenders.
         unsafe { libc::flock(self._file.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct FileLock {
+    _file: fs::File,
+}
+
+#[cfg(target_os = "windows")]
+impl FileLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(path)
+            .map_err(Error::from)?;
+        lock_file_exclusive(&file)
+            .map_err(|e| Error::Other(format!("LockFileEx {path:?}: {e}")))?;
+        Ok(FileLock { _file: file })
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = unlock_file(&self._file);
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[repr(C)]
+union OverlappedOffset {
+    offset: OffsetPair,
+    pointer: *mut std::ffi::c_void,
+}
+
+#[cfg(target_os = "windows")]
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct OffsetPair {
+    offset: u32,
+    offset_high: u32,
+}
+
+#[cfg(target_os = "windows")]
+#[repr(C)]
+struct Overlapped {
+    internal: usize,
+    internal_high: usize,
+    offset_or_pointer: OverlappedOffset,
+    h_event: *mut std::ffi::c_void,
+}
+
+#[cfg(target_os = "windows")]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn LockFileEx(
+        h_file: *mut std::ffi::c_void,
+        dw_flags: u32,
+        dw_reserved: u32,
+        n_number_of_bytes_to_lock_low: u32,
+        n_number_of_bytes_to_lock_high: u32,
+        lp_overlapped: *mut Overlapped,
+    ) -> i32;
+    fn UnlockFileEx(
+        h_file: *mut std::ffi::c_void,
+        dw_reserved: u32,
+        n_number_of_bytes_to_unlock_low: u32,
+        n_number_of_bytes_to_unlock_high: u32,
+        lp_overlapped: *mut Overlapped,
+    ) -> i32;
+}
+
+#[cfg(target_os = "windows")]
+fn zero_overlapped() -> Overlapped {
+    Overlapped {
+        internal: 0,
+        internal_high: 0,
+        offset_or_pointer: OverlappedOffset {
+            offset: OffsetPair {
+                offset: 0,
+                offset_high: 0,
+            },
+        },
+        h_event: std::ptr::null_mut(),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn lock_file_exclusive(file: &fs::File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x0000_0002;
+    const LOCK_LEN_LOW: u32 = u32::MAX;
+    const LOCK_LEN_HIGH: u32 = u32::MAX;
+
+    let mut overlapped = zero_overlapped();
+    let ok = unsafe {
+        LockFileEx(
+            file.as_raw_handle() as *mut std::ffi::c_void,
+            LOCKFILE_EXCLUSIVE_LOCK,
+            0,
+            LOCK_LEN_LOW,
+            LOCK_LEN_HIGH,
+            &mut overlapped,
+        )
+    };
+    if ok == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn unlock_file(file: &fs::File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    const LOCK_LEN_LOW: u32 = u32::MAX;
+    const LOCK_LEN_HIGH: u32 = u32::MAX;
+
+    let mut overlapped = zero_overlapped();
+    let ok = unsafe {
+        UnlockFileEx(
+            file.as_raw_handle() as *mut std::ffi::c_void,
+            0,
+            LOCK_LEN_LOW,
+            LOCK_LEN_HIGH,
+            &mut overlapped,
+        )
+    };
+    if ok == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
     }
 }
 
@@ -621,6 +761,7 @@ mod tests {
         assert_eq!(response_validator(&h).as_deref(), Some("\"deadbeef\""));
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn file_lock_is_exclusive() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/infr-hub/src/pull.rs
+++ b/crates/infr-hub/src/pull.rs
@@ -17,7 +17,6 @@ use infr_core::progress;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::{
     fs,
-    os::unix::fs::symlink,
     path::{Component, Path, PathBuf},
 };
 use tracing::{debug, info};
@@ -160,7 +159,7 @@ fn fetch_and_link(
     }
     let _ = fs::remove_file(&link); // replace a stale/dangling link
     let target = blob_link_target(filename, &hex);
-    symlink(&target, &link).map_err(Error::from)?;
+    link_blob(&target, &link).map_err(Error::from)?;
     debug!("linked {link:?} -> {target}");
     Ok(link)
 }
@@ -282,6 +281,30 @@ pub(crate) fn blob_link_target(rel: &str, hex: &str) -> String {
     target.push_str("blobs/");
     target.push_str(hex);
     target
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn link_blob(target: impl AsRef<Path>, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn link_blob(target: impl AsRef<Path>, link: &Path) -> std::io::Result<()> {
+    let target = target.as_ref();
+    match std::os::windows::fs::symlink_file(target, link) {
+        Ok(()) => Ok(()),
+        Err(symlink_err) => {
+            let source = link.parent().unwrap_or_else(|| Path::new("")).join(target);
+            fs::hard_link(&source, link).map_err(|hard_link_err| {
+                std::io::Error::new(
+                    hard_link_err.kind(),
+                    format!(
+                        "symlink_file {link:?} -> {target:?} failed: {symlink_err}; hard_link fallback from {source:?} failed: {hard_link_err}"
+                    ),
+                )
+            })
+        }
+    }
 }
 
 /// True when `name` may be `join`ed onto a local directory without escaping it: non-empty, relative,
@@ -511,7 +534,7 @@ fn fetch_companions(
         match dl {
             Ok((_, hex, _)) => {
                 let _ = fs::remove_file(&link);
-                match symlink(blob_link_target(name, &hex), &link) {
+                match link_blob(blob_link_target(name, &hex), &link) {
                     Ok(()) => info!("hf:{repo}: cached companion {name}"),
                     Err(e) => debug!("hf:{repo}: companion {name} symlink failed: {e}"),
                 }

--- a/crates/infr-hub/src/ranged.rs
+++ b/crates/infr-hub/src/ranged.rs
@@ -34,8 +34,7 @@ use reqwest::header::{
 };
 use reqwest::StatusCode;
 use std::fs;
-use std::io::Read;
-use std::os::unix::fs::FileExt;
+use std::io::{self, Read};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
@@ -308,6 +307,32 @@ impl Job<'_> {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
+fn write_all_at(file: &fs::File, buf: &[u8], offset: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+
+    file.write_all_at(buf, offset)
+}
+
+#[cfg(target_os = "windows")]
+fn write_all_at(file: &fs::File, mut buf: &[u8], mut offset: u64) -> io::Result<()> {
+    use std::io::ErrorKind;
+    use std::os::windows::fs::FileExt;
+
+    while !buf.is_empty() {
+        let n = file.seek_write(buf, offset)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                ErrorKind::WriteZero,
+                "failed to write the full chunk at its offset",
+            ));
+        }
+        buf = &buf[n..];
+        offset += n as u64;
+    }
+    Ok(())
+}
+
 /// Start one more chunk worker, holding `permit` for as long as it runs. The permit rides with the
 /// thread so the budget gets it back the moment this worker runs out of chunks to claim, even if it
 /// returns early or panics.
@@ -442,9 +467,7 @@ fn fetch_chunk(job: &Job, i: usize) -> std::result::Result<(), RangedError> {
                 job.label
             ))));
         }
-        job.file
-            .write_all_at(&buf[..n], at)
-            .map_err(|e| RangedError::Fatal(Error::from(e)))?;
+        write_all_at(&job.file, &buf[..n], at).map_err(|e| RangedError::Fatal(Error::from(e)))?;
         at += n as u64;
         left -= n as u64;
         job.pb.inc(n as u64);

--- a/crates/infr-hub/src/store.rs
+++ b/crates/infr-hub/src/store.rs
@@ -296,7 +296,6 @@ fn gguf_match(fname: &str, sel: &str) -> Match {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::unix::fs::symlink;
 
     /// Build a fake HF Hub repo dir: blobs/<sha> + snapshots/<commit>/<file> -> blob + refs/main.
     ///
@@ -313,7 +312,7 @@ mod tests {
         fs::write(blobs.join(sha), b"fake gguf bytes").unwrap();
         let link = snap.join(file);
         fs::create_dir_all(link.parent().unwrap()).unwrap();
-        symlink(crate::pull::blob_link_target(file, sha), link).unwrap();
+        crate::pull::link_blob(crate::pull::blob_link_target(file, sha), &link).unwrap();
         fs::create_dir_all(dir.join("refs")).unwrap();
         fs::write(dir.join("refs").join("main"), commit).unwrap();
     }

--- a/crates/infr-vulkan/src/p2p.rs
+++ b/crates/infr-vulkan/src/p2p.rs
@@ -35,6 +35,9 @@
 //! imports on success) while the export keeps its original — a `P2pExport` can be imported more than
 //! once (a dma-buf may have many importers) and there is never a double-close.
 
+#[cfg(target_os = "windows")]
+type RawFd = std::os::raw::c_int;
+#[cfg(not(target_os = "windows"))]
 use std::os::fd::RawFd;
 
 use ash::vk;

--- a/crates/infr-vulkan/src/tp_sem.rs
+++ b/crates/infr-vulkan/src/tp_sem.rs
@@ -16,6 +16,9 @@
 //! [`VulkanBackend::external_semaphore_supported`] — a device/driver that can't import one makes the
 //! all-reduce fall back to the host fence.
 
+#[cfg(target_os = "windows")]
+type RawFd = std::os::raw::c_int;
+#[cfg(not(target_os = "windows"))]
 use std::os::fd::RawFd;
 use std::sync::Arc;
 


### PR DESCRIPTION
Replace Unix-only file locking with Windows LockFileEx

Add Windows ranged file writes using seek_write

Add Windows-compatible blob linking fallback

Gate Unix fd APIs behind platform cfg

Keep Linux implementations unchanged